### PR TITLE
fix(db): give the phantom schema.rb columns real migrations

### DIFF
--- a/app/services/workflow_duplicator/dependency_copier.rb
+++ b/app/services/workflow_duplicator/dependency_copier.rb
@@ -122,7 +122,7 @@ class WorkflowDuplicator
         scope: @project,
         name: skill.name, title: skill.title, description: skill.description,
         package: skill.package, source: skill.source, source_url: skill.source_url,
-        content: skill.content, references_data: skill.references_data, install_count: 0
+        content: skill.content, install_count: 0
       ).id
     end
 

--- a/db/migrate/20260202160004_add_kind_to_tools.rb
+++ b/db/migrate/20260202160004_add_kind_to_tools.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+# CreateTools already declares `kind` and its index, so on a database built by
+# replaying the migrations this one is a no-op. It is kept (rather than deleted)
+# because databases created before CreateTools grew the column have it recorded
+# as applied.
 class AddKindToTools < ActiveRecord::Migration[7.2]
   def change
-    add_column :tools, :kind, :string, null: false, default: "custom"
-    add_index :tools, :kind
+    add_column :tools, :kind, :string, null: false, default: "custom", if_not_exists: true
+    add_index :tools, :kind, if_not_exists: true
   end
 end

--- a/db/migrate/20260204154533_consolidated_migration.action_mcp.rb
+++ b/db/migrate/20260204154533_consolidated_migration.action_mcp.rb
@@ -141,11 +141,15 @@ class ConsolidatedMigration < ActiveRecord::Migration[8.0]
 
   private
 
+  # The action_mcp gem is gone (see DropActionMCPTables), so its
+  # ApplicationRecord no longer resolves. It pointed at this same database, so
+  # the migration's own connection answers identically — and replaying the
+  # migrations from scratch stops raising NameError halfway through.
   def table_exists?(table_name)
-    ActionMCP::ApplicationRecord.connection.table_exists?(table_name)
+    connection.table_exists?(table_name)
   end
 
   def column_exists?(table_name, column_name)
-    ActionMCP::ApplicationRecord.connection.column_exists?(table_name, column_name)
+    connection.column_exists?(table_name, column_name)
   end
 end

--- a/db/migrate/20260625000005_add_relay_state_to_trigger_events.rb
+++ b/db/migrate/20260625000005_add_relay_state_to_trigger_events.rb
@@ -18,8 +18,14 @@ class AddRelayStateToTriggerEvents < ActiveRecord::Migration[8.0]
 
     # The relay sweep only ever scans not-yet-done rows; a partial index keeps it
     # cheap as the (mostly-dispatched) event log grows.
+    #
+    # Spelled out as `= ANY (ARRAY[...])` with the casts Postgres itself applies,
+    # rather than the `IN (...)` this was originally written as: the two are the
+    # same predicate, but Postgres prints them differently, so the `IN` form made
+    # the dump of a migrated database differ from the dump of a schema-loaded one
+    # (see SchemaParityTest). This form survives the dump/load round trip.
     add_index :trigger_events, [ :relay_state, :created_at ],
-      where: "relay_state IN ('pending', 'dispatching')",
+      where: "(relay_state)::text = ANY (ARRAY[('pending'::character varying)::text, ('dispatching'::character varying)::text])",
       name: "index_trigger_events_pending_relay"
   end
 end

--- a/db/migrate/20260806000001_reconcile_schema_drift_with_migrations.rb
+++ b/db/migrate/20260806000001_reconcile_schema_drift_with_migrations.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Reconciles the columns that reached db/schema.rb through a schema dump of a
+# hand-modified development database instead of through a migration.
+#
+# Because development, test and CI databases are all built with
+# `db:schema:load`, these existed everywhere except production — where
+# `mcp_servers.args` surfaced as an ActiveModel::UnknownAttributeError the first
+# time somebody installed a package connector.
+#
+# Every statement is conditional: the databases that already have these columns
+# (any database loaded from schema.rb) must reach the same end state as the ones
+# that never did.
+#
+#   * mcp_servers.args               — kept. Written by MCP::ConnectorAttributes
+#                                      and read by every agent adapter.
+#   * skills.references_data         — dropped. Nothing ever wrote it; its only
+#                                      reader was WorkflowDuplicator, which is
+#                                      updated in this change.
+#   * usage_statistics.cursor_token_fee_cents — dropped. No reader, no writer.
+#   * index_tools_on_scope_type      — dropped. Redundant with the
+#                                      (scope_type, scope_id, name) index.
+class ReconcileSchemaDriftWithMigrations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :mcp_servers, :args, :jsonb, default: [], if_not_exists: true
+
+    remove_column :skills, :references_data, :jsonb, default: {}, if_exists: true
+    remove_column :usage_statistics, :cursor_token_fee_cents, :decimal,
+      precision: 12, scale: 6, default: "0.0", if_exists: true
+    remove_index :tools, :scope_type, name: "index_tools_on_scope_type", if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_04_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_06_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -574,7 +574,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_04_000001) do
     t.string "name", null: false
     t.string "origin", default: "registry", null: false
     t.string "package"
