### PR TITLE
fix(deps): bump transitive brace-expansion to 5.0.9

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3621,11 +3621,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes Dependabot alert [#13](https://github.com/AixleHQ/flow/security/dependabot/13).

`GHSA-3jxr-9vmj-r5cp` (high) — DoS via exponential-time expansion of consecutive non-expanding `{}` groups.

The lockfile carries two `brace-expansion` copies. PR #28 patched the `^1.1.7` one to 1.1.18; the second, resolved from `^5.0.5`, was still on 5.0.5 and vulnerable (patched in 5.0.7). `yarn up -R brace-expansion` takes it to 5.0.9 — a lockfile-only diff, transitive dev dependency, no manifest change.

`docker compose exec -T web make check_all` green (rails-test, rubocop, brakeman, system-test, eslint, typescript, fe-test, vite-build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)