### PR TITLE
feat(board): let MCP set a board task assignee

### DIFF
--- a/app/resources/application_resource.rb
+++ b/app/resources/application_resource.rb
@@ -17,10 +17,27 @@ class ApplicationResource
     end
   end
 
+  # `params[:snake_keys]` serializes this resource in Ruby conventions instead.
+  # The camelCase above exists for the Inertia/TS frontend; agent-facing
+  # surfaces (MCP and workflow tools) speak snake_case like the rest of the
+  # app, so a tool payload matches the column and param names an agent reads
+  # everywhere else. Only declared attribute names are renamed — opaque value
+  # hashes (gate metadata, asset metadata) keep their own keys verbatim.
   def to_h
     result = super
+    snake = params[:snake_keys]
+    result = snake_keys(result) if snake
     keys = self.class._preserve_keys
-    result["_preserveKeys"] = keys if keys.any?
+    if keys.any?
+      result[snake ? "_preserve_keys" : "_preserveKeys"] = snake ? keys.map { |k| k.to_s.underscore } : keys
+    end
     result
+  end
+
+  private
+
+  def snake_keys(hash)
+    names = self.class._attributes.keys.index_by { |name| name.to_s.camelize(:lower) }
+    hash.transform_keys { |key| names[key.to_s]&.to_s || key.to_s }
   end
 end

--- a/app/resources/board_resource.rb
+++ b/app/resources/board_resource.rb
@@ -5,6 +5,7 @@ class BoardResource < ApplicationResource
 
   typelize "BoardColumn[]"
   attribute :board_columns, if: proc { params[:include_columns] } do |board|
-    board.board_columns.order(:position).map { |c| BoardColumnResource.new(c).to_h }
+    # params carries `snake_keys` through to the nested columns.
+    board.board_columns.order(:position).map { |c| BoardColumnResource.new(c, params: params).to_h }
   end
 end

--- a/app/services/context_builders/board_context.rb
+++ b/app/services/context_builders/board_context.rb
@@ -65,7 +65,7 @@ module ContextBuilders
       lines << "- **board_get_task_assets** — get assets attached to a task"
       lines << "- **board_add_comment** — add a comment to a task (markdown supported in body)"
       lines << "- **board_update_task** — update task fields (title, description, priority, assignee_id, etc)"
-      lines << "- **board_create_task** — create a new task on the board"
+      lines << "- **board_create_task** — create a new task on the board (optionally assignee_id)"
       lines << "- **board_move_task** — move a task to a different column by column_name"
       lines << "- **board_attach_asset** — attach a file to a task (use file_path for screenshots, file_content for small text)"
       lines << "- **board_manage_tags** — add/remove tags on a task"

--- a/app/services/context_builders/board_context.rb
+++ b/app/services/context_builders/board_context.rb
@@ -36,6 +36,7 @@ module ContextBuilders
       lines << "- **Priority:** #{task.priority}" if task.priority.present?
       lines << "- **Description:** #{task.description.truncate(500)}" if task.description.present?
       lines << "- **Tags:** #{task.tags.join(', ')}" if task.tags.present?
+      lines << "- **Assignee:** #{task.assignee.name} (id: #{task.assignee_id})" if task.assignee
 
       lines << ""
       lines << "### Board Columns"
@@ -63,11 +64,12 @@ module ContextBuilders
       lines << "- **board_get_comments** — get comments for a task"
       lines << "- **board_get_task_assets** — get assets attached to a task"
       lines << "- **board_add_comment** — add a comment to a task (markdown supported in body)"
-      lines << "- **board_update_task** — update task fields (title, description, priority, etc)"
+      lines << "- **board_update_task** — update task fields (title, description, priority, assignee_id, etc)"
       lines << "- **board_create_task** — create a new task on the board"
       lines << "- **board_move_task** — move a task to a different column by column_name"
       lines << "- **board_attach_asset** — attach a file to a task (use file_path for screenshots, file_content for small text)"
       lines << "- **board_manage_tags** — add/remove tags on a task"
+      lines << "- **board_list_members** — list project members with the user ids to assign a task to"
 
       lines.join("\n")
     end