-    t.jsonb "references_data", default: {}
     t.bigint "scope_id"
     t.string "scope_type"
     t.string "source"
@@ -917,7 +916,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_04_000001) do
     t.index ["deleted_at"], name: "index_tools_on_deleted_at"
     t.index ["name"], name: "index_tools_on_name_where_source_code", unique: true, where: "(((source)::text = 'code'::text) AND (deleted_at IS NULL))"
     t.index ["scope_type", "scope_id", "name"], name: "index_tools_on_scope_type_and_scope_id_and_name", unique: true, where: "(deleted_at IS NULL)"
-    t.index ["scope_type"], name: "index_tools_on_scope_type"
   end
 
   add_check_constraint "tools", "name::text !~~ 'mcp\\_\\_%'::text", name: "tools_name_not_managed_namespace", validate: false
@@ -992,7 +990,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_04_000001) do
     t.bigint "cache_write_tokens", default: 0, null: false
     t.bigint "cost_cents", default: 0, null: false
     t.datetime "created_at", null: false
-    t.decimal "cursor_token_fee_cents", precision: 12, scale: 6, default: "0.0"
     t.integer "events_count", default: 0, null: false
     t.jsonb "events_data", default: []
     t.bigint "input_tokens", default: 0, null: false

--- a/test/db/schema_parity_test.rb
+++ b/test/db/schema_parity_test.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "open3"
+require "tmpdir"
+
+# db/schema.rb must be reproducible from db/migrate alone.
+#
+# Every database we develop and test against is built with `db:schema:load`, so a
+# column that lives ONLY in schema.rb — hand-added to somebody's development
+# database and then captured by a schema dump — is present and healthy in
+# development, in test and in CI. Production is the one database built by running
+# migrations, so it is the one place the column is missing, and nothing before
+# deploy can notice.
+#
+# That is how `mcp_servers.args` reached production without a migration and took
+# the connector install down with it:
+#
+#   ActiveModel::UnknownAttributeError: unknown attribute 'args' for MCPServer
+#   Web::Company::Projects::ConnectorsController#create
+#
+# This test replays the migrations into a throwaway database and diffs the dump
+# against the committed schema, which catches the whole class of drift rather
+# than the one column that happened to blow up first.
+class SchemaParityTest < ActiveSupport::TestCase
+  PARITY_DATABASE = "aixle_schema_parity"
+
+  # Replaying ~200 migrations in a subprocess is slow by nature; it is worth one
+  # slot in the suite because nothing cheaper can see production's schema.
+  test "db/schema.rb is reproducible from db/migrate" do
+    Dir.mktmpdir("schema-parity") do |dir|
+      seed = File.join(dir, "empty_schema.rb")
+      dumped = File.join(dir, "dumped_schema.rb")
+      # `db:migrate` loads the schema file into an empty database before it
+      # migrates. Point it at an empty one so the migrations, and only the
+      # migrations, build the result.
+      File.write(seed, "ActiveRecord::Schema[8.1].define(version: 0) do\nend\n")
+
+      begin
+        assert_targets_parity_database
+        run_rails!(%w[db:drop db:create db:migrate], schema: seed)
+        run_rails!(%w[db:schema:dump], schema: dumped)
+
+        assert_no_drift(committed_schema, File.read(dumped))
+      ensure
+        run_rails(%w[db:drop], schema: seed)
+      end
+    end
+  end
+
+  private
+
+  def committed_schema
+    Rails.root.join("db/schema.rb").read
+  end
+
+  def assert_no_drift(committed, replayed)
+    only_committed = committed.lines.map(&:rstrip) - replayed.lines.map(&:rstrip)
+    only_replayed = replayed.lines.map(&:rstrip) - committed.lines.map(&:rstrip)
+    return if only_committed.empty? && only_replayed.empty?
+
+    flunk <<~MESSAGE
+      db/schema.rb does not match a database built from db/migrate.
+
+      In schema.rb but NOT produced by any migration (missing in production):
+      #{only_committed.map { |line| "  #{line.strip}" }.join("\n").presence || '  (none)'}
+
+      Produced by the migrations but NOT in schema.rb (schema.rb is stale):
+      #{only_replayed.map { |line| "  #{line.strip}" }.join("\n").presence || '  (none)'}
+
+      Add the missing migration (or re-dump schema.rb from the test database).
+    MESSAGE
+  end
+
+  # Cheap insurance before `db:drop`: prove the subprocess really is pointed at
+  # the throwaway database and not at the suite's own.
+  def assert_targets_parity_database
+    output = run_rails!(%w[runner], schema: nil, args: [ "print ActiveRecord::Base.connection_db_config.database" ])
+
+    assert_includes output, PARITY_DATABASE,
+      "refusing to run: the parity subprocess is not pointed at #{PARITY_DATABASE}"
+  end
+
+  def run_rails!(tasks, schema:, args: [])
+    output, status = run_rails(tasks, schema: schema, args: args)
+    assert status.success?, "`bin/rails #{tasks.join(' ')}` failed:\n#{output}"
+    output
+  end
+
+  def run_rails(tasks, schema:, args: [])
+    env = {
+      "RAILS_ENV" => "test",
+      "DATABASE_URL" => parity_database_url,
+      "SKIP_COVERAGE" => "1",
+      "VERBOSE" => "false"
+    }
+    env["SCHEMA"] = schema if schema
+
+    Open3.capture2e(env, Rails.root.join("bin/rails").to_s, *tasks, *args, chdir: Rails.root.to_s)
+  end
+
+  def parity_database_url
+    config = ActiveRecord::Base.connection_db_config.configuration_hash
+    userinfo = [ config[:username], config[:password] ].compact.join(":")
+
+    "postgres://#{userinfo}@#{config[:host]}:#{config[:port]}/#{PARITY_DATABASE}"
+  end
+end

