### PR TITLE
fix(oauth): merge params into an authorization_endpoint that has a query

### DIFF
--- a/app/controllers/web/oauth_controller.rb
+++ b/app/controllers/web/oauth_controller.rb
@@ -65,16 +65,15 @@ class Web::OauthController < Web::ApplicationController
       code_verifier: code_verifier
     )
 
-    query = URI.encode_www_form(
-      response_type: "code",
-      client_id: client.client_id,
-      redirect_uri: redirect_uri,
-      scope: client.scopes,
-      state: state,
-      code_challenge: code_challenge,
-      code_challenge_method: "S256"
-    )
-    redirect_to "#{client.authorization_endpoint}?#{query}", allow_other_host: true
+    redirect_to authorize_url(client.authorization_endpoint,
+                              response_type: "code",
+                              client_id: client.client_id,
+                              redirect_uri: redirect_uri,
+                              scope: client.scopes,
+                              state: state,
+                              code_challenge: code_challenge,
+                              code_challenge_method: "S256"),
+                allow_other_host: true
   rescue Oauth::MissingClientConfig
     redirect_to root_path, alert: "This provider is not configured"
   end
@@ -182,17 +181,16 @@ class Web::OauthController < Web::ApplicationController
       oauth_client_id: result.oauth_client.id
     )
 
-    query = URI.encode_www_form(
-      response_type: "code",
-      client_id: result.oauth_client.client_id,
-      redirect_uri: redirect_uri,
-      scope: result.scopes || result.oauth_client.scopes,
-      resource: result.resource, # RFC 8707 resource indicator
-      state: state,
-      code_challenge: code_challenge,
-      code_challenge_method: "S256"
-    )
-    redirect_to "#{result.oauth_client.authorization_endpoint}?#{query}", allow_other_host: true
+    redirect_to authorize_url(result.oauth_client.authorization_endpoint,
+                              response_type: "code",
+                              client_id: result.oauth_client.client_id,
+                              redirect_uri: redirect_uri,
+                              scope: result.scopes || result.oauth_client.scopes,
+                              resource: result.resource, # RFC 8707 resource indicator
+                              state: state,
+                              code_challenge: code_challenge,
+                              code_challenge_method: "S256"),
+                allow_other_host: true
   rescue MCP::DiscoveryError => e
     # (7) token-free logging: class + server id only, never discovered metadata.
     Rails.logger.warn("[Oauth] MCP discovery failed for server=#{params[:mcp_server_id]}: #{e.class.name}")
@@ -207,6 +205,31 @@ class Web::OauthController < Web::ApplicationController
 
   def redirect_uri
     "#{Settings.protocol}://#{Settings.domain}/oauth/callback"
+  end
+
+  # Build the consent URL by MERGING our parameters into whatever query the
+  # authorization_endpoint already carries — never by concatenating "?#{query}".
+  #
+  # An authorization_endpoint is allowed to ship with its own query string, and
+  # discovered ones do: Railway's RFC 8414 metadata advertises
+  # `https://backboard.railway.com/oauth/auth?resource=https%3A%2F%2Fbackboard.railway.com`.
+  # Appending a second "?" makes everything up to the first "&" part of the
+  # PRECEDING parameter's value, so `response_type=code` was swallowed into
+  # `resource` and Railway bounced the user straight back to /oauth/callback with
+  # `error=invalid_request&error_description=missing required parameter 'response_type'`
+  # — which the callback reports as "Connection was cancelled".
+  #
+  # Our values win on conflict: the endpoint's baked-in `resource` names the
+  # authorization server itself, while RFC 8707 requires the resource indicator to
+  # name the MCP server we want the token audience bound to. Blank values are
+  # dropped rather than sent as `scope=` (an empty scope is a request error at some
+  # authorization servers).
+  def authorize_url(endpoint, params)
+    uri = URI.parse(endpoint)
+    existing = URI.decode_www_form(uri.query.to_s).to_h
+    merged = existing.merge(params.stringify_keys).reject { |_k, v| v.blank? }
+    uri.query = URI.encode_www_form(merged)
+    uri.to_s
   end
 
   # Open-redirect guard: accept only same-site absolute paths ("/..."). Rejects

--- a/test/controllers/web/oauth_controller_test.rb
+++ b/test/controllers/web/oauth_controller_test.rb
@@ -302,6 +302,40 @@ class Web::OauthControllerTest < ActionDispatch::IntegrationTest
     assert_equal @project.id, payload["owner_id"]
   end
 