--- a/app/services/internal_tools/board_create_task.rb
+++ b/app/services/internal_tools/board_create_task.rb
@@ -30,6 +30,10 @@ module InternalTools
             type: "string",
             description: "Target column name. Defaults to the first column."
           },
+          assignee_id: {
+            type: "integer",
+            description: "Optional user ID to assign the task to — must be a project member (see board_list_members)"
+          },
           description: {
             type: "string",
             description: "Task description"
@@ -55,6 +59,7 @@ module InternalTools
         title: params[:title],
         description: params[:description],
         task_type: params[:task_type] || :not_specified,
+        assignee_id: params[:assignee_id].presence,
         tags: params[:tags] || []
       )
 
@@ -62,8 +67,13 @@ module InternalTools
         id: task.id,
         title: task.title,
         column: column.name,
+        assignee_id: task.assignee_id,
         position: task.position
       }.to_json)
+    rescue ActiveRecord::RecordInvalid => e
+      # An assignee who can't reach the project is the realistic case here, and
+      # the step should read the reason rather than die on the exception.
+      error(e.record.errors.full_messages.to_sentence.presence || e.message)
     end
   end
 end

--- a/app/services/internal_tools/board_get_board_info.rb
+++ b/app/services/internal_tools/board_get_board_info.rb
@@ -19,7 +19,7 @@ module InternalTools
       board = BoardContextResolver.resolve(session)
       return error("No board available in current context") unless board
 
-      result = BoardResource.new(board, params: { include_columns: true }).to_h
+      result = BoardResource.new(board, params: { include_columns: true, snake_keys: true }).to_h
       success(result.to_json)
     end
   end

--- a/app/services/internal_tools/board_get_comments.rb
+++ b/app/services/internal_tools/board_get_comments.rb
@@ -40,7 +40,7 @@ module InternalTools
       comments = comments.with_tag(params[:tag]) if params[:tag].present?
       comments = comments.by_author_type(params[:author_type]) if params[:author_type].present?
 
-      result = comments.map { |c| TaskCommentResource.new(c).to_h }
+      result = comments.map { |c| TaskCommentResource.new(c, params: { snake_keys: true }).to_h }
       success(result.to_json)
     end
   end

--- a/app/services/internal_tools/board_get_task.rb
+++ b/app/services/internal_tools/board_get_task.rb
@@ -32,7 +32,7 @@ module InternalTools
                   .find_by(id: task_id)
       return error("Task not found on this board") unless task
 
-      success(BoardTaskResource.new(task).to_h.to_json)
+      success(BoardTaskResource.new(task, params: { snake_keys: true }).to_h.to_json)
     end
   end
 end

--- a/app/services/internal_tools/board_get_task_assets.rb
+++ b/app/services/internal_tools/board_get_task_assets.rb
@@ -34,7 +34,7 @@ module InternalTools
       assets = task.task_assets.includes(:author).order(created_at: :desc)
       assets = assets.with_tag(params[:tag]) if params[:tag].present?
 
-      result = assets.map { |a| TaskAssetResource.new(a).to_h }
+      result = assets.map { |a| TaskAssetResource.new(a, params: { snake_keys: true }).to_h }
       success(result.to_json)
     end
   end

--- a/app/services/internal_tools/board_list_members.rb
+++ b/app/services/internal_tools/board_list_members.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module InternalTools
+  class BoardListMembers < Base
+    tool do
+      display_name "Board List Members"
+      description "List the people who can access this board's project, with the user IDs to assign a task to."
+      tags :board
+      inject_when :workflow_step_session
+      read_only
+      input_schema({
+        type: "object",
+        required: [],
+        properties: {}
+      })
+    end
+
+    def execute
+      require_workflow_context!
+      board = BoardContextResolver.resolve(session)
+      return error("No board available in current context") unless board
+
+      board_project = board.project
+      return error("This board has no project") unless board_project
+
+      # Filtered by the same predicate BoardTask validates an assignee against,
+      # so every id returned here is actually assignable (a collaborator whose
+      # company membership was revoked still has a project_collaborators row).
+      members = board_project.member_users.select { |u| board_project.accessible_by?(u) }.map do |u|
+        { id: u.id, name: u.name, role: u.id == board_project.owner_id ? "owner" : "collaborator" }
+      end
+      success({ project_id: board_project.id, members: members }.to_json)
+    end
+  end
+end

