### PR TITLE
docs(legal): Aixle Flow Terms of Service and Privacy Policy

### DIFF
--- a/app/views/layouts/web/legal.html.erb
+++ b/app/views/layouts/web/legal.html.erb
@@ -49,6 +49,10 @@ nav{padding:16px 0;background:rgba(9,9,11,.9);border-bottom:1px solid rgba(63,63
 .legal-content ul,.legal-content ol{margin:12px 0 20px 24px;color:var(--text-secondary);font-size:15px;line-height:1.8}
 .legal-content li{margin-bottom:8px}
 .legal-content strong{color:var(--text-primary);font-weight:600}
+.legal-table{overflow-x:auto;margin:20px 0 28px}
+.legal-content table{width:100%;min-width:520px;border-collapse:collapse;font-size:14px;color:var(--text-secondary)}
+.legal-content th,.legal-content td{border:1px solid var(--border-default);padding:10px 12px;text-align:left;vertical-align:top;line-height:1.7}
+.legal-content th{background:var(--bg-surface);color:var(--text-primary);font-weight:600}
 
 footer{border-top:1px solid rgba(63,63,70,.3);padding:40px 0;text-align:center}
 .footer-inner{max-width:900px;margin:0 auto;padding:0 24px;display:flex;justify-content:space-between;align-items:center;font-size:13px;color:var(--text-muted)}
@@ -89,7 +93,7 @@ footer{border-top:1px solid rgba(63,63,70,.3);padding:40px 0;text-align:center}
 
 <footer>
   <div class="footer-inner">
-    <span>&copy; <%= Date.current.year %> Aixle. All rights reserved.</span>
+    <span>&copy; <%= Date.current.year %> Dualboot Partners, LLC. All rights reserved.</span>
     <div class="footer-links">
       <a href="/privacy-policy">Privacy</a>
       <a href="/terms-of-service">Terms</a>

--- a/app/views/web/pages/privacy_policy.html.erb
+++ b/app/views/web/pages/privacy_policy.html.erb
@@ -1,86 +1,125 @@
 <% content_for(:title, "Privacy Policy") %>
 
-<h1>Privacy Policy</h1>
-<p class="legal-meta">Last updated: March 14, 2026</p>
+<h1>Privacy Policy — Aixle Flow</h1>
+<p class="legal-meta">Last updated: August 6, 2026 · Effective: August 6, 2026</p>
 
-<p>Aixle ("we," "us," or "our") operates the Aixle platform (the "Service"). This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our Service.</p>
+<h2>1. Who We Are</h2>
+<p>Aixle Flow ("the Service") is provided by Dualboot Partners, LLC ("Dualboot," "we," "us"), 5540 Centerview Dr., Ste. 204, #24754, Raleigh, NC 27606.</p>
 
-<h2>1. Information We Collect</h2>
+<h2>2. Two Deployment Models</h2>
+<p>The Service is available in two forms, and our role differs between them. This distinction determines most of what follows.</p>
+<p><strong>Hosted (we operate it):</strong> We run the infrastructure. Our role under GDPR is Processor on behalf of the customer organization, which is the controller. We are an independent controller only for account and billing data. What we can see is everything described in Section 3. This policy applies in full.</p>
+<p><strong>Self-hosted (you operate it):</strong> You run the infrastructure, on your own systems. We are neither controller nor processor — we do not receive, access, or store your data. This policy applies only to Sections 1, 9, and 10.</p>
+<p>The Service's source code is available under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>. If you deploy it yourself, we have no visibility into your data and no ability to access it, and you are the controller for all data you process with it.</p>
 
-<h3>Information You Provide</h3>
+<h2>3. What We Collect (Hosted Deployments)</h2>
+<p><strong>3.1 Account and identity data.</strong> Collected when a user signs in through a supported identity provider (we support Google OpenID Connect, and request only the user's email address and basic profile) or, where enabled for an organization, through a password credential issued in the product: email address, display name, profile picture URL, job title, identity-provider identifiers and access tokens, password hash where password sign-in is used, role within the organization, organization membership, invitation records, interface language preference, and timestamps of account creation, invitation, onboarding, and sign-in.</p>
+<p><strong>3.2 Organization and project configuration.</strong> Organization name, identifier, email domain, branding, and settings; projects and project membership; repository names, URLs, descriptions, and default branches; connected integrations (source-control, issue-tracker, messaging, and infrastructure providers) and their credentials in encrypted form; MCP server definitions and their configuration values; agent, skill, tool, workflow, and board definitions; and resource quotas.</p>
+<p><strong>3.3 Credentials for your AI-assistant accounts.</strong> When a user onboards an AI coding assistant (for example Claude Code, Codex, Cursor CLI, or Gemini CLI), the Service captures and stores, in encrypted form, the authentication artifacts that the assistant's own client produces — an OAuth token set or an API key for that user's account with the AI provider — together with metadata such as expiry, the model selected, and when the credential was last used. These credentials are injected into the container at the start of a session so the agent can authenticate to the provider, and are used for no other purpose.</p>
+<p><strong>3.4 Session inputs and repository content.</strong> For each session: the instruction or prompt submitted; the session configuration and injected context; the source code and repository contents retrieved from your connected source-control systems into the session's container; files the agent creates or modifies; artifacts collected at the end of a session; files and assets your users upload; and the text of board tasks and comments, whether written by a person or by an agent.</p>
+<p><strong>3.5 Session transcripts and captured provider traffic.</strong> The Service retains, as files:</p>
 <ul>
-  <li><strong>Account Information:</strong> When you create an account, we collect your name, email address, and authentication credentials (via Google OAuth or other identity providers).</li>
-  <li><strong>Company Information:</strong> Organization name, team member details, and project configuration data.</li>
-  <li><strong>Content:</strong> Code, files, workflow configurations, and other content you upload or create through the Service.</li>
-  <li><strong>Communications:</strong> Information you provide when contacting us through support or contact forms.</li>
+  <li>A complete capture of the session terminal — everything submitted by the user and everything produced by the agent during the session, including source-code contents, command output, and file paths.</li>
+  <li>A log of the agent's network traffic to its AI provider, recorded by a proxy inside the container. For agents where this is enabled, it contains the complete body of each request and response — that is, the prompts and any file content sent with them, and the model's replies — together with the request and response headers.</li>
 </ul>
+<p>This content is stored as submitted or as produced. It is not redacted, filtered, or reduced. Because it is whatever a developer instructed an agent to do and whatever the agent did in response, it may contain information we cannot anticipate — including source code, credentials, your customers' data, and personal data relating to people who are not our users. We do not seek this data and cannot control what appears in it.</p>
+<p>Our <a href="/terms-of-service">Terms of Service</a> require customers not to knowingly submit special-category personal data (as defined under Article 9 of the GDPR), payment-card data, or regulated health data to the Service. Because session content is captured as submitted or produced, we cannot verify or enforce compliance with that restriction at the point of submission, and this section describes what may occur in practice notwithstanding that contractual restriction.</p>
+<p><strong>3.6 Usage and cost records.</strong> For each session: the agent and models used, input, output, and cached token counts, computed cost, event counts and the underlying usage events, session duration and state, the associated project and repositories, and the identity of the user who initiated it. These are collected from telemetry the agent emits and from the traffic described in Section 3.5.</p>
+<p><strong>3.7 Data received from your connected systems.</strong> Where you connect a source-control, issue-tracker, or messaging provider, we receive and store the payloads those systems send us, which typically include commit, branch, and pull-request metadata and the names and email addresses of the people who authored them. Those people may not be users of the Service.</p>
+<p><strong>3.8 Technical and diagnostic data.</strong> Server logs, IP addresses, request metadata, and error reports (including stack traces and request context). Retained for security, debugging, and abuse prevention.</p>
+<p><strong>3.9 What we do not collect.</strong> We do not collect payment-card data. We do not use advertising or cross-site tracking technologies. We do not sell personal data. We do not request access to your email, calendar, files, or other data held by your identity provider.</p>
 
-<h3>Information Collected Automatically</h3>
-<ul>
-  <li><strong>Usage Data:</strong> We collect information about how you interact with the Service, including features used, actions performed, and session duration.</li>
-  <li><strong>Device Information:</strong> Browser type, operating system, device identifiers, and IP address.</li>
-  <li><strong>Log Data:</strong> Server logs that record requests made to our Service, including timestamps, URLs, and response codes.</li>
-</ul>
+<h2>4. Why We Process It; Legal Basis</h2>
+<div class="legal-table">
+<table>
+  <thead>
+    <tr><th>Purpose</th><th>Data</th><th>Legal basis (GDPR)</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Providing the Service to the customer organization — running agent sessions and workflows on its instructions</td>
+      <td>Sections 3.1–3.7</td>
+      <td>Performance of a contract (Art. 6(1)(b)); for individual developers, the customer's legitimate interest (Art. 6(1)(f)), subject to Section 6 of our <a href="/terms-of-service">Terms of Service</a></td>
+    </tr>
+    <tr>
+      <td>Authentication and access control</td>
+      <td>Sections 3.1, 3.3</td>
+      <td>Contract; legitimate interest (Art. 6(1)(f))</td>
+    </tr>
+    <tr>
+      <td>Cost and usage reporting to the customer organization</td>
+      <td>Sections 3.2, 3.6</td>
+      <td>Performance of a contract (Art. 6(1)(b))</td>
+    </tr>
+    <tr>
+      <td>Security, abuse prevention, and debugging</td>
+      <td>Sections 3.1, 3.8</td>
+      <td>Legitimate interest (Art. 6(1)(f))</td>
+    </tr>
+    <tr>
+      <td>Improving the Service</td>
+      <td>Aggregated and de-identified data only</td>
+      <td>Legitimate interest (Art. 6(1)(f))</td>
+    </tr>
+    <tr>
+      <td>Legal and regulatory compliance</td>
+      <td>As required</td>
+      <td>Legal obligation (Art. 6(1)(c))</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+<p>We do not rely on any legal basis for using session content or source code to train machine-learning models, because we do not do so. Section 4.4 of our <a href="/terms-of-service">Terms of Service</a> commits us not to.</p>
 
-<h2>2. How We Use Your Information</h2>
-<p>We use the collected information to:</p>
-<ul>
-  <li>Provide, maintain, and improve the Service</li>
-  <li>Process and manage your account</li>
-  <li>Execute AI agent sessions and workflows on your behalf</li>
-  <li>Monitor and analyze usage patterns and trends</li>
-  <li>Detect, prevent, and address technical issues and security threats</li>
-  <li>Communicate with you about the Service, including updates and support</li>
-  <li>Comply with legal obligations</li>
-</ul>
+<h2>5. Sub-processors and Third Parties</h2>
+<p>Company may engage third-party service providers, contractors, and subprocessors ("Subprocessors") to perform functions and provide services to Company in connection with the Service.</p>
+<p>Company may add, remove, or replace Subprocessors from time to time as necessary to operate and improve the Service. Where Company processes personal data on behalf of a customer as a data processor under applicable data protection law, the specific terms governing Subprocessor engagement, notice, and objection rights are set forth in the applicable Data Processing Addendum, which shall control over this Section in the event of any conflict.</p>
+<p>Separately from our Subprocessors, the AI providers your users connect to the Service necessarily receive the content an agent sends to them, authenticated with the credentials described in Section 3.3. Those providers process that content under their own terms, as described in Section 5.3 of our <a href="/terms-of-service">Terms of Service</a>. The providers the Service supports today are Anthropic, OpenAI, Cursor, and Google.</p>
 
-<h2>3. Data Storage and Security</h2>
-<p>We implement industry-standard security measures to protect your data:</p>
-<ul>
-  <li>All data is encrypted in transit using TLS/SSL</li>
-  <li>Sensitive credentials and secrets are encrypted at rest</li>
-  <li>Agent sessions run in isolated containers with no shared state</li>
-  <li>Access controls and authentication protect all API endpoints</li>
-  <li>Regular security audits and monitoring are conducted</li>
-</ul>
-
-<h2>4. Data Sharing and Disclosure</h2>
-<p>We do not sell your personal information. We may share information in the following circumstances:</p>
-<ul>
-  <li><strong>Service Providers:</strong> With third-party vendors who assist us in operating the Service (e.g., cloud hosting, analytics, AI model providers).</li>
-  <li><strong>AI Model Providers:</strong> Code and prompts may be sent to AI model providers (such as Anthropic, OpenAI, Google) to execute agent sessions. We do not control these providers' data practices.</li>
-  <li><strong>Legal Requirements:</strong> When required by law, regulation, or legal process.</li>
-  <li><strong>Business Transfers:</strong> In connection with a merger, acquisition, or sale of assets.</li>
-  <li><strong>With Your Consent:</strong> When you have given us explicit permission.</li>
-</ul>
-
-<h2>5. Third-Party Integrations</h2>
-<p>The Service integrates with third-party platforms (e.g., GitHub, container registries). When you connect these integrations, the respective third-party privacy policies also apply. We encourage you to review those policies.</p>
-
-<h2>6. Data Retention</h2>
-<p>We retain your information for as long as your account is active or as needed to provide the Service. You may request deletion of your account and associated data at any time by contacting us. Some data may be retained as required by law or for legitimate business purposes.</p>
+<h2>6. Retention</h2>
+<p>We retain the data described in Section 3 for as long as your organization maintains an account, except where a shorter period is stated below.</p>
+<div class="legal-table">
+<table>
+  <thead>
+    <tr><th>Data</th><th>Retention</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Account and organization data (Sections 3.1–3.2)</td><td>For the life of the account, and up to 30 days after its deletion</td></tr>
+    <tr><td>Credentials for AI-assistant accounts (Section 3.3)</td><td>Until the user replaces them, deletes them, or the account is deleted</td></tr>
+    <tr><td>Session inputs, artifacts, and assets (Section 3.4)</td><td>For the life of the account, unless you delete them earlier</td></tr>
+    <tr><td>Session transcripts and captured provider traffic (Section 3.5)</td><td>For the life of the account, unless you delete them earlier</td></tr>
+    <tr><td>Usage and cost records (Section 3.6)</td><td>For the life of the account, and as required for billing and financial records</td></tr>
+    <tr><td>Payloads from connected systems (Section 3.7)</td><td>For the life of the account, unless you delete them earlier</td></tr>
+    <tr><td>Tool execution results</td><td>30 days</td></tr>
+    <tr><td>Technical and diagnostic data (Section 3.8)</td><td>Per the retention period of our error-monitoring provider</td></tr>
+  </tbody>
+</table>
+</div>
+<p>You may ask us to delete session records, transcripts, artifacts, or your account at any time using the contact details in Section 13, and we will do so except where we are required to retain data by law. On termination, our retention obligations are as set out in Section 14.3 of our <a href="/terms-of-service">Terms of Service</a>.</p>
 
 <h2>7. Your Rights</h2>
-<p>Depending on your jurisdiction, you may have the right to:</p>
-<ul>
-  <li>Access, correct, or delete your personal data</li>
-  <li>Object to or restrict certain processing activities</li>
-  <li>Export your data in a portable format</li>
-  <li>Withdraw consent where processing is based on consent</li>
-</ul>
-<p>To exercise these rights, contact us at <a href="mailto:privacy@aixle.com">privacy@aixle.com</a>.</p>
+<p>Depending on your location you may have rights to access, correct, delete, port, restrict, or object to the processing of your personal data, and to withdraw consent where processing relies on it.</p>
+<p><strong>If you are a developer using the Service through your employer's organization account:</strong> that organization is the controller of the data described in Section 3. Requests should ordinarily be directed to your employer. We will assist them and will not respond directly except where required by law or instructed by the controller. Contact us using the details in Section 13 if you cannot reach the controller.</p>
+<p>The customer organization's obligations to its personnel regarding notice, consultation, and legal basis — including any works council or employee-representative consultation required by Applicable Law — are addressed in Section 6 (Visibility of Individual Usage and Personnel Monitoring) of our <a href="/terms-of-service">Terms of Service</a>, which the customer organization agrees to as a condition of using the Service.</p>
+<p>Complaints may be lodged with your local supervisory authority.</p>
 
-<h2>8. Children's Privacy</h2>
-<p>The Service is not intended for individuals under the age of 16. We do not knowingly collect personal information from children. If we become aware that we have collected data from a child, we will take steps to delete it.</p>
+<h2>8. Reserved.</h2>
 
-<h2>9. International Data Transfers</h2>
-<p>Your information may be transferred to and processed in countries other than your country of residence. We ensure appropriate safeguards are in place for such transfers in compliance with applicable data protection laws.</p>
+<h2>9. International Transfers</h2>
+<p>We are a US-based company. If you access the Service from outside the United States, your personal data will be transferred to, stored, and processed in the United States, and may be transferred to other jurisdictions where our sub-processors operate (see Section 5).</p>
+<p>Where a transfer involves personal data originating in the European Economic Area, the United Kingdom, or Switzerland to a country not recognized as providing an adequate level of data protection, we will implement an appropriate transfer mechanism recognized under Applicable Law — such as the European Commission's Standard Contractual Clauses, the UK International Data Transfer Addendum, or a valid EU-U.S. Data Privacy Framework self-certification — before making such transfer.</p>
 
-<h2>10. Changes to This Policy</h2>
-<p>We may update this Privacy Policy from time to time. We will notify you of material changes by posting the updated policy on this page and updating the "Last updated" date. Your continued use of the Service after changes constitutes acceptance of the revised policy.</p>
+<h2>10. Security</h2>
+<p>We maintain technical and organizational measures designed to protect the data described in Section 3, including encryption of data in transit, isolation of each agent session in its own container, separation of compute by project and by user, encryption of connected credentials at rest, access controls limiting internal access to personal data on a need-to-know basis, and network security controls appropriate to a hosted service.</p>
+<p>Providing the Service inherently requires processing the content of your sessions — the instructions you give an agent, the source code it works on, and the traffic it exchanges with its AI provider (see Section 3.5). This is a necessary consequence of the Service's core function of running agents on your code on your behalf, not a byproduct of how we handle security. We do not currently redact or filter that content before it is stored. As a result, session records may contain information you or your personnel did not intend to retain, including credentials and information relating to third parties. We describe this here so that customers and their personnel can make an informed decision about what to submit to the Service. We may introduce redaction capabilities in the future; until then, this section reflects current practice.</p>
+<p>Our operational staff can access account, session, and session-record data through an internal administrative console where necessary to provide, secure, support, or troubleshoot the Service. Complete session transcripts and captured provider traffic (Section 3.5) are reachable in that way; they are not exposed in the customer-facing interface. Within your organization account, session records and usage — including the instruction submitted with each session — are visible to every member of that account, not only to administrators; the controls available to you are described in Section 6.6 of our <a href="/terms-of-service">Terms of Service</a>.</p>
+<p>No method of transmission or storage is completely secure, and we cannot guarantee the absolute security of your data.</p>
 
-<h2>11. Contact Us</h2>
-<p>If you have questions about this Privacy Policy, please contact us at:</p>
-<ul>
-  <li>Email: <a href="mailto:privacy@aixle.com">privacy@aixle.com</a></li>
-</ul>
+<h2>11. Children</h2>
+<p>The Service is not directed to individuals under the age of 18, and we do not knowingly collect personal data from children. If you believe a child has provided us with personal data, please contact us using the details in Section 13 and we will take steps to investigate and, where appropriate, delete it.</p>
+
+<h2>12. Changes</h2>
+<p>We may update this Privacy Policy from time to time. If we make material changes, we will provide reasonable notice (for example, by email to the account administrator or an in-app notice) before the changes take effect. The "Last updated" date above indicates when this Policy was last revised.</p>
+
+<h2>13. Contact</h2>
+<p>Questions about this Privacy Policy, or requests relating to your personal data, should be directed to Dualboot Partners, LLC, 5540 Centerview Dr., Ste. 204, #24754, Raleigh, NC 27606, or by email to <a href="mailto:privacy@aixle.com">privacy@aixle.com</a>.</p>

--- a/app/views/web/pages/terms_of_service.html.erb
+++ b/app/views/web/pages/terms_of_service.html.erb
@@ -1,89 +1,112 @@
 <% content_for(:title, "Terms of Service") %>
 
-<h1>Terms of Service</h1>
-<p class="legal-meta">Last updated: March 14, 2026</p>
+<h1>Aixle Flow Terms of Service</h1>
+<p class="legal-meta">Last updated: August 6, 2026 · Effective: August 6, 2026</p>
 
-<p>These Terms of Service ("Terms") govern your access to and use of the Aixle platform (the "Service") operated by Aixle ("we," "us," or "our"). By accessing or using the Service, you agree to be bound by these Terms.</p>
+<h2>1. Agreement and Parties</h2>
+<p>These Terms of Service ("Terms") govern access to and use of the hosted Aixle Flow service ("Service") provided by Dualboot Partners, LLC ("Dualboot," "we," "us"), 5540 Centerview Dr., Ste. 204, #24754, Raleigh, NC 27606.</p>
+<p>By creating an account, accessing the Service, or agreeing to these Terms on behalf of an organization, you accept them. If you accept on behalf of an organization, you represent that you are authorized to bind it, and "you" and "Customer" refer to that organization.</p>
 
-<h2>1. Acceptance of Terms</h2>
-<p>By creating an account or using the Service, you agree to these Terms and our <a href="/privacy-policy">Privacy Policy</a>. If you are using the Service on behalf of an organization, you represent that you have the authority to bind that organization to these Terms.</p>
+<h2>2. Relationship to the Open-Source License</h2>
+<p>The software underlying the Service is made available separately under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>. These Terms govern only our provision of the hosted Service.</p>
+<p>Nothing in these Terms limits any right granted to you under the Apache License 2.0 in respect of the source code, including the rights to use, modify, and redistribute it, and to operate your own deployment for any purpose. Our trademarks are not licensed by the Apache License or by these Terms; their use is governed by our trademark policy.</p>
+<p>If you obtained the software directly (for example, via a public repository) rather than through the hosted Service, your use of that software is governed solely by the Apache License and any accompanying NOTICE file, not by these Terms.</p>
 
-<h2>2. Description of Service</h2>
-<p>Aixle is an agentic software development lifecycle (SDLC) platform that enables AI agents to execute stages of the software development process. The Service includes agent session management, workflow orchestration, code execution in isolated containers, and related tools.</p>
+<h2>3. Accounts and Access</h2>
+<p><strong>3.1</strong> Access requires authentication through a supported identity provider (we support Google OpenID Connect) or, where we have enabled it for your organization, a password credential issued through your organization account. You are responsible for your users' credentials and for all activity under your organization's account.</p>
+<p><strong>3.2</strong> You control who you invite to your organization and what role each user holds. Roles are Employee and Admin, with different privileges.</p>
+<p><strong>3.3</strong> Your organization account is associated with an email domain. Where automatic acceptance is enabled for your organization, any person who authenticates with an email address in that domain joins your organization without individual approval, and thereby obtains the access described in Section 6.1. You are responsible for deciding whether that configuration is appropriate for your organization and for control of your email domain.</p>
+<p><strong>3.4</strong> You must notify us promptly of any suspected unauthorized access.</p>
+<p><strong>3.5</strong> Our operational staff may access your account, sessions, and session records where necessary to provide, secure, support, or troubleshoot the Service. Such access is subject to Section 10 (Confidentiality) and to our <a href="/privacy-policy">Privacy Policy</a>.</p>
 
-<h2>3. Account Registration</h2>
+<h2>4. Customer Data</h2>
+<p><strong>4.1 Definition.</strong> "Customer Data" means all data you or your users submit to, or that the Service generates, collects, or captures on your behalf in the course of providing the Service — including instructions and prompts submitted to agents; source code and repository contents retrieved from your connected source-control systems; files, artifacts, and assets created, modified, or uploaded during a session; agent session transcripts and container logs, including logs of traffic between an agent and the AI provider it is configured to use; board, task, workflow, and comment content; payloads received from your connected systems by webhook; usage and cost records; and user records. The categories are described in the <a href="/privacy-policy">Privacy Policy</a>.</p>
+<p><strong>4.2 Ownership.</strong> You retain all right, title, and interest in Customer Data. We claim no ownership.</p>
+<p><strong>4.3 Our license.</strong> You grant us a limited, non-exclusive license to host, store, process, and transmit Customer Data solely to provide, secure, and support the Service, and as instructed by you. We do not use Customer Data for any other purpose.</p>
+<p><strong>4.4 No use for model training.</strong> We do not use Customer Data — including instructions, source code, or session transcripts — to train machine-learning models, and we do not disclose it to third parties for that purpose.</p>
+<p><strong>4.5 Your responsibilities.</strong> You are responsible for ensuring you have the legal right and any necessary basis, notices, and permissions to submit Customer Data to the Service and to grant us access to the systems you connect, including the right to submit any source code or third-party material processed in a session, and including as set forth in Section 6 with respect to visibility of individual usage by your personnel.</p>
+<p><strong>4.6 Sensitive data.</strong> The Service is not designed for, and you must not knowingly submit, special-category personal data, payment-card data, regulated health data, or any other regulated data class. You acknowledge that instructions, repository contents, and session transcripts are captured as submitted by your users or as produced by an agent, and that we cannot filter them.</p>
+
+<h2>5. Agent Execution, Connected Credentials, and Customer Environments</h2>
+<p><strong>5.1 What the Service does.</strong> The Service launches AI coding agents in isolated containers that we operate, injects the context you configure (repositories, MCP servers, tools, skills, assets, and configuration), and runs those agents on your instructions. Depending on how you configure a session or workflow, an agent may operate autonomously, without step-by-step human confirmation of individual actions.</p>
+<p><strong>5.2 Credentials and systems you connect.</strong> You may connect source-control accounts and installations, issue trackers, messaging and infrastructure providers, MCP servers, and AI-assistant accounts. You determine what you connect and the scope of the permissions you grant, which may include write access to your repositories. We store connected credentials in encrypted form and use them only to operate sessions you or your users initiate. You are responsible for the scope of access you grant, for keeping it current, and for revoking it when it is no longer required.</p>
+<p><strong>5.3 AI-assistant accounts and provider terms.</strong> A session authenticates to the AI provider using credentials your user onboards through the Service — typically that user's own account with, or API key for, that provider. The provider's own terms and privacy practices govern the provider's processing of anything the agent sends to it. You and your users are responsible for holding the rights necessary to use those accounts in an automated, server-hosted environment and for compliance with any applicable provider limits or restrictions. We are not a party to that relationship, do not resell provider capacity, and make no representation about a provider's processing of that content.</p>
+<p><strong>5.4 Actions taken by agents.</strong> Within the permissions you grant, an agent may read, create, modify, and delete files in its container; execute commands and install dependencies; make outbound network requests; invoke MCP tools and connected integrations; and read from and write to your connected source-control systems. Actions taken using credentials you connected are treated as taken by you, whether or not a user directed the specific action. We do not review agent actions before they occur and do not control what an agent decides to do in response to your instructions.</p>
+<p><strong>5.5 Human review.</strong> You are responsible for reviewing agent output before merging, deploying, or otherwise relying on it. The Service provides approval gates in workflows and artifact review; whether you use them is your decision.</p>
+<p><strong>5.6 No warranty as to output.</strong> Output produced by an agent may be inaccurate, incomplete, insecure, non-functional, or substantially similar to third-party material. We make no representation or warranty that output is correct, original, fit for any purpose, or free of third-party rights, and you are responsible for any testing, security review, and license-compliance review before using it. This Section 5.6 is without limitation to Section 11.</p>
+<p><strong>5.7 Containers are ephemeral.</strong> A session's container and its filesystem are destroyed when the session ends. Only artifacts that the Service collects and stores persist. You are responsible for ensuring that work you wish to keep is committed to a connected repository or exported before a session ends.</p>
+
+<h2>6. Visibility of Individual Usage and Personnel Monitoring</h2>
+<p><strong>6.1 What the Service records and who can see it.</strong> The Service records, for each session, the user who initiated it, the instruction submitted, the agent and model used, token counts, computed cost, duration, and the artifacts produced. Any member of your organization account can view sessions and usage records for your organization, including sessions initiated by other users and the instructions submitted with them. Complete session transcripts and container logs are retained by the Service as described in the <a href="/privacy-policy">Privacy Policy</a>.</p>
+<p><strong>6.2 Customer's Sole Responsibility.</strong> The Service allows Customer to monitor, log, or review individual usage by Customer's personnel, including instructions and session content attributable to specific individuals. As between the parties, Customer is solely responsible for determining whether such monitoring is lawful in each jurisdiction in which Customer's personnel are located, and for obtaining and maintaining any legal basis, notice, consent, works council or employee-representative consultation, or regulatory approval that Applicable Law requires before enabling or using such functionality.</p>
+<p><strong>6.3 Representation and Warranty.</strong> Customer represents and warrants that, before enabling monitoring of any individual's usage of the Service, Customer has completed any notice, consultation, or approval process required by Applicable Law in the relevant jurisdiction, including any consultation with or approval from a works council, employee representative body, or similar entity where such consultation or approval is a legal prerequisite to implementing the monitoring. Customer will promptly notify Company if it becomes aware that this representation is or becomes inaccurate.</p>
+<p><strong>6.4 No Assumption of Customer's Obligations.</strong> Company provides the Service, including any monitoring functionality, on Customer's instructions as controller. Nothing in this Section or these Terms shifts to Company any obligation to provide notice to, or obtain consent, consultation, or approval from, Customer's personnel or their representatives, and Company makes no independent determination as to the legality of Customer's use of monitoring functionality in any jurisdiction.</p>
+<p><strong>6.5 Indemnification.</strong> Without limiting Section 13, Customer will indemnify, defend, and hold harmless Company from and against any claims, damages, liabilities, fines, regulatory actions, or expenses (including reasonable attorneys' fees) arising from or relating to Customer's failure to satisfy any notice, consent, consultation, or approval requirement described in this Section, including any claim brought by an employee, employee representative body, works council, or regulator arising from Customer's use of the Service in violation of Applicable Law.</p>
+<p><strong>6.6 Available Controls.</strong> Company makes available controls over organization membership, automatic acceptance of users by email domain, project membership, and which users may initiate sessions. Customer is responsible for configuring the Service consistent with the outcome of its own legal assessment under this Section.</p>
+
+<h2>7. Free Tier and Quotas</h2>
+<p>The Service is currently provided free of charge. Company may establish, modify, or remove usage limits, rate limits, compute and storage quotas, or session concurrency limits for the free tier at any time, with such changes taking effect upon posting or by other reasonable notice. We reserve the right to introduce paid tiers or modify the scope of the free offering in the future, with reasonable advance notice for material changes affecting existing Customers.</p>
+
+<h2>8. Acceptable Use</h2>
+<p>You must not, and must not permit your users to:</p>
 <ul>
-  <li>You must provide accurate and complete information when creating an account.</li>
-  <li>You are responsible for maintaining the security of your account credentials.</li>
-  <li>You must notify us immediately of any unauthorized access to your account.</li>
-  <li>You are responsible for all activities that occur under your account.</li>
+  <li>(a) access the Service other than through the interfaces we provide, or circumvent rate limits, quotas, or access controls;</li>
+  <li>(b) use the Service to store or transmit unlawful, infringing, or malicious content;</li>
+  <li>(c) attempt to gain unauthorized access to the Service, other customers' data, or our infrastructure;</li>
+  <li>(d) interfere with or disrupt the integrity or performance of the Service;</li>
+  <li>(e) resell, sublicense, or offer the hosted Service (as distinct from the underlying open-source software, which may be freely used, modified, and hosted by anyone under the Apache License 2.0) to third parties as a competing hosted or managed offering, or use our trademarks in connection with any such offering, except as separately agreed with us in writing;</li>
+  <li>(f) use the container execution capabilities of the Service to mine cryptocurrency, to run workloads unrelated to the operation of agents on your own projects, or otherwise to consume compute, storage, or network resources abusively;</li>
+  <li>(g) use a session, its network access, or a connected integration to scan, probe, attack, or send unsolicited communications to any system you are not authorized to access;</li>
+  <li>(h) attempt to escape, disable, or circumvent the isolation of a container, or to access the containers, namespaces, credentials, or data of another user or customer;</li>
+  <li>(i) submit source code or other content you do not have the right to submit, or use the Service in a manner that breaches the terms of an AI provider or other third-party system you connect to it.</li>
 </ul>
 
-<h2>4. Acceptable Use</h2>
-<p>You agree not to use the Service to:</p>
-<ul>
-  <li>Violate any applicable law, regulation, or third-party rights</li>
-  <li>Upload or transmit malicious code, viruses, or harmful content</li>
-  <li>Attempt to gain unauthorized access to the Service or its infrastructure</li>
-  <li>Interfere with the security or integrity of the Service</li>
-  <li>Use the Service for cryptocurrency mining or other resource-abusive activities</li>
-  <li>Reverse-engineer, decompile, or disassemble any part of the Service</li>
-  <li>Use the Service to build a competing product or service</li>
-  <li>Share your account credentials with unauthorized parties</li>
-</ul>
+<h2>9. Availability and Support</h2>
+<p>As of the Effective Date, we do not offer a service-level agreement or uptime commitment for the Service. Sessions and their containers are ephemeral, and we make no commitment to preserve the state of a running session; see Section 5.7.</p>
+<p>Community support for the open-source project (for example, GitHub issues and discussions) is provided on a best-efforts, volunteer basis and is not a contractual support commitment for the hosted Service.</p>
 
-<h2>5. Intellectual Property</h2>
+<h2>10. Confidentiality</h2>
+<p><strong>10.1</strong> Each party may receive from the other information that is designated confidential or that reasonably should be understood to be confidential given the nature of the information and the circumstances of disclosure ("Confidential Information"). Confidential Information does not include Customer Data, which is addressed exclusively in Section 4.</p>
+<p><strong>10.2</strong> Each party will use the other party's Confidential Information solely to exercise its rights and perform its obligations under these Terms, will protect it using at least the same degree of care it uses for its own confidential information of a similar nature (and in no event less than a reasonable degree of care), and will not disclose it to any third party except to employees, contractors, and advisors who need to know it and are bound by confidentiality obligations at least as protective as those in this Section.</p>
+<p><strong>10.3</strong> These obligations do not apply to information that: (a) is or becomes publicly available through no fault of the receiving party; (b) was rightfully known to the receiving party before disclosure; (c) is rightfully received from a third party without a duty of confidentiality; or (d) is independently developed without use of the disclosing party's Confidential Information.</p>
+<p><strong>10.4</strong> A party may disclose Confidential Information to the extent required by Applicable Law or legal process, provided it gives the other party prompt notice of the requirement (where legally permitted) so that the other party may seek a protective order or other appropriate remedy.</p>
 
-<h3>Your Content</h3>
-<p>You retain ownership of all code, files, and content you upload or create through the Service ("Your Content"). By using the Service, you grant us a limited license to process Your Content solely for the purpose of providing the Service to you.</p>
+<h2>11. Warranties and Disclaimers</h2>
+<p><strong>11.1</strong> THE SERVICE AND ANY ASSOCIATED SOFTWARE ARE PROVIDED "AS IS" AND "AS AVAILABLE," WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS, IMPLIED, OR STATUTORY, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT, AND ANY WARRANTIES ARISING OUT OF COURSE OF DEALING OR USAGE OF TRADE. WE DO NOT WARRANT THAT THE SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, OR SECURE.</p>
+<p><strong>11.2</strong> This Section 11 governs only the hosted Service. It does not apply to, limit, or expand the warranty disclaimer in Section 7 of the Apache License, Version 2.0, which applies independently and solely to the underlying source code licensed thereunder.</p>
+<p><strong>11.3</strong> Without limiting Section 11.1, we give no warranty as to output produced by an agent, or as to the actions an agent takes in your systems; see Sections 5.4 and 5.6.</p>
 
-<h3>Our Service</h3>
-<p>The Service, including its design, features, and underlying technology, is owned by Aixle and protected by intellectual property laws. These Terms do not grant you any rights to our trademarks, logos, or brand features.</p>
+<h2>12. Limitation of Liability</h2>
+<p><strong>12.1</strong> EXCEPT FOR DAMAGES RESULTING FROM A PARTY'S GROSS NEGLIGENCE, WILLFUL MISCONDUCT, OR FRAUD, OR AS OTHERWISE PROVIDED IN AN AGREEMENT BETWEEN DUALBOOT AND YOU, TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, DUALBOOT SHALL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS, REVENUE, DATA, OR GOODWILL, ARISING OUT OF OR RELATED TO THESE TERMS OR THE SERVICE, REGARDLESS OF THE THEORY OF LIABILITY, EVEN IF SUCH PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</p>
+<p><strong>12.2</strong> This Section 12 governs only liability arising from the hosted Service under these Terms. It does not apply to, limit, or expand the limitation of liability in Section 8 of the Apache License, Version 2.0, which applies independently and solely to claims relating to the licensed source code.</p>
 
-<h2>6. AI Agent Sessions</h2>
-<ul>
-  <li>AI agent sessions run in isolated containers for security and reproducibility.</li>
-  <li>You are responsible for reviewing and approving the output of AI agent sessions before deploying to production.</li>
-  <li>We do not guarantee the accuracy, completeness, or suitability of AI-generated code or outputs.</li>
-  <li>AI agent outputs may be subject to the terms and licenses of the underlying AI model providers.</li>
-</ul>
+<h2>13. Indemnification</h2>
+<p><strong>13.1 By Customer.</strong> Customer will indemnify, defend, and hold harmless Company from and against any claims, damages, liabilities, and expenses (including reasonable attorneys' fees) arising from: (a) Customer Data, including any claim that our receipt, storage, or processing of Customer Data in accordance with these Terms infringes, misappropriates, or violates the rights of any third party; (b) Customer's or its users' use of the Service in violation of these Terms or Applicable Law; (c) Customer's breach of Section 4 (Customer Data) or Section 5 (Agent Execution, Connected Credentials, and Customer Environments); (d) any action taken by an agent using credentials or access Customer or its users connected to the Service, and Customer's use of, deployment of, or reliance on output produced by an agent, including any claim that such output infringes or misappropriates the rights of any third party; or (e) any claim by an AI provider or other third party arising from the use of an account or credential Customer or its users connected to the Service.</p>
+<p><strong>13.2</strong> The indemnified party will provide prompt written notice of any claim, allow the indemnifying party to control the defense and settlement (provided any settlement imposing liability or obligations on the indemnified party requires its prior written consent, not to be unreasonably withheld), and provide reasonable cooperation at the indemnifying party's expense.</p>
 
-<h2>7. Third-Party Services</h2>
-<p>The Service may integrate with third-party platforms and services (e.g., GitHub, AI model providers, container registries). Your use of such integrations is subject to the respective third-party terms and policies. We are not responsible for third-party services.</p>
+<h2>14. Term and Termination</h2>
+<p><strong>14.1</strong> These Terms remain in effect for as long as you maintain an account or otherwise access the Service, unless earlier terminated as set out below.</p>
+<p><strong>14.2</strong> Either party may terminate these Terms for convenience upon notice.</p>
+<p><strong>14.3</strong> We may suspend or terminate your access to the Service at any time, with or without cause, where not prohibited by Applicable Law. Upon termination: (a) your right to access the Service ends; (b) Company has no obligation to retain, and may immediately and without notice delete, any data, content, or information associated with your account, including session records, transcripts, and artifacts. You are solely responsible for exporting or backing up any data you wish to retain prior to termination. Company disclaims all liability for any data unavailability or deletion following termination; and (c) termination of the hosted Service does not affect any rights previously granted to you under the Apache License 2.0 with respect to source code you have already obtained.</p>
+<p><strong>14.4</strong> Sections 4 (solely as to Customer Data not yet deleted or returned), 5, 6, 10–13, and 17–18 survive termination.</p>
 
-<h2>8. Fees and Payment</h2>
-<p>Certain features of the Service may require payment. Pricing details, billing terms, and payment conditions will be communicated through the Service or a separate agreement. We reserve the right to modify pricing with reasonable notice.</p>
+<h2>15. Suspension</h2>
+<p><strong>15.1</strong> We may suspend your (or any user's) access to all or part of the Service, without liability, if: (a) we reasonably believe your use presents a security risk to the Service or other customers; (b) your use violates Section 8 (Acceptable Use); (c) suspension is required to comply with Applicable Law or a governmental request; or (d) continued provision of the Service to you would, in our reasonable judgment, expose us to material legal or regulatory risk.</p>
+<p><strong>15.2</strong> Where reasonably practicable and not prohibited by Applicable Law, we will provide advance notice of a suspension and the reason for it. We will restore access promptly once the circumstance giving rise to the suspension is resolved.</p>
+<p><strong>15.3</strong> Suspension under this Section does not itself terminate these Terms, and Sections 4, 5, 6, and 10–19 continue to apply during any period of suspension.</p>
 
-<h2>9. Service Availability</h2>
-<p>We strive to maintain high availability but do not guarantee uninterrupted access to the Service. We may perform scheduled maintenance, updates, or experience downtime. We are not liable for any loss or damage resulting from service interruptions.</p>
+<h2>16. Changes to the Service or Terms</h2>
+<p>We may modify the Service or these Terms at any time. We will provide reasonable advance notice of material changes to these Terms (for example, by email or an in-app notice) before they take effect. Continued use of the Service after a change takes effect constitutes acceptance of the revised Terms; if you do not agree, you must stop using the Service and may terminate your account in accordance with Section 14.</p>
 
-<h2>10. Limitation of Liability</h2>
-<p>To the maximum extent permitted by applicable law:</p>
-<ul>
-  <li>The Service is provided "as is" and "as available" without warranties of any kind.</li>
-  <li>We disclaim all warranties, whether express, implied, or statutory, including warranties of merchantability, fitness for a particular purpose, and non-infringement.</li>
-  <li>We are not liable for any indirect, incidental, special, consequential, or punitive damages arising from your use of the Service.</li>
-  <li>Our total liability shall not exceed the amount you paid for the Service in the 12 months preceding the claim.</li>
-</ul>
+<h2>17. Governing Law and Disputes</h2>
+<p>These Terms are governed by the laws of North Carolina, without regard to its conflict-of-laws principles. Any dispute arising out of or relating to these Terms or the Service will be resolved exclusively in the state or federal courts located in North Carolina, and each party consents to the exclusive jurisdiction of such forum.</p>
 
-<h2>11. Indemnification</h2>
-<p>You agree to indemnify and hold harmless Aixle, its officers, directors, employees, and agents from any claims, damages, losses, or expenses (including legal fees) arising from your use of the Service, your violation of these Terms, or your violation of any third-party rights.</p>
+<h2>18. General</h2>
+<p><strong>18.1 Severability.</strong> If any provision of these Terms is found unenforceable, the remaining provisions remain in full force and effect.</p>
+<p><strong>18.2 Entire agreement.</strong> These Terms, together with the Apache License 2.0 (as applicable to the licensed source code) and our <a href="/privacy-policy">Privacy Policy</a>, constitute the entire agreement between you and us regarding the Service, and supersede any prior agreements regarding the Service.</p>
+<p><strong>18.3 No waiver.</strong> Failure to enforce any provision is not a waiver of that provision.</p>
+<p><strong>18.4 Assignment.</strong> You may not assign or transfer these Terms without our prior written consent; we may assign these Terms without restriction, including in connection with a merger, acquisition, or sale of assets.</p>
+<p><strong>18.5 Relationship of the parties.</strong> Nothing in these Terms creates a partnership, joint venture, agency, or employment relationship between the parties.</p>
 
-<h2>12. Termination</h2>
-<ul>
-  <li>You may terminate your account at any time by contacting us.</li>
-  <li>We may suspend or terminate your access if you violate these Terms or for any other reason with reasonable notice.</li>
-  <li>Upon termination, your right to use the Service ceases immediately. We may delete your data after a reasonable retention period.</li>
-</ul>
-
-<h2>13. Governing Law</h2>
-<p>These Terms are governed by and construed in accordance with applicable laws, without regard to conflict of law principles. Any disputes arising from these Terms or the Service shall be resolved through binding arbitration or in the courts of competent jurisdiction.</p>
-
-<h2>14. Changes to These Terms</h2>
-<p>We may update these Terms from time to time. We will notify you of material changes by posting the updated Terms on this page and updating the "Last updated" date. Your continued use of the Service after changes constitutes acceptance of the revised Terms.</p>
-
-<h2>15. Contact Us</h2>
-<p>If you have questions about these Terms of Service, please contact us at:</p>
-<ul>
-  <li>Email: <a href="mailto:legal@aixle.com">legal@aixle.com</a></li>
-</ul>
+<h2>19. Contact</h2>
+<p>Questions about these Terms should be directed to Dualboot Partners, LLC, 5540 Centerview Dr., Ste. 204, #24754, Raleigh, NC 27606, or by email to <a href="mailto:legal@aixle.com">legal@aixle.com</a>.</p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,11 @@ The active workflow: a research report in `research/` feeds a frozen-intent spec
 
 - **[strategy/](./strategy/)** — Business / open-source strategy documents
 
+## Legal
+
+- **[legal/TERMS_OF_SERVICE.md](./legal/TERMS_OF_SERVICE.md)** — Aixle Flow Terms of Service; published verbatim at `/terms-of-service` (`app/views/web/pages/terms_of_service.html.erb`)
+- **[legal/PRIVACY_POLICY.md](./legal/PRIVACY_POLICY.md)** — Aixle Flow Privacy Policy; published verbatim at `/privacy-policy` (`app/views/web/pages/privacy_policy.html.erb`)
+
 ## Related documentation elsewhere
 
 - `references/aixle-system-reference.md` — agent-facing platform reference (domain model, runtimes, container layout)

--- a/docs/legal/PRIVACY_POLICY.md
+++ b/docs/legal/PRIVACY_POLICY.md
@@ -1,0 +1,122 @@
+# Privacy Policy — Aixle Flow
+
+**Last updated:** August 6, 2026 · **Effective:** August 6, 2026
+
+## 1. Who We Are
+
+Aixle Flow ("the Service") is provided by Dualboot Partners, LLC ("Dualboot," "we," "us"), 5540 Centerview Dr., Ste. 204, #24754, Raleigh, NC 27606.
+
+## 2. Two Deployment Models
+
+The Service is available in two forms, and our role differs between them. This distinction determines most of what follows.
+
+**Hosted (we operate it):** We run the infrastructure. Our role under GDPR is Processor on behalf of the customer organization, which is the controller. We are an independent controller only for account and billing data. What we can see is everything described in Section 3. This policy applies in full.
+
+**Self-hosted (you operate it):** You run the infrastructure, on your own systems. We are neither controller nor processor — we do not receive, access, or store your data. This policy applies only to Sections 1, 9, and 10.
+
+The Service's source code is available under the Apache License 2.0. If you deploy it yourself, we have no visibility into your data and no ability to access it, and you are the controller for all data you process with it.
+
+## 3. What We Collect (Hosted Deployments)
+
+**3.1 Account and identity data.** Collected when a user signs in through a supported identity provider (we support Google OpenID Connect, and request only the user's email address and basic profile) or, where enabled for an organization, through a password credential issued in the product: email address, display name, profile picture URL, job title, identity-provider identifiers and access tokens, password hash where password sign-in is used, role within the organization, organization membership, invitation records, interface language preference, and timestamps of account creation, invitation, onboarding, and sign-in.
+
+**3.2 Organization and project configuration.** Organization name, identifier, email domain, branding, and settings; projects and project membership; repository names, URLs, descriptions, and default branches; connected integrations (source-control, issue-tracker, messaging, and infrastructure providers) and their credentials in encrypted form; MCP server definitions and their configuration values; agent, skill, tool, workflow, and board definitions; and resource quotas.
+
+**3.3 Credentials for your AI-assistant accounts.** When a user onboards an AI coding assistant (for example Claude Code, Codex, Cursor CLI, or Gemini CLI), the Service captures and stores, in encrypted form, the authentication artifacts that the assistant's own client produces — an OAuth token set or an API key for that user's account with the AI provider — together with metadata such as expiry, the model selected, and when the credential was last used. These credentials are injected into the container at the start of a session so the agent can authenticate to the provider, and are used for no other purpose.
+
+**3.4 Session inputs and repository content.** For each session: the instruction or prompt submitted; the session configuration and injected context; the source code and repository contents retrieved from your connected source-control systems into the session's container; files the agent creates or modifies; artifacts collected at the end of a session; files and assets your users upload; and the text of board tasks and comments, whether written by a person or by an agent.
+
+**3.5 Session transcripts and captured provider traffic.** The Service retains, as files:
+
+- A complete capture of the session terminal — everything submitted by the user and everything produced by the agent during the session, including source-code contents, command output, and file paths.
+- A log of the agent's network traffic to its AI provider, recorded by a proxy inside the container. For agents where this is enabled, it contains the complete body of each request and response — that is, the prompts and any file content sent with them, and the model's replies — together with the request and response headers.
+
+This content is stored as submitted or as produced. It is not redacted, filtered, or reduced. Because it is whatever a developer instructed an agent to do and whatever the agent did in response, it may contain information we cannot anticipate — including source code, credentials, your customers' data, and personal data relating to people who are not our users. We do not seek this data and cannot control what appears in it.
+
+Our Terms of Service require customers not to knowingly submit special-category personal data (as defined under Article 9 of the GDPR), payment-card data, or regulated health data to the Service. Because session content is captured as submitted or produced, we cannot verify or enforce compliance with that restriction at the point of submission, and this section describes what may occur in practice notwithstanding that contractual restriction.
+
+**3.6 Usage and cost records.** For each session: the agent and models used, input, output, and cached token counts, computed cost, event counts and the underlying usage events, session duration and state, the associated project and repositories, and the identity of the user who initiated it. These are collected from telemetry the agent emits and from the traffic described in Section 3.5.
+
+**3.7 Data received from your connected systems.** Where you connect a source-control, issue-tracker, or messaging provider, we receive and store the payloads those systems send us, which typically include commit, branch, and pull-request metadata and the names and email addresses of the people who authored them. Those people may not be users of the Service.
+
+**3.8 Technical and diagnostic data.** Server logs, IP addresses, request metadata, and error reports (including stack traces and request context). Retained for security, debugging, and abuse prevention.
+
+**3.9 What we do not collect.** We do not collect payment-card data. We do not use advertising or cross-site tracking technologies. We do not sell personal data. We do not request access to your email, calendar, files, or other data held by your identity provider.
+
+## 4. Why We Process It; Legal Basis
+
+| Purpose | Data | Legal basis (GDPR) |
+|---|---|---|
+| Providing the Service to the customer organization — running agent sessions and workflows on its instructions | Sections 3.1–3.7 | Performance of a contract (Art. 6(1)(b)); for individual developers, the customer's legitimate interest (Art. 6(1)(f)), subject to Section 6 of our Terms of Service |
+| Authentication and access control | Sections 3.1, 3.3 | Contract; legitimate interest (Art. 6(1)(f)) |
+| Cost and usage reporting to the customer organization | Sections 3.2, 3.6 | Performance of a contract (Art. 6(1)(b)) |
+| Security, abuse prevention, and debugging | Sections 3.1, 3.8 | Legitimate interest (Art. 6(1)(f)) |
+| Improving the Service | Aggregated and de-identified data only | Legitimate interest (Art. 6(1)(f)) |
+| Legal and regulatory compliance | As required | Legal obligation (Art. 6(1)(c)) |
+
+We do not rely on any legal basis for using session content or source code to train machine-learning models, because we do not do so. Section 4.4 of our Terms of Service commits us not to.
+
+## 5. Sub-processors and Third Parties
+
+Company may engage third-party service providers, contractors, and subprocessors ("Subprocessors") to perform functions and provide services to Company in connection with the Service.
+
+Company may add, remove, or replace Subprocessors from time to time as necessary to operate and improve the Service. Where Company processes personal data on behalf of a customer as a data processor under applicable data protection law, the specific terms governing Subprocessor engagement, notice, and objection rights are set forth in the applicable Data Processing Addendum, which shall control over this Section in the event of any conflict.
+
+Separately from our Subprocessors, the AI providers your users connect to the Service necessarily receive the content an agent sends to them, authenticated with the credentials described in Section 3.3. Those providers process that content under their own terms, as described in Section 5.3 of our Terms of Service. The providers the Service supports today are Anthropic, OpenAI, Cursor, and Google.
+
+## 6. Retention
+
+We retain the data described in Section 3 for as long as your organization maintains an account, except where a shorter period is stated below.
+
+| Data | Retention |
+|---|---|
+| Account and organization data (Sections 3.1–3.2) | For the life of the account, and up to 30 days after its deletion |
+| Credentials for AI-assistant accounts (Section 3.3) | Until the user replaces them, deletes them, or the account is deleted |
+| Session inputs, artifacts, and assets (Section 3.4) | For the life of the account, unless you delete them earlier |
+| Session transcripts and captured provider traffic (Section 3.5) | For the life of the account, unless you delete them earlier |
+| Usage and cost records (Section 3.6) | For the life of the account, and as required for billing and financial records |
+| Payloads from connected systems (Section 3.7) | For the life of the account, unless you delete them earlier |
+| Tool execution results | 30 days |
+| Technical and diagnostic data (Section 3.8) | Per the retention period of our error-monitoring provider |
+
+You may ask us to delete session records, transcripts, artifacts, or your account at any time using the contact details in Section 13, and we will do so except where we are required to retain data by law. On termination, our retention obligations are as set out in Section 14.3 of our Terms of Service.
+
+## 7. Your Rights
+
+Depending on your location you may have rights to access, correct, delete, port, restrict, or object to the processing of your personal data, and to withdraw consent where processing relies on it.
+
+**If you are a developer using the Service through your employer's organization account:** that organization is the controller of the data described in Section 3. Requests should ordinarily be directed to your employer. We will assist them and will not respond directly except where required by law or instructed by the controller. Contact us using the details in Section 13 if you cannot reach the controller.
+
+The customer organization's obligations to its personnel regarding notice, consultation, and legal basis — including any works council or employee-representative consultation required by Applicable Law — are addressed in Section 6 (Visibility of Individual Usage and Personnel Monitoring) of our Terms of Service, which the customer organization agrees to as a condition of using the Service.
+
+Complaints may be lodged with your local supervisory authority.
+
+## 8. Reserved.
+
+## 9. International Transfers
+
+We are a US-based company. If you access the Service from outside the United States, your personal data will be transferred to, stored, and processed in the United States, and may be transferred to other jurisdictions where our sub-processors operate (see Section 5).
+
+Where a transfer involves personal data originating in the European Economic Area, the United Kingdom, or Switzerland to a country not recognized as providing an adequate level of data protection, we will implement an appropriate transfer mechanism recognized under Applicable Law — such as the European Commission's Standard Contractual Clauses, the UK International Data Transfer Addendum, or a valid EU-U.S. Data Privacy Framework self-certification — before making such transfer.
+
+## 10. Security
+
+We maintain technical and organizational measures designed to protect the data described in Section 3, including encryption of data in transit, isolation of each agent session in its own container, separation of compute by project and by user, encryption of connected credentials at rest, access controls limiting internal access to personal data on a need-to-know basis, and network security controls appropriate to a hosted service.
+
+Providing the Service inherently requires processing the content of your sessions — the instructions you give an agent, the source code it works on, and the traffic it exchanges with its AI provider (see Section 3.5). This is a necessary consequence of the Service's core function of running agents on your code on your behalf, not a byproduct of how we handle security. We do not currently redact or filter that content before it is stored. As a result, session records may contain information you or your personnel did not intend to retain, including credentials and information relating to third parties. We describe this here so that customers and their personnel can make an informed decision about what to submit to the Service. We may introduce redaction capabilities in the future; until then, this section reflects current practice.
+
+Our operational staff can access account, session, and session-record data through an internal administrative console where necessary to provide, secure, support, or troubleshoot the Service. Complete session transcripts and captured provider traffic (Section 3.5) are reachable in that way; they are not exposed in the customer-facing interface. Within your organization account, session records and usage — including the instruction submitted with each session — are visible to every member of that account, not only to administrators; the controls available to you are described in Section 6.6 of our Terms of Service.
+
+No method of transmission or storage is completely secure, and we cannot guarantee the absolute security of your data.
+
+## 11. Children
+
+The Service is not directed to individuals under the age of 18, and we do not knowingly collect personal data from children. If you believe a child has provided us with personal data, please contact us using the details in Section 13 and we will take steps to investigate and, where appropriate, delete it.
+
+## 12. Changes
+
+We may update this Privacy Policy from time to time. If we make material changes, we will provide reasonable notice (for example, by email to the account administrator or an in-app notice) before the changes take effect. The "Last updated" date above indicates when this Policy was last revised.
+
+## 13. Contact
+
+Questions about this Privacy Policy, or requests relating to your personal data, should be directed to Dualboot Partners, LLC, 5540 Centerview Dr., Ste. 204, #24754, Raleigh, NC 27606, or by email to privacy@aixle.com.

--- a/docs/legal/TERMS_OF_SERVICE.md
+++ b/docs/legal/TERMS_OF_SERVICE.md
@@ -1,0 +1,169 @@
+# Aixle Flow Terms of Service
+
+**Last updated:** August 6, 2026 · **Effective:** August 6, 2026
+
+## 1. Agreement and Parties
+
+These Terms of Service ("Terms") govern access to and use of the hosted Aixle Flow service ("Service") provided by Dualboot Partners, LLC ("Dualboot," "we," "us"), 5540 Centerview Dr., Ste. 204, #24754, Raleigh, NC 27606.
+
+By creating an account, accessing the Service, or agreeing to these Terms on behalf of an organization, you accept them. If you accept on behalf of an organization, you represent that you are authorized to bind it, and "you" and "Customer" refer to that organization.
+
+## 2. Relationship to the Open-Source License
+
+The software underlying the Service is made available separately under the Apache License, Version 2.0. These Terms govern only our provision of the hosted Service.
+
+Nothing in these Terms limits any right granted to you under the Apache License 2.0 in respect of the source code, including the rights to use, modify, and redistribute it, and to operate your own deployment for any purpose. Our trademarks are not licensed by the Apache License or by these Terms; their use is governed by our trademark policy.
+
+If you obtained the software directly (for example, via a public repository) rather than through the hosted Service, your use of that software is governed solely by the Apache License and any accompanying NOTICE file, not by these Terms.
+
+## 3. Accounts and Access
+
+**3.1** Access requires authentication through a supported identity provider (we support Google OpenID Connect) or, where we have enabled it for your organization, a password credential issued through your organization account. You are responsible for your users' credentials and for all activity under your organization's account.
+
+**3.2** You control who you invite to your organization and what role each user holds. Roles are Employee and Admin, with different privileges.
+
+**3.3** Your organization account is associated with an email domain. Where automatic acceptance is enabled for your organization, any person who authenticates with an email address in that domain joins your organization without individual approval, and thereby obtains the access described in Section 6.1. You are responsible for deciding whether that configuration is appropriate for your organization and for control of your email domain.
+
+**3.4** You must notify us promptly of any suspected unauthorized access.
+
+**3.5** Our operational staff may access your account, sessions, and session records where necessary to provide, secure, support, or troubleshoot the Service. Such access is subject to Section 10 (Confidentiality) and to our Privacy Policy.
+
+## 4. Customer Data
+
+**4.1 Definition.** "Customer Data" means all data you or your users submit to, or that the Service generates, collects, or captures on your behalf in the course of providing the Service — including instructions and prompts submitted to agents; source code and repository contents retrieved from your connected source-control systems; files, artifacts, and assets created, modified, or uploaded during a session; agent session transcripts and container logs, including logs of traffic between an agent and the AI provider it is configured to use; board, task, workflow, and comment content; payloads received from your connected systems by webhook; usage and cost records; and user records. The categories are described in the Privacy Policy.
+
+**4.2 Ownership.** You retain all right, title, and interest in Customer Data. We claim no ownership.
+
+**4.3 Our license.** You grant us a limited, non-exclusive license to host, store, process, and transmit Customer Data solely to provide, secure, and support the Service, and as instructed by you. We do not use Customer Data for any other purpose.
+
+**4.4 No use for model training.** We do not use Customer Data — including instructions, source code, or session transcripts — to train machine-learning models, and we do not disclose it to third parties for that purpose.
+
+**4.5 Your responsibilities.** You are responsible for ensuring you have the legal right and any necessary basis, notices, and permissions to submit Customer Data to the Service and to grant us access to the systems you connect, including the right to submit any source code or third-party material processed in a session, and including as set forth in Section 6 with respect to visibility of individual usage by your personnel.
+
+**4.6 Sensitive data.** The Service is not designed for, and you must not knowingly submit, special-category personal data, payment-card data, regulated health data, or any other regulated data class. You acknowledge that instructions, repository contents, and session transcripts are captured as submitted by your users or as produced by an agent, and that we cannot filter them.
+
+## 5. Agent Execution, Connected Credentials, and Customer Environments
+
+**5.1 What the Service does.** The Service launches AI coding agents in isolated containers that we operate, injects the context you configure (repositories, MCP servers, tools, skills, assets, and configuration), and runs those agents on your instructions. Depending on how you configure a session or workflow, an agent may operate autonomously, without step-by-step human confirmation of individual actions.
+
+**5.2 Credentials and systems you connect.** You may connect source-control accounts and installations, issue trackers, messaging and infrastructure providers, MCP servers, and AI-assistant accounts. You determine what you connect and the scope of the permissions you grant, which may include write access to your repositories. We store connected credentials in encrypted form and use them only to operate sessions you or your users initiate. You are responsible for the scope of access you grant, for keeping it current, and for revoking it when it is no longer required.
+
+**5.3 AI-assistant accounts and provider terms.** A session authenticates to the AI provider using credentials your user onboards through the Service — typically that user's own account with, or API key for, that provider. The provider's own terms and privacy practices govern the provider's processing of anything the agent sends to it. You and your users are responsible for holding the rights necessary to use those accounts in an automated, server-hosted environment and for compliance with any applicable provider limits or restrictions. We are not a party to that relationship, do not resell provider capacity, and make no representation about a provider's processing of that content.
+
+**5.4 Actions taken by agents.** Within the permissions you grant, an agent may read, create, modify, and delete files in its container; execute commands and install dependencies; make outbound network requests; invoke MCP tools and connected integrations; and read from and write to your connected source-control systems. Actions taken using credentials you connected are treated as taken by you, whether or not a user directed the specific action. We do not review agent actions before they occur and do not control what an agent decides to do in response to your instructions.
+
+**5.5 Human review.** You are responsible for reviewing agent output before merging, deploying, or otherwise relying on it. The Service provides approval gates in workflows and artifact review; whether you use them is your decision.
+
+**5.6 No warranty as to output.** Output produced by an agent may be inaccurate, incomplete, insecure, non-functional, or substantially similar to third-party material. We make no representation or warranty that output is correct, original, fit for any purpose, or free of third-party rights, and you are responsible for any testing, security review, and license-compliance review before using it. This Section 5.6 is without limitation to Section 11.
+
+**5.7 Containers are ephemeral.** A session's container and its filesystem are destroyed when the session ends. Only artifacts that the Service collects and stores persist. You are responsible for ensuring that work you wish to keep is committed to a connected repository or exported before a session ends.
+
+## 6. Visibility of Individual Usage and Personnel Monitoring
+
+**6.1 What the Service records and who can see it.** The Service records, for each session, the user who initiated it, the instruction submitted, the agent and model used, token counts, computed cost, duration, and the artifacts produced. Any member of your organization account can view sessions and usage records for your organization, including sessions initiated by other users and the instructions submitted with them. Complete session transcripts and container logs are retained by the Service as described in the Privacy Policy.
+
+**6.2 Customer's Sole Responsibility.** The Service allows Customer to monitor, log, or review individual usage by Customer's personnel, including instructions and session content attributable to specific individuals. As between the parties, Customer is solely responsible for determining whether such monitoring is lawful in each jurisdiction in which Customer's personnel are located, and for obtaining and maintaining any legal basis, notice, consent, works council or employee-representative consultation, or regulatory approval that Applicable Law requires before enabling or using such functionality.
+
+**6.3 Representation and Warranty.** Customer represents and warrants that, before enabling monitoring of any individual's usage of the Service, Customer has completed any notice, consultation, or approval process required by Applicable Law in the relevant jurisdiction, including any consultation with or approval from a works council, employee representative body, or similar entity where such consultation or approval is a legal prerequisite to implementing the monitoring. Customer will promptly notify Company if it becomes aware that this representation is or becomes inaccurate.
+
+**6.4 No Assumption of Customer's Obligations.** Company provides the Service, including any monitoring functionality, on Customer's instructions as controller. Nothing in this Section or these Terms shifts to Company any obligation to provide notice to, or obtain consent, consultation, or approval from, Customer's personnel or their representatives, and Company makes no independent determination as to the legality of Customer's use of monitoring functionality in any jurisdiction.
+
+**6.5 Indemnification.** Without limiting Section 13, Customer will indemnify, defend, and hold harmless Company from and against any claims, damages, liabilities, fines, regulatory actions, or expenses (including reasonable attorneys' fees) arising from or relating to Customer's failure to satisfy any notice, consent, consultation, or approval requirement described in this Section, including any claim brought by an employee, employee representative body, works council, or regulator arising from Customer's use of the Service in violation of Applicable Law.
+
+**6.6 Available Controls.** Company makes available controls over organization membership, automatic acceptance of users by email domain, project membership, and which users may initiate sessions. Customer is responsible for configuring the Service consistent with the outcome of its own legal assessment under this Section.
+
+## 7. Free Tier and Quotas
+
+The Service is currently provided free of charge. Company may establish, modify, or remove usage limits, rate limits, compute and storage quotas, or session concurrency limits for the free tier at any time, with such changes taking effect upon posting or by other reasonable notice. We reserve the right to introduce paid tiers or modify the scope of the free offering in the future, with reasonable advance notice for material changes affecting existing Customers.
+
+## 8. Acceptable Use
+
+You must not, and must not permit your users to:
+
+**(a)** access the Service other than through the interfaces we provide, or circumvent rate limits, quotas, or access controls;
+**(b)** use the Service to store or transmit unlawful, infringing, or malicious content;
+**(c)** attempt to gain unauthorized access to the Service, other customers' data, or our infrastructure;
+**(d)** interfere with or disrupt the integrity or performance of the Service;
+**(e)** resell, sublicense, or offer the hosted Service (as distinct from the underlying open-source software, which may be freely used, modified, and hosted by anyone under the Apache License 2.0) to third parties as a competing hosted or managed offering, or use our trademarks in connection with any such offering, except as separately agreed with us in writing;
+**(f)** use the container execution capabilities of the Service to mine cryptocurrency, to run workloads unrelated to the operation of agents on your own projects, or otherwise to consume compute, storage, or network resources abusively;
+**(g)** use a session, its network access, or a connected integration to scan, probe, attack, or send unsolicited communications to any system you are not authorized to access;
+**(h)** attempt to escape, disable, or circumvent the isolation of a container, or to access the containers, namespaces, credentials, or data of another user or customer;
+**(i)** submit source code or other content you do not have the right to submit, or use the Service in a manner that breaches the terms of an AI provider or other third-party system you connect to it.
+
+## 9. Availability and Support
+
+As of the Effective Date, we do not offer a service-level agreement or uptime commitment for the Service. Sessions and their containers are ephemeral, and we make no commitment to preserve the state of a running session; see Section 5.7.
+
+Community support for the open-source project (for example, GitHub issues and discussions) is provided on a best-efforts, volunteer basis and is not a contractual support commitment for the hosted Service.
+
+## 10. Confidentiality
+
+**10.1** Each party may receive from the other information that is designated confidential or that reasonably should be understood to be confidential given the nature of the information and the circumstances of disclosure ("Confidential Information"). Confidential Information does not include Customer Data, which is addressed exclusively in Section 4.
+
+**10.2** Each party will use the other party's Confidential Information solely to exercise its rights and perform its obligations under these Terms, will protect it using at least the same degree of care it uses for its own confidential information of a similar nature (and in no event less than a reasonable degree of care), and will not disclose it to any third party except to employees, contractors, and advisors who need to know it and are bound by confidentiality obligations at least as protective as those in this Section.
+
+**10.3** These obligations do not apply to information that: (a) is or becomes publicly available through no fault of the receiving party; (b) was rightfully known to the receiving party before disclosure; (c) is rightfully received from a third party without a duty of confidentiality; or (d) is independently developed without use of the disclosing party's Confidential Information.
+
+**10.4** A party may disclose Confidential Information to the extent required by Applicable Law or legal process, provided it gives the other party prompt notice of the requirement (where legally permitted) so that the other party may seek a protective order or other appropriate remedy.
+
+## 11. Warranties and Disclaimers
+
+**11.1** THE SERVICE AND ANY ASSOCIATED SOFTWARE ARE PROVIDED "AS IS" AND "AS AVAILABLE," WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS, IMPLIED, OR STATUTORY, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT, AND ANY WARRANTIES ARISING OUT OF COURSE OF DEALING OR USAGE OF TRADE. WE DO NOT WARRANT THAT THE SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, OR SECURE.
+
+**11.2** This Section 11 governs only the hosted Service. It does not apply to, limit, or expand the warranty disclaimer in Section 7 of the Apache License, Version 2.0, which applies independently and solely to the underlying source code licensed thereunder.
+
+**11.3** Without limiting Section 11.1, we give no warranty as to output produced by an agent, or as to the actions an agent takes in your systems; see Sections 5.4 and 5.6.
+
+## 12. Limitation of Liability
+
+**12.1** EXCEPT FOR DAMAGES RESULTING FROM A PARTY'S GROSS NEGLIGENCE, WILLFUL MISCONDUCT, OR FRAUD, OR AS OTHERWISE PROVIDED IN AN AGREEMENT BETWEEN DUALBOOT AND YOU, TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, DUALBOOT SHALL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS, REVENUE, DATA, OR GOODWILL, ARISING OUT OF OR RELATED TO THESE TERMS OR THE SERVICE, REGARDLESS OF THE THEORY OF LIABILITY, EVEN IF SUCH PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+**12.2** This Section 12 governs only liability arising from the hosted Service under these Terms. It does not apply to, limit, or expand the limitation of liability in Section 8 of the Apache License, Version 2.0, which applies independently and solely to claims relating to the licensed source code.
+
+## 13. Indemnification
+
+**13.1 By Customer.** Customer will indemnify, defend, and hold harmless Company from and against any claims, damages, liabilities, and expenses (including reasonable attorneys' fees) arising from: (a) Customer Data, including any claim that our receipt, storage, or processing of Customer Data in accordance with these Terms infringes, misappropriates, or violates the rights of any third party; (b) Customer's or its users' use of the Service in violation of these Terms or Applicable Law; (c) Customer's breach of Section 4 (Customer Data) or Section 5 (Agent Execution, Connected Credentials, and Customer Environments); (d) any action taken by an agent using credentials or access Customer or its users connected to the Service, and Customer's use of, deployment of, or reliance on output produced by an agent, including any claim that such output infringes or misappropriates the rights of any third party; or (e) any claim by an AI provider or other third party arising from the use of an account or credential Customer or its users connected to the Service.
+
+**13.2** The indemnified party will provide prompt written notice of any claim, allow the indemnifying party to control the defense and settlement (provided any settlement imposing liability or obligations on the indemnified party requires its prior written consent, not to be unreasonably withheld), and provide reasonable cooperation at the indemnifying party's expense.
+
+## 14. Term and Termination
+
+**14.1** These Terms remain in effect for as long as you maintain an account or otherwise access the Service, unless earlier terminated as set out below.
+
+**14.2** Either party may terminate these Terms for convenience upon notice.
+
+**14.3** We may suspend or terminate your access to the Service at any time, with or without cause, where not prohibited by Applicable Law. Upon termination: (a) your right to access the Service ends; (b) Company has no obligation to retain, and may immediately and without notice delete, any data, content, or information associated with your account, including session records, transcripts, and artifacts. You are solely responsible for exporting or backing up any data you wish to retain prior to termination. Company disclaims all liability for any data unavailability or deletion following termination; and (c) termination of the hosted Service does not affect any rights previously granted to you under the Apache License 2.0 with respect to source code you have already obtained.
+
+**14.4** Sections 4 (solely as to Customer Data not yet deleted or returned), 5, 6, 10–13, and 17–18 survive termination.
+
+## 15. Suspension
+
+**15.1** We may suspend your (or any user's) access to all or part of the Service, without liability, if: (a) we reasonably believe your use presents a security risk to the Service or other customers; (b) your use violates Section 8 (Acceptable Use); (c) suspension is required to comply with Applicable Law or a governmental request; or (d) continued provision of the Service to you would, in our reasonable judgment, expose us to material legal or regulatory risk.
+
+**15.2** Where reasonably practicable and not prohibited by Applicable Law, we will provide advance notice of a suspension and the reason for it. We will restore access promptly once the circumstance giving rise to the suspension is resolved.
+
+**15.3** Suspension under this Section does not itself terminate these Terms, and Sections 4, 5, 6, and 10–19 continue to apply during any period of suspension.
+
+## 16. Changes to the Service or Terms
+
+We may modify the Service or these Terms at any time. We will provide reasonable advance notice of material changes to these Terms (for example, by email or an in-app notice) before they take effect. Continued use of the Service after a change takes effect constitutes acceptance of the revised Terms; if you do not agree, you must stop using the Service and may terminate your account in accordance with Section 14.
+
+## 17. Governing Law and Disputes
+
+These Terms are governed by the laws of North Carolina, without regard to its conflict-of-laws principles. Any dispute arising out of or relating to these Terms or the Service will be resolved exclusively in the state or federal courts located in North Carolina, and each party consents to the exclusive jurisdiction of such forum.
+
+## 18. General
+
+**18.1 Severability.** If any provision of these Terms is found unenforceable, the remaining provisions remain in full force and effect.
+
+**18.2 Entire agreement.** These Terms, together with the Apache License 2.0 (as applicable to the licensed source code) and our Privacy Policy, constitute the entire agreement between you and us regarding the Service, and supersede any prior agreements regarding the Service.
+
+**18.3 No waiver.** Failure to enforce any provision is not a waiver of that provision.
+
+**18.4 Assignment.** You may not assign or transfer these Terms without our prior written consent; we may assign these Terms without restriction, including in connection with a merger, acquisition, or sale of assets.
+
+**18.5 Relationship of the parties.** Nothing in these Terms creates a partnership, joint venture, agency, or employment relationship between the parties.
+
+## 19. Contact
+
+Questions about these Terms should be directed to Dualboot Partners, LLC, 5540 Centerview Dr., Ste. 204, #24754, Raleigh, NC 27606, or by email to legal@aixle.com.


### PR DESCRIPTION
## Summary

Adapts the counsel-approved **Aixle Insights** Terms of Service and Privacy Policy (both dated 2026-08-04) to **Aixle Flow**, and replaces the outdated text served on `/terms-of-service` and `/privacy-policy`.

Three commits:

1. `docs(legal)` — adds `docs/legal/TERMS_OF_SERVICE.md` and `docs/legal/PRIVACY_POLICY.md`.
2. `fix(legal)` — publishes them on the existing legal pages verbatim, so the pages and the source documents stay in sync.
3. `docs` — indexes both documents in `docs/index.md`.

### Why the published pages had to change

They served text dated **2026-03-14**, written before the Apache 2.0 decision, and two clauses contradicted the license we now ship:

- "Use the Service to build a competing product or service" — under Apache 2.0 anyone may take the source and run a competing hosted service; a term purporting to forbid it is both ineffective and inconsistent with the license.
- "Reverse-engineer, decompile, or disassemble any part of the Service" — Apache 2.0 grants the right to modify the source.

The pages also named "Aixle" as the operating entity rather than **Dualboot Partners, LLC**, and described none of the product's actual behaviour: no self-hosted deployment model, no agent execution, no AI-provider credentials, no session-transcript retention.

### What carried over from counsel's approved text, unchanged

ToS: the open-source relationship clause, confidentiality, warranties, limitation of liability, indemnification procedure, term and termination, suspension, changes, North Carolina governing law, general. Privacy Policy: the two-deployment-model framing, sub-processors, international transfers, children, changes, contact.

### What is new or rewritten, because Flow executes rather than observes

Insights observes AI-assistant usage. Flow launches autonomous agents in containers, clones customer repositories into them with credentials the customer connects, and produces code the customer ships. That drives:

- **ToS § 5 (new)** — Agent Execution, Connected Credentials, and Customer Environments: autonomous operation, scope of connected credentials (including repository write access), AI-provider accounts that belong to the individual developer, attribution of agent actions to the customer, human review of output, no warranty as to output, ephemeral containers.
- **ToS § 3** — real access model: Google OIDC or password sign-in, Employee/Admin roles, email-domain auto-join, operational-staff access for support.
- **ToS § 6** — counsel's personnel-monitoring clauses kept nearly verbatim, with a new § 6.1 stating what is actually visible: any member of an organization account can see other members' sessions and the instructions submitted with them. Insights' reference to "configurable monitoring granularity" was dropped because Flow has no such control.
- **ToS § 8** — acceptable use extended for container execution: resource abuse, attacks from a session, container-isolation escape, breach of a connected provider's terms.
- **ToS § 13.1(d)–(e)** — indemnity heads for agent actions, reliance on agent output, and AI-provider account claims.
- **Privacy § 3** — Flow's data categories, including two Insights has no counterpart for: § 3.3 credentials for users' own AI-assistant accounts, and § 3.5 session transcripts plus captured provider traffic.
- **Privacy §§ 4 and 6** — legal-basis and retention tables; both were left blank in the approved Insights document.
- **Privacy § 10** — security section written to current practice: session content is not redacted before storage, and staff access through the internal console is disclosed. No scrubbing or redaction representation is made, because the code does not support one today.

### Follow-ups this PR deliberately does not do

Three code items that the policy text is written around rather than over. Each would let us make a stronger statement; the first is worth fixing regardless of the policy:

1. `docker/base/logger/mitm_logger.py` records request headers verbatim, so the AI provider's `Authorization` / `x-api-key` value is written into a log file that is uploaded to object storage.
2. `config/initializers/sentry.rb` sets `send_default_pii = true` with no scrub rules and 100% trace/profile sampling.
3. `SessionLog` records have no expiry; tool results already expire at 30 days and provide a pattern to copy.

## Type of change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Breaking change

## How was this tested?

Content-only change to two ERB views and the legal layout — no Ruby logic touched. `test/integration/web/pages_controller_test.rb` covers rendering of both pages.

`make check_all` is green on this branch (rails-test, rubocop, brakeman, system-test, eslint, typescript, vite-build, fe-test), with backend coverage at 90.52% and frontend at 78.17%.

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] All my commits are signed off for the [DCO](../DCO) (`git commit -s`).
- [x] I have signed (or will sign) the [CLA](../CLA.md) when the bot prompts me — or my organization has executed the [Corporate CLA](../CLA-CORPORATE.md).
- [x] `make check_all` passes locally.
- [ ] I added/updated tests where it makes sense — existing render tests cover both pages; no new behaviour to test.
- [x] I updated documentation where it makes sense.
- [x] My commits use clear, descriptive messages.

---

**Review note:** the legal text should not be merged on engineering review alone. Nita Northington approved the Insights originals; the Flow-specific sections (ToS §§ 3, 5, 6.1, 8(f)–(i), 13.1(d)–(e); Privacy §§ 3.3, 3.5, 4, 6, 10) are new and unreviewed by counsel.

Authored by @Alexandra-Kozhukhar; commits carried over unchanged with their sign-offs.