+  # Regression: Railway's discovered authorization_endpoint is
+  # ".../oauth/auth?resource=https%3A%2F%2Fbackboard.railway.com". Appending a
+  # second "?" folded `response_type=code` into that `resource` value, so Railway
+  # answered `error=invalid_request` / "missing required parameter 'response_type'".
+  test "mcp_connect merges its parameters into an authorization_endpoint that already carries a query" do
+    server = create(:mcp_server, :custom, scope: @project, auth_type: :oauth, credential_scope: :shared,
+                    url: "https://mcp.acme.test/v1")
+    client = build_dcr_client
+    client.update!(authorization_endpoint: "https://auth.mcp.test/authorize?resource=https%3A%2F%2Fauth.mcp.test&prompt=consent")
+    stub_discovery!(client: client)
+
+    get oauth_mcp_connect_path(mcp_server_id: server.id)
+
+    assert_response :redirect
+    location = @response.headers["Location"]
+    assert_equal 1, location.count("?"), "a second '?' folds our first parameter into the endpoint's own value"
+
+    pairs = URI.decode_www_form(URI(location).query.to_s)
+    assert_equal "code", pairs.to_h["response_type"]
+    assert_equal "consent", pairs.to_h["prompt"], "the endpoint's own parameters survive the merge"
+    assert_equal [ "https://mcp.acme.test/v1" ], pairs.select { |k, _| k == "resource" }.map(&:last),
+                 "exactly one RFC 8707 resource indicator, naming the MCP server and not the auth server"
+  end
+
+  test "mcp_connect omits scope entirely when neither discovery nor the client advertises one" do
+    server = create(:mcp_server, :custom, scope: @project, auth_type: :oauth, url: "https://mcp.acme.test/v1")
+    stub_discovery!(client: build_dcr_client(scopes: nil), scopes: nil)
+
+    get oauth_mcp_connect_path(mcp_server_id: server.id)
+
+    q = query_params(@response.headers["Location"])
+    refute q.key?("scope"), "an empty scope= is a request error at some authorization servers"
+  end
+
   test "mcp_connect pins the connecting identity to the current user for a per_user server" do
     server = create(:mcp_server, :custom, scope: @project, auth_type: :oauth, credential_scope: :per_user,
                     url: "https://mcp.acme.test/v1")


### PR DESCRIPTION
## Problem

Connecting the Railway remote MCP server (`https://mcp.railway.com/`, OAuth 2.1) always failed in production with **"Connection was cancelled"**.

Discovery and DCR were never at fault — both work against Railway (verified live: PRM → `authorization_servers: ["https://backboard.railway.com"]`, DCR returns a public `rlwy_oaci_…` client). The consent URL was malformed.

Railway's RFC 8414 metadata advertises an `authorization_endpoint` that **already carries a query string**:

```
https://backboard.railway.com/oauth/auth?resource=https%3A%2F%2Fbackboard.railway.com
```

`Web::OauthController` built the redirect as `"#{endpoint}?#{query}"`. The second `?` is not a delimiter, so everything up to the first `&` became part of the preceding parameter's value — `response_type=code` was swallowed into `resource`. Railway's actual response to the URL we sent:

```
303 -> https://<domain>/oauth/callback?error=invalid_request
       &error_description=missing+required+parameter+%27response_type%27
       &state=…&iss=https%3A%2F%2Fbackboard.railway.com
```

The callback sees `params[:error]` and takes the cancel branch → "Connection was cancelled".

## Fix

New `authorize_url(endpoint, params)` merges our parameters into whatever query the endpoint already carries, instead of concatenating. Applied to both `#authorize` (static providers — same bug class, latent) and `#mcp_connect`.

- **Our values win on conflict.** The endpoint's baked-in `resource` names the *authorization server*; RFC 8707 requires the resource indicator to name the *MCP server* the token audience is bound to. Merging without precedence would send Railway's value and mint a token for the wrong audience.
- **Blank values are dropped** rather than sent as `scope=` — an empty scope is a request error at some authorization servers.

## Verification

The URL the fixed code emits, against live Railway:

```
303 -> https://backboard.railway.com/oauth/interaction/9JHplKMqoZWf1apBmtaRXyZg5brVAYvshm57zRI6E8c   ← consent page
```

Two regression tests at the request layer: the endpoint's own parameters survive the merge, `response_type` is present, exactly one `resource` (naming the MCP server); and `scope` is omitted entirely when neither discovery nor the client advertises one.

`docker compose exec -T web make check_all` — green, all 8 checks (backend coverage 90.52%, frontend 78.15%).

## Follow-ups (not in this PR)

- **Railway rate-limits `/oauth/register`.** An unauthenticated DCR POST returned `429 too_many_requests` from one IP while succeeding from another. If a first connect surfaces "Couldn't connect to this MCP server", that is DCR 429 — retry. One-time only; the client is reused per issuer.
- **Resource trailing slash.** We send the server URL verbatim (`https://mcp.railway.com/`); Railway's protected-resource metadata declares `https://mcp.railway.com`. Railway's authorize endpoint accepts both. If tool calls 401 after a successful connect, normalize to the PRM `resource` value — and change `Oauth::TokenService#perform_refresh!` (which derives `resource` from `cred.mcp_server.url`) in the same commit, or refresh will send a mismatched audience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)