--- a/app/services/internal_tools/board_list_tasks.rb
+++ b/app/services/internal_tools/board_list_tasks.rb
@@ -49,7 +49,7 @@ module InternalTools
       tasks = tasks.where(task_type: params[:task_type]) if params[:task_type].present?
       tasks = tasks.where(assignee_id: params[:assignee_id]) if params[:assignee_id].present?
 
-      result = tasks.map { |t| BoardTaskResource.new(t).to_h }
+      result = tasks.map { |t| BoardTaskResource.new(t, params: { snake_keys: true }).to_h }
       success(result.to_json)
     end
   end

--- a/app/services/internal_tools/board_update_task.rb
+++ b/app/services/internal_tools/board_update_task.rb
@@ -4,7 +4,7 @@ module InternalTools
   class BoardUpdateTask < Base
     tool do
       display_name "Board Update Task"
-      description "Update mutable task fields such as title, description, priority, tags, or task type."
+      description "Update mutable task fields such as title, description, priority, tags, task type, or assignee."
       tags :board
       inject_when :workflow_step_session
       input_schema({
@@ -30,9 +30,17 @@ module InternalTools
             type: "string",
             description: "Updated task priority"
           },
+          unassign: {
+            type: "boolean",
+            description: "Clear the current assignee. Cannot be combined with assignee_id."
+          },
           task_type: {
             type: "string",
             description: "Updated task type"
+          },
+          assignee_id: {
+            type: "integer",
+            description: "User ID to assign the task to — must be a project member (see board_list_members)"
           },
           description: {
             type: "string",
@@ -53,6 +61,11 @@ module InternalTools
       return error("Task not found on this board") unless task
 
       updates = params.slice(*UPDATABLE_FIELDS).reject { |_, v| v.nil? }
+      if assign? && unassign?
+        return error("Pass either assignee_id or unassign, not both")
+      elsif assign? || unassign?
+        updates["assignee_id"] = unassign? ? nil : params[:assignee_id]
+      end
       return error("No valid fields to update") if updates.empty?
 
       task.update!(updates)
@@ -60,8 +73,18 @@ module InternalTools
       success({
         id: task.id,
         title: task.title,
+        assignee_id: task.assignee_id,
         updated_fields: updates.keys
       }.to_json)
+    rescue ActiveRecord::RecordInvalid => e
+      # An assignee who can't reach the project is the realistic case here, and
+      # the step should read the reason rather than die on the exception.
+      error(e.record.errors.full_messages.to_sentence.presence || e.message)
     end
+
+    private
+
+    def assign? = params[:assignee_id].present?
+    def unassign? = ActiveModel::Type::Boolean.new.cast(params[:unassign]).present?
   end
 end

--- a/app/services/personal_tools/create_board_task.rb
+++ b/app/services/personal_tools/create_board_task.rb
@@ -13,6 +13,8 @@ module PersonalTools
       param :description, type: :string, description: "Task description (markdown)."
       param :task_type, type: :string, description: "Task type."
       param :priority, type: :string, description: "Task priority."
+      param :assignee_id, type: :integer,
+            description: "User id to assign the task to — must be a project member (see list_project_members)."
       param :tags, type: :array, description: "Task tags.", items: { type: "string" }
     end
 
@@ -29,12 +31,14 @@ module PersonalTools
         board: board,
         params: { board_column: column, title: params[:title], description: params[:description],
                   task_type: params[:task_type].presence || :not_specified,
-                  priority: params[:priority].presence, tags: params[:tags] || [] }.compact,
+                  priority: params[:priority].presence, assignee_id: params[:assignee_id].presence,
+                  tags: params[:tags] || [] }.compact,
         actor: user
       )
       return error("Failed to create task: #{task.errors.full_messages.to_sentence}") unless task.persisted?
 
-      success(id: task.id, title: task.title, column: column.name, column_id: column.id, position: task.position)
+      success(id: task.id, title: task.title, column: column.name, column_id: column.id,
+              assignee_id: task.assignee_id, position: task.position)
     end
   end
 end

--- a/app/services/personal_tools/get_board_task.rb
+++ b/app/services/personal_tools/get_board_task.rb
@@ -18,7 +18,7 @@ module PersonalTools
       task = find_task(project)
       return error("Task not found on this project's board") unless task
 