--- a/test/services/mcp/connector_installer_test.rb
+++ b/test/services/mcp/connector_installer_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module MCP
+  # The installer is the only path that turns a catalog entry into an MCPServer,
+  # and the row it writes is what every agent adapter later emits into .mcp.json.
+  #
+  # The argv assertions are the point of the package tests: `command` and `args`
+  # together ARE the launch line, so a package install that persists one without
+  # the other produces a server that cannot start.
+  class ConnectorInstallerTest < ActiveSupport::TestCase
+    REGISTRY = "https://registry.modelcontextprotocol.io/v0.1/servers"
+    PACKAGE_NAME = "com.pulsemcp/remote-filesystem"
+
+    setup do
+      @company = create(:company)
+      @user = create(:user, company: @company)
+      @project = create(:project, company: @company, owner: @user)
+    end
+
+    def entry(fixture)
+      JSON.parse(file_fixture("mcp_registry/#{fixture}.json").read)
+    end
+
+    def connector_for(fixture, **attrs)
+      manifest = ConnectorManifest.normalize(entry(fixture))
+      create(:connector, name: manifest["name"], version: manifest["version"], manifest: manifest, **attrs)
+    end
+
+    def stub_registry(name:, version:, fixture:)
+      stub_request(:get, "#{REGISTRY}/#{CGI.escape(name)}/versions/#{version}")
+        .to_return(status: 200, body: entry(fixture).to_json, headers: { "Content-Type" => "application/json" })
+    end
+
+    def install(connector, target_index: 0, values: {})
+      target = connector.manifest["targets"][target_index]
+      ConnectorInstaller.call(connector: connector, target_id: target["id"], values: values, project: @project)
+    end
+
+    # ------------------------------------------------------------- package/stdio
+
+    test "installing a package connector persists the whole launch line" do
+      connector = connector_for("package_npm_runtime_args")
+      stub_registry(name: PACKAGE_NAME, version: "0.1.2", fixture: "package_npm_runtime_args")
+
+      server = install(connector, values: { "GCS_BUCKET" => "my-bucket" }).server
+
+      assert_equal "stdio", server.transport.to_s
+      assert_equal "npx", server.command
+      # The runtime's own argument leads, then the version-pinned package spec.
+      assert_equal [ "-y", "remote-filesystem-mcp-server@0.1.2" ], server.args
+      assert_equal({ "GCS_BUCKET" => "my-bucket" }, server.env)
+    end
+
+    test "a stdio install records its catalog provenance" do
+      connector = connector_for("package_npm_runtime_args")
+      stub_registry(name: PACKAGE_NAME, version: "0.1.2", fixture: "package_npm_runtime_args")
+
+      server = install(connector, values: { "GCS_BUCKET" => "my-bucket" }).server
+
+      assert_equal PACKAGE_NAME, server.connector_name
+      assert_equal "0.1.2", server.connector_version
+      assert server.connector_version_pinned?
+      # stdio is never probed (executing the package here is the thing we refuse
+      # to do), so it must not come back claiming a verified baseline.
+      assert_not server.tool_baseline?
+    end
+
+    test "installing the same connector twice keeps both servers under distinct names" do
+      connector = connector_for("package_npm_runtime_args")
+      stub_registry(name: PACKAGE_NAME, version: "0.1.2", fixture: "package_npm_runtime_args")
+
+      first = install(connector, values: { "GCS_BUCKET" => "one" }).server
+      second = install(connector, values: { "GCS_BUCKET" => "two" }).server
+
+      assert_not_equal first.name, second.name
+      assert_equal "#{first.name} (2)", second.name
+    end
+
+    # ------------------------------------------------------------------- staleness
+
+    test "an unreachable registry installs from the mirrored manifest and says so" do
+      connector = connector_for("package_npm_runtime_args")
+      stub_request(:get, %r{#{Regexp.escape(REGISTRY)}/.*}).to_timeout
+
+      result = install(connector, values: { "GCS_BUCKET" => "my-bucket" })
+
+      assert result.stale
+      assert_equal [ "-y", "remote-filesystem-mcp-server@0.1.2" ], result.server.args
+    end
+
+    test "a target the connector no longer offers is refused" do
+      connector = connector_for("package_npm_runtime_args")
+      stub_registry(name: PACKAGE_NAME, version: "0.1.2", fixture: "package_npm_runtime_args")
+
+      error = assert_raises(ConnectorInstaller::Error) do
+        ConnectorInstaller.call(connector: connector, target_id: "gone", values: {}, project: @project)
+      end
+
+      assert_match(/no longer offered/, error.message)
+    end
+  end
+end


### PR DESCRIPTION
## The bug

Production, on the first install of a package connector:

```
ActiveModel::UnknownAttributeError: unknown attribute 'args' for MCPServer
Web::Company::Projects::ConnectorsController#create
```

`mcp_servers.args` has **never had a migration**. It entered `db/schema.rb` in March through a schema dump of a hand-modified development database. Development, test and CI are all built with `db:schema:load`, so the column is present and healthy in every one of them; production is the only database built by running migrations, and it is the only place the column is missing. Nothing before deploy could notice.

Three more columns had drifted in exactly the same way:

| | verdict |
|---|---|
| `mcp_servers.args` | **added** — written by `MCP::ConnectorAttributes`, read by every agent adapter |
| `skills.references_data` | **dropped** — nothing ever wrote it; its only reader was `WorkflowDuplicator`, which would have raised in production too |
| `usage_statistics.cursor_token_fee_cents` | **dropped** — no reader, no writer |
| `index_tools_on_scope_type` | **dropped** — redundant with the `(scope_type, scope_id, name)` index |

Every statement in the new migration is conditional (`if_exists` / `if_not_exists`), so databases that already have these columns and databases that never did converge on the same end state.

## The test, which failed first

`test/db/schema_parity_test.rb` replays `db/migrate` into a throwaway database and diffs the dump against the committed schema, catching the whole class of drift rather than the one column that happened to blow up first. Its first run:

```
db/schema.rb does not match a database built from db/migrate.

In schema.rb but NOT produced by any migration (missing in production):
  t.jsonb "args", default: []
  t.jsonb "references_data", default: {}
  t.index ["scope_type"], name: "index_tools_on_scope_type"
  t.decimal "cursor_token_fee_cents", precision: 12, scale: 6, default: "0.0"
```

No feature-level test could have caught this — the test database has the column. Runs in ~8s.

## Making the replay possible

Two migrations had been unreplayable for months:

- `ConsolidatedMigration` called `ActionMCP::ApplicationRecord.connection` for its `table_exists?` helpers. The gem is gone; it now uses the migration's own connection, which is the same database it always pointed at.
- `AddKindToTools` re-added a column `CreateTools` already declares. Now `if_not_exists`, kept rather than deleted because older databases have it recorded as applied.

`AddRelayStateToTriggerEvents` moves from `where: "relay_state IN (...)"` to the `= ANY (ARRAY[...])` form with the casts Postgres itself applies. Same predicate — but Postgres prints the two differently, so the `IN` form made a migrated database's dump permanently differ from a schema-loaded one.

## Also

`ConnectorInstaller` had no test at all. Added coverage of the argv it writes (`command` and `args` together *are* the launch line), catalog provenance, name collisions, the stale-mirror fallback, and a withdrawn target.

## Verification

`docker compose exec -T web make check_all` — green (rails-test, rubocop, brakeman, system-test, eslint, typescript, vitest, vite-build). Backend coverage 90.35%, frontend 78.14%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)