-      success(BoardTaskResource.new(task).to_h)
+      success(BoardTaskResource.new(task, params: { snake_keys: true }).to_h)
     end
 
     private

--- a/app/services/personal_tools/list_board_tasks.rb
+++ b/app/services/personal_tools/list_board_tasks.rb
@@ -28,7 +28,7 @@ module PersonalTools
       rows = tasks.limit(LIMIT).map do |t|
         { id: t.id, title: t.title, task_type: t.task_type, priority: t.priority,
           column: t.board_column&.name, column_id: t.board_column_id,
-          assignee: t.assignee&.name, tags: t.tags }
+          assignee: t.assignee&.name, assignee_id: t.assignee_id, tags: t.tags }
       end
       payload = { project_id: project.id, tasks: rows }
       payload[:truncated] = true if tasks.count > LIMIT

--- a/app/services/personal_tools/list_project_members.rb
+++ b/app/services/personal_tools/list_project_members.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class ListProjectMembers < Base
+    tool do
+      display_name "List Project Members"
+      description "List the users who can access a project, with ids to use as a board task assignee."
+      audience :user
+      tags :resources
+      read_only
+      param :project_id, type: :integer, description: "Project id (from list_projects).", required: true
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project, :index?, policy: Web::Company::Projects::MembersPolicy, project: project)
+
+      # Filtered by the same predicate BoardTask validates an assignee against,
+      # so every id returned here is actually assignable (a collaborator whose
+      # company membership was revoked still has a project_collaborators row).
+      members = project.member_users.select { |u| project.accessible_by?(u) }.map do |u|
+        { id: u.id, name: u.name, email: u.email, role: u.id == project.owner_id ? "owner" : "collaborator" }
+      end
+      success(project_id: project.id, members: members)
+    end
+  end
+end

--- a/app/services/personal_tools/update_board_task.rb
+++ b/app/services/personal_tools/update_board_task.rb
@@ -4,7 +4,7 @@ module PersonalTools
   class UpdateBoardTask < Base
     tool do
       display_name "Update Board Task"
-      description "Update mutable fields of a board task (title, description, priority, task type, tags)."
+      description "Update mutable fields of a board task (title, description, priority, task type, tags, assignee)."
       audience :user
       tags :board
       param :project_id, type: :integer, description: "Project id.", required: true
@@ -14,6 +14,9 @@ module PersonalTools
       param :priority, type: :string, description: "Updated priority."
       param :task_type, type: :string, description: "Updated task type."
       param :tags, type: :array, description: "Replacement tag list.", items: { type: "string" }
+      param :assignee_id, type: :integer,
+            description: "User id to assign the task to — must be a project member (see list_project_members)."
+      param :unassign, type: :boolean, description: "Clear the current assignee. Cannot be combined with assignee_id."
     end
 
     UPDATABLE = %w[title description priority task_type tags].freeze
@@ -25,12 +28,24 @@ module PersonalTools
       return error("Task not found on this project's board") unless task
 
       updates = params.slice(*UPDATABLE).reject { |_, v| v.nil? }
+      if assign? && unassign?
+        return error("Pass either assignee_id or unassign, not both")
+      elsif assign? || unassign?
+        updates["assignee_id"] = unassign? ? nil : params[:assignee_id]
+      end
       return error("No fields to update") if updates.empty?
 
       TaskService.update(task: task, params: updates, actor: user)
+      # The model rejects an assignee who can't reach the project, so a bad
+      # assignee_id surfaces as a tool error rather than a silent no-op.
       return error("Update failed: #{task.errors.full_messages.to_sentence}") if task.errors.any?
 
-      success(id: task.id, title: task.title, updated_fields: updates.keys)
+      success(id: task.id, title: task.title, assignee_id: task.assignee_id, updated_fields: updates.keys)
     end
+
+    private
+
+    def assign? = params[:assignee_id].present?
+    def unassign? = ActiveModel::Type::Boolean.new.cast(params[:unassign]).present?
   end
 end

--- a/test/integration/personal_mcp_board_test.rb
+++ b/test/integration/personal_mcp_board_test.rb
@@ -45,9 +45,13 @@ class PersonalMCPBoardTest < ActionDispatch::IntegrationTest
     assert_empty filtered
   end
 
-  test "get_board_task returns full detail" do
+  test "get_board_task returns full detail with snake_case keys" do
     task = payload(call_tool("get_board_task", { project_id: @project.id, task_id: @task.id }))
     assert_equal "First task", task["title"]
+    # The resource camelizes for the frontend; a tool payload must not.
+    assert_equal @todo.id, task["board_column_id"]
+    assert task.key?("comments_count")
+    assert_empty task.keys.grep(/[A-Z]/)
   end
 
   test "create_board_task creates a task in the target column" do
@@ -74,9 +78,8 @@ class PersonalMCPBoardTest < ActionDispatch::IntegrationTest
     assert_not tool_error?(assigned)
     assert_equal member.id, @task.reload.assignee_id
     assert_equal member.id, payload(assigned)["assignee_id"]
-    # get_board_task serializes through BoardTaskResource, whose keys are camelCase.
-    assert_equal member.id, payload(call_tool("get_board_task",
-                                             { project_id: @project.id, task_id: @task.id }))["assigneeId"]
+    detail = payload(call_tool("get_board_task", { project_id: @project.id, task_id: @task.id }))
+    assert_equal member.id, detail["assignee_id"]
 
     cleared = call_tool("update_board_task",
                         { project_id: @project.id, task_id: @task.id, unassign: true })

--- a/test/integration/personal_mcp_board_test.rb
+++ b/test/integration/personal_mcp_board_test.rb
@@ -65,6 +65,65 @@ class PersonalMCPBoardTest < ActionDispatch::IntegrationTest
     assert_equal "high", @task.reload.priority
   end
 
+  test "update_board_task assigns and then unassigns a project member" do
+    member = create(:user, company: @company)
+    @project.add_collaborator(member)
+
+    assigned = call_tool("update_board_task",
+                         { project_id: @project.id, task_id: @task.id, assignee_id: member.id })
+    assert_not tool_error?(assigned)
+    assert_equal member.id, @task.reload.assignee_id
+    assert_equal member.id, payload(assigned)["assignee_id"]
+    # get_board_task serializes through BoardTaskResource, whose keys are camelCase.
+    assert_equal member.id, payload(call_tool("get_board_task",
+                                             { project_id: @project.id, task_id: @task.id }))["assigneeId"]
+
+    cleared = call_tool("update_board_task",
+                        { project_id: @project.id, task_id: @task.id, unassign: true })
+    assert_not tool_error?(cleared)
+    assert_nil @task.reload.assignee_id
+  end
+
+  test "update_board_task refuses an assignee who cannot reach the project" do
+    outsider = create(:user, :with_company)
+
+    body = call_tool("update_board_task",
+                     { project_id: @project.id, task_id: @task.id, assignee_id: outsider.id })
+    assert tool_error?(body)
+    assert_match(/member of the project/i, body.dig("result", "content").map { |c| c["text"] }.join(" "))
+    assert_nil @task.reload.assignee_id
+  end
+
+  test "update_board_task rejects assignee_id together with unassign" do
+    member = create(:user, company: @company)
+    @project.add_collaborator(member)
+    @task.update!(assignee: member)
+
+    body = call_tool("update_board_task",
+                     { project_id: @project.id, task_id: @task.id, assignee_id: member.id, unassign: true })
+    assert tool_error?(body)
+    assert_match(/either assignee_id or unassign/i, body.dig("result", "content").map { |c| c["text"] }.join(" "))
+    assert_equal member.id, @task.reload.assignee_id
+  end
+
+  test "list_project_members returns assignable users with roles" do
+    member = create(:user, company: @company)
+    @project.add_collaborator(member)
+
+    members = payload(call_tool("list_project_members", { project_id: @project.id }))["members"]
+    assert_equal [ "owner", "collaborator" ], members.map { |m| m["role"] }
+    assert_equal [ @user.id, member.id ], members.map { |m| m["id"] }
+  end
+
+  test "list_project_members omits a collaborator whose company membership was revoked" do
+    member = create(:user, company: @company)
+    @project.add_collaborator(member)
+    member.company_memberships.find_by(company: @company).revoke!
+
+    members = payload(call_tool("list_project_members", { project_id: @project.id }))["members"]
+    assert_equal [ @user.id ], members.map { |m| m["id"] }
+  end
+
   test "move_board_task moves to another column" do
     body = call_tool("move_board_task", { project_id: @project.id, task_id: @task.id, column_id: @done.id })
     assert_not tool_error?(body)

--- a/test/integration/personal_mcp_board_test.rb
+++ b/test/integration/personal_mcp_board_test.rb
@@ -63,6 +63,27 @@ class PersonalMCPBoardTest < ActionDispatch::IntegrationTest
     assert_equal "To Do", created["column"]
   end
 
+  test "create_board_task can assign the task on creation" do
+    member = create(:user, company: @company)
+    @project.add_collaborator(member)
+
+    created = payload(call_tool("create_board_task",
+                                { project_id: @project.id, column_id: @todo.id,
+                                  title: "Assigned on create", assignee_id: member.id }))
+    assert_equal member.id, created["assignee_id"]
+    assert_equal member.id, BoardTask.find(created["id"]).assignee_id
+  end
+
+  test "create_board_task refuses an assignee who cannot reach the project" do
+    outsider = create(:user, :with_company)
+
+    body = call_tool("create_board_task",
+                     { project_id: @project.id, column_id: @todo.id, title: "Nope", assignee_id: outsider.id })
+    assert tool_error?(body)
+    assert_match(/member of the project/i, body.dig("result", "content").map { |c| c["text"] }.join(" "))
+    assert_not BoardTask.exists?(title: "Nope")
+  end
+
   test "update_board_task updates fields" do
     body = call_tool("update_board_task", { project_id: @project.id, task_id: @task.id, priority: "high" })
     assert_not tool_error?(body)

--- a/test/seeds/platform_tools_test.rb
+++ b/test/seeds/platform_tools_test.rb
@@ -17,6 +17,7 @@ class PlatformToolsReconcileTest < ActiveSupport::TestCase
       board_move_task
       board_attach_asset
       board_manage_tags
+      board_list_members
     ].each do |tool_name|
       tool = Tool.find_by(name: tool_name)
       assert_not_nil tool, "expected #{tool_name} to be seeded"

--- a/test/services/context_builders/board_context_test.rb
+++ b/test/services/context_builders/board_context_test.rb
@@ -129,7 +129,7 @@ class ContextBuilders::BoardContextTest < ActiveSupport::TestCase
     content = ContextBuilders::BoardContext.new(session).build.first.content
     %w[board_get_board_info board_list_tasks board_get_task board_get_comments
        board_get_task_assets board_add_comment board_update_task board_create_task
-       board_move_task board_attach_asset board_manage_tags].each do |tool|
+       board_move_task board_attach_asset board_manage_tags board_list_members].each do |tool|
       assert_includes content, tool, "Expected content to include #{tool}"
     end
   end

--- a/test/services/internal_tools/board_read_tools_test.rb
+++ b/test/services/internal_tools/board_read_tools_test.rb
@@ -77,10 +77,10 @@ class InternalTools::BoardReadToolsTest < ActiveSupport::TestCase
     assert_equal @task.id, data["id"]
     assert_equal "Test task", data["title"]
     assert_equal "Do something", data["description"]
-    assert_equal @col1.id, data["boardColumnId"]
-    assert data.key?("childrenCount")
-    assert data.key?("commentsCount")
-    assert data.key?("assetsCount")
+    assert_equal @col1.id, data["board_column_id"]
+    assert data.key?("children_count")
+    assert data.key?("comments_count")
+    assert data.key?("assets_count")
   end
 
   test "board_get_task uses workflow_run board_task_id when no task_id param" do
@@ -106,8 +106,8 @@ class InternalTools::BoardReadToolsTest < ActiveSupport::TestCase
     assert_equal 0, result[:exit_code]
     data = JSON.parse(result[:stdout])
     assert_equal 2, data.size
-    assert data.first.key?("authorName")
-    assert data.first.key?("authorType")
+    assert data.first.key?("author_name")
+    assert data.first.key?("author_type")
   end
 
   test "board_get_comments filters by tag" do
@@ -140,7 +140,7 @@ class InternalTools::BoardReadToolsTest < ActiveSupport::TestCase
     data = JSON.parse(result[:stdout])
     assert_equal 1, data.size
     assert_equal "report.md", data.first["name"]
-    assert data.first.key?("fileUrl")
+    assert data.first.key?("file_url")
   end
 
   test "board_get_task_assets filters by tag" do
@@ -161,8 +161,8 @@ class InternalTools::BoardReadToolsTest < ActiveSupport::TestCase
     data = JSON.parse(result[:stdout])
     assert_equal @board.id, data["id"]
     assert_equal @board.name, data["name"]
-    assert_equal 2, data["boardColumns"].size
-    assert_equal "Backlog", data["boardColumns"].first["name"]
-    assert_equal "New tasks", data["boardColumns"].first["purpose"]
+    assert_equal 2, data["board_columns"].size
+    assert_equal "Backlog", data["board_columns"].first["name"]
+    assert_equal "New tasks", data["board_columns"].first["purpose"]
   end
 end

--- a/test/services/internal_tools/board_write_tools_test.rb
+++ b/test/services/internal_tools/board_write_tools_test.rb
@@ -49,6 +49,33 @@ class InternalTools::BoardWriteToolsTest < ActiveSupport::TestCase
     assert_equal "Backlog", data["column"]
   end
 
+  test "board_create_task assigns the task on creation" do
+    member = create(:user, company: @company)
+    @project.add_collaborator(member)
+
+    result = InternalTools::BoardCreateTask.new(
+      params: { title: "Assigned on create", assignee_id: member.id },
+      session: @session
+    ).execute
+
+    assert_equal 0, result[:exit_code]
+    assert_equal member.id, JSON.parse(result[:stdout])["assignee_id"]
+    assert_equal member.id, BoardTask.find(JSON.parse(result[:stdout])["id"]).assignee_id
+  end
+
+  test "board_create_task reports an assignee who cannot reach the project" do
+    outsider = create(:user, :with_company)
+
+    result = InternalTools::BoardCreateTask.new(
+      params: { title: "Nope", assignee_id: outsider.id },
+      session: @session
+    ).execute
+
+    assert_equal 1, result[:exit_code]
+    assert_match(/member of the project/i, result[:stderr])
+    assert_not BoardTask.exists?(title: "Nope")
+  end
+
   test "board_create_task returns error for unknown column" do
     result = InternalTools::BoardCreateTask.new(
       params: { title: "Task", column_name: "Nonexistent" },

--- a/test/services/internal_tools/board_write_tools_test.rb
+++ b/test/services/internal_tools/board_write_tools_test.rb
@@ -83,6 +83,73 @@ class InternalTools::BoardWriteToolsTest < ActiveSupport::TestCase
     assert_includes result[:stderr], "No valid fields"
   end
 
+  test "board_update_task assigns and then unassigns a project member" do
+    member = create(:user, company: @company)
+    @project.add_collaborator(member)
+
+    assigned = InternalTools::BoardUpdateTask.new(
+      params: { task_id: @task.id, assignee_id: member.id },
+      session: @session
+    ).execute
+
+    assert_equal 0, assigned[:exit_code]
+    assert_equal member.id, JSON.parse(assigned[:stdout])["assignee_id"]
+    assert_equal member.id, @task.reload.assignee_id
+
+    cleared = InternalTools::BoardUpdateTask.new(
+      params: { task_id: @task.id, unassign: true },
+      session: @session
+    ).execute
+
+    assert_equal 0, cleared[:exit_code]
+    assert_nil @task.reload.assignee_id
+  end
+
+  test "board_update_task reports an assignee who cannot reach the project" do
+    outsider = create(:user, :with_company)
+
+    result = InternalTools::BoardUpdateTask.new(
+      params: { task_id: @task.id, assignee_id: outsider.id },
+      session: @session
+    ).execute
+
+    assert_equal 1, result[:exit_code]
+    assert_match(/member of the project/i, result[:stderr])
+    assert_nil @task.reload.assignee_id
+  end
+
+  test "board_update_task rejects assignee_id together with unassign" do
+    member = create(:user, company: @company)
+    @project.add_collaborator(member)
+    @task.update!(assignee: member)
+
+    result = InternalTools::BoardUpdateTask.new(
+      params: { task_id: @task.id, assignee_id: member.id, unassign: true },
+      session: @session
+    ).execute
+
+    assert_equal 1, result[:exit_code]
+    assert_match(/either assignee_id or unassign/i, result[:stderr])
+    assert_equal member.id, @task.reload.assignee_id
+  end
+
+  # === board_list_members ===
+
+  test "board_list_members lists assignable users and omits revoked memberships" do
+    member = create(:user, company: @company)
+    @project.add_collaborator(member)
+    revoked = create(:user, company: @company)
+    @project.add_collaborator(revoked)
+    revoked.company_memberships.find_by(company: @company).revoke!
+
+    result = InternalTools::BoardListMembers.new(params: {}, session: @session).execute
+
+    assert_equal 0, result[:exit_code]
+    members = JSON.parse(result[:stdout])["members"]
+    assert_equal [ @user.id, member.id ], members.map { |m| m["id"] }
+    assert_equal [ "owner", "collaborator" ], members.map { |m| m["role"] }
+  end
+
   test "board_update_task returns error for unknown task" do
     result = InternalTools::BoardUpdateTask.new(
       params: { task_id: 99999, title: "X" },

--- a/test/services/tools/registry_test.rb
+++ b/test/services/tools/registry_test.rb
@@ -46,7 +46,7 @@ class Tools::RegistryTest < ActiveSupport::TestCase
     defs = Tools::Registry.definitions.values
 
     assert_equal 28, defs.count { |d| d.tags.include?(:builder) }
-    assert_equal 17, defs.count { |d| d.inject_rules.include?(:workflow_step_session) }
+    assert_equal 18, defs.count { |d| d.inject_rules.include?(:workflow_step_session) }
     assert_equal 3, defs.count { |d| d.inject_rules.intersect?(%i[container_tools_present non_interactive_session]) }
   end
 end


### PR DESCRIPTION
## Why

The personal MCP surface could read a task's assignee but never write it — `assignee_id` was only reachable through the board UI, so an agent could not hand a card to a person. Nothing in the workflow/MCP tool set touched it (`board_create_task`, `board_update_task`, `create_board_task`, `update_board_task` all omitted the field).

## What

**Assignee, on any task (not only at creation)**

- `update_board_task` takes `assignee_id`, or `unassign: true` to clear it; passing both is an error rather than a silent precedence rule. The response now reports the resulting `assignee_id`.
- `list_project_members` (new, read-only) returns the assignable users — `{id, name, email, role}`, owner first — filtered by the same `Project#accessible_by?` predicate `BoardTask` validates an assignee against, so a collaborator whose company membership was revoked is never offered as a candidate.
- `create_board_task` takes an optional `assignee_id`, so a card never has to sit unowned between creation and a follow-up call.
- `list_board_tasks` rows carry `assignee_id` next to the assignee name.

A non-member `assignee_id` surfaces the model validation as a tool error and leaves the task untouched. No migration: `audience :user` tools are never materialized as rows.

**The same, for agents inside a workflow step**

That is where hand-off actually happens, so the session-side tools get the identical shape:

- `board_update_task` takes `assignee_id` / `unassign` and reports the resulting `assignee_id`. A rejected assignee comes back as a tool error rather than a raised `RecordInvalid`, so the step can read the reason instead of dying.
- `board_create_task` takes the same optional `assignee_id`.
- `board_list_members` (new) resolves the ids from the board's project, same accessibility filter.
- Board context now states the current assignee and advertises both capabilities.

**snake_case for agent-facing payloads**

`get_board_task` (and the five internal board read tools) serialized through the Alba resources the frontend uses, so agents got `assigneeId` / `boardColumnId` / `commentsCount` while every neighbouring tool answered in snake_case. `params[:snake_keys]` now maps serialized keys back to the declared attribute names — only those, so opaque value hashes (gate metadata, asset metadata) keep their keys verbatim — and the six board read tools opt in. The frontend contract is unchanged.

## Tests

Seven cases in `test/integration/personal_mcp_board_test.rb` and six in `test/services/internal_tools/board_write_tools_test.rb` (assign, unassign, non-member refusal, conflicting flags, member listing including the revoked-membership case), plus a pin that no tool payload key contains an uppercase letter. Inventory counts in `registry_test` / `platform_tools_test` / `board_context_test` updated for the new tool. `make check_all` green: backend 90.38%, frontend 78.14%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
