### PR TITLE
fix(oauth): prompt for consent so offline_access actually yields a refresh token

### DIFF
--- a/app/controllers/web/oauth_controller.rb
+++ b/app/controllers/web/oauth_controller.rb
@@ -70,6 +70,7 @@ class Web::OauthController < Web::ApplicationController
                               client_id: client.client_id,
                               redirect_uri: redirect_uri,
                               scope: client.scopes,
+                              prompt: consent_prompt_for(client.scopes),
                               state: state,
                               code_challenge: code_challenge,
                               code_challenge_method: "S256"),
@@ -181,11 +182,14 @@ class Web::OauthController < Web::ApplicationController
       oauth_client_id: result.oauth_client.id
     )
 
+    scope = result.scopes || result.oauth_client.scopes
+
     redirect_to authorize_url(result.oauth_client.authorization_endpoint,
                               response_type: "code",
                               client_id: result.oauth_client.client_id,
                               redirect_uri: redirect_uri,
-                              scope: result.scopes || result.oauth_client.scopes,
+                              scope: scope,
+                              prompt: consent_prompt_for(scope),
                               resource: result.resource, # RFC 8707 resource indicator
                               state: state,
                               code_challenge: code_challenge,
@@ -221,15 +225,34 @@ class Web::OauthController < Web::ApplicationController
   #
   # Our values win on conflict: the endpoint's baked-in `resource` names the
   # authorization server itself, while RFC 8707 requires the resource indicator to
-  # name the MCP server we want the token audience bound to. Blank values are
-  # dropped rather than sent as `scope=` (an empty scope is a request error at some
-  # authorization servers).
+  # name the MCP server we want the token audience bound to. Our blank values are
+  # dropped BEFORE the merge — both so nothing is sent as `scope=` (an empty scope
+  # is a request error at some authorization servers) and so a parameter we are not
+  # supplying leaves whatever the endpoint carries for it intact.
   def authorize_url(endpoint, params)
     uri = URI.parse(endpoint)
     existing = URI.decode_www_form(uri.query.to_s).to_h
-    merged = existing.merge(params.stringify_keys).reject { |_k, v| v.blank? }
-    uri.query = URI.encode_www_form(merged)
+    ours = params.stringify_keys.reject { |_k, v| v.blank? }
+    uri.query = URI.encode_www_form(existing.merge(ours))
     uri.to_s
+  end
+
+  # `prompt=consent` for an authorization request that asks for `offline_access`,
+  # and only then.
+  #
+  # OIDC Core §11 says an authorization server MUST ignore an `offline_access`
+  # request unless it obtains explicit consent, so asking for the scope without
+  # `prompt=consent` yields a token set with NO refresh_token — silently, since the
+  # granted `scope` simply comes back missing that one entry. Railway's OIDC
+  # provider behaves exactly this way (its docs require the pair): the MCP
+  # credential then had nothing to refresh from, `OauthCredential.refresh_due`
+  # skipped it for want of a refresh_token, and the connection reverted to a
+  # Connect button every time the 1-hour access token lapsed.
+  #
+  # Gated on the requested scope so a plain OAuth 2.1 server, which has no notion
+  # of `prompt`, is never sent an OIDC-only parameter.
+  def consent_prompt_for(scope)
+    "consent" if scope.to_s.split.include?("offline_access")
   end
 
   # Open-redirect guard: accept only same-site absolute paths ("/..."). Rejects

--- a/app/models/oauth_credential.rb
+++ b/app/models/oauth_credential.rb
@@ -31,8 +31,19 @@ class OauthCredential < ApplicationRecord
   scope :for_owner,      ->(owner) { where(owner: owner) }
   scope :for_mcp_server, ->(server) { where(mcp_server_id: server.id) }
   # Sweep scope (Phase 2 consumes this; index [:status, :expires_at] backs it).
+  #
+  # Deliberately NOT filtered to credentials that have a refresh token. One without
+  # one cannot be refreshed, but that is exactly the case worth surfacing: an
+  # authorization server may issue a token set with no refresh_token at all (Railway
+  # does when offline access is not consented to), and while such a row was excluded
+  # here it sat :active with a failure count of 0 until its access token quietly
+  # lapsed — the owner learned about it from a dead connection, never from us.
+  # Oauth::TokenService.fresh records the failure for these, so the ordinary
+  # escalation path (status:error + reconnect notification) applies. Once escalated
+  # they leave this scope via with_status(:active), so the sweep does not loop on
+  # them forever.
   scope :refresh_due, ->(within = 15.minutes) {
-    with_status(:active).where.not(encrypted_refresh_token: nil).where(expires_at: ..within.from_now)
+    with_status(:active).where(expires_at: ..within.from_now)
   }
 
   # --- Encrypted accessors (Encryptable) ---

--- a/app/services/oauth/token_service.rb
+++ b/app/services/oauth/token_service.rb
@@ -65,7 +65,17 @@ module Oauth
     # Ensure `cred` yields a fresh token; refresh under lock if near expiry.
     def fresh(cred)
       return cred.access_token unless cred.expired?(REFRESH_SKEW)
-      raise ReauthRequired.new(cred) unless cred.refreshable?
+
+      # Nothing to refresh from. Record it like any other refresh failure so the
+      # credential escalates to status:error (and notifies the owner to reconnect)
+      # through the ONE existing path, instead of sitting :active until its access
+      # token lapses. The sweep sees these rows too — OauthCredential.refresh_due is
+      # not filtered on refresh_token — so escalation does not wait for a session to
+      # happen to use the credential.
+      unless cred.refreshable?
+        cred.mark_refresh_error!("no refresh token — reconnect required")
+        raise ReauthRequired.new(cred)
+      end
 
       cred.with_lock do
         cred.reload

--- a/docs/design/oauth-implementation.md
+++ b/docs/design/oauth-implementation.md
@@ -124,12 +124,18 @@ never clobber a fresher token):
 - **On-demand** at use time (`TokenService.fresh`, under `with_lock`).
 - **Proactive** — `Workflows::OauthTokenRefreshWorkflow` (`*/5`, `overlap: skip`) runs
   `Activities::Oauth::RefreshExpiringTokensActivity`, sweeping `OauthCredential.refresh_due` (active +
-  refresh_token present + expiring within 15 min) via `TokenService.refresh_credential`.
+  expiring within 15 min) via `TokenService.refresh_credential`.
 
 **Failure escalation**: `mark_refresh_error!` increments `refresh_failure_count`; a single blip keeps the
 credential `active` (the sweep retries). After `MAX_REFRESH_FAILURES = 3` consecutive failures it escalates
 to `status:error` and — for `User` owners — sends `OauthMailer#refresh_failed` (reconnect link). Any success
 resets the counter.
+
+A credential with **no refresh_token at all** goes down the same path: `refresh_due` deliberately does not
+filter on the refresh token, and `TokenService.fresh` records the failure before raising `ReauthRequired`, so
+the row escalates to `status:error` and notifies instead of sitting `active` until its access token lapses.
+That is not a hypothetical — an authorization server may grant `offline_access` silently as "no", which is why
+`Web::OauthController` sends `prompt=consent` whenever it requests that scope (OIDC Core §11).
 
 ---
 

--- a/test/controllers/web/oauth_controller_test.rb
+++ b/test/controllers/web/oauth_controller_test.rb
@@ -326,6 +326,31 @@ class Web::OauthControllerTest < ActionDispatch::IntegrationTest
                  "exactly one RFC 8707 resource indicator, naming the MCP server and not the auth server"
   end
 
+  # Regression: Railway advertises `offline_access` in its protected-resource
+  # metadata, we requested it, and its OIDC provider dropped the scope and issued no
+  # refresh_token (OIDC Core §11 — offline_access is ignored without consent). The
+  # credential then had nothing to refresh from and the connection lapsed at the
+  # 1-hour access-token TTL.
+  test "mcp_connect prompts for consent when it requests offline_access (else no refresh_token is issued)" do
+    server = create(:mcp_server, :custom, scope: @project, auth_type: :oauth, url: "https://mcp.acme.test/v1")
+    stub_discovery!(client: build_dcr_client, scopes: "openid offline_access workspace:member")
+
+    get oauth_mcp_connect_path(mcp_server_id: server.id)
+
+    q = query_params(@response.headers["Location"])
+    assert_equal "openid offline_access workspace:member", q["scope"]
+    assert_equal "consent", q["prompt"]
+  end
+
+  test "mcp_connect omits prompt when offline_access is not requested (an OIDC-only parameter)" do
+    server = create(:mcp_server, :custom, scope: @project, auth_type: :oauth, url: "https://mcp.acme.test/v1")
+    stub_discovery!(client: build_dcr_client, scopes: "mcp:read")
+
+    get oauth_mcp_connect_path(mcp_server_id: server.id)
+
+    refute query_params(@response.headers["Location"]).key?("prompt")
+  end
+
   test "mcp_connect omits scope entirely when neither discovery nor the client advertises one" do
     server = create(:mcp_server, :custom, scope: @project, auth_type: :oauth, url: "https://mcp.acme.test/v1")
     stub_discovery!(client: build_dcr_client(scopes: nil), scopes: nil)

--- a/test/models/oauth_credential_test.rb
+++ b/test/models/oauth_credential_test.rb
@@ -300,7 +300,7 @@ class OauthCredentialTest < ActiveSupport::TestCase
     assert_not_includes OauthCredential.for_mcp_server(server), detached
   end
 
-  test "refresh_due returns only active, refreshable credentials expiring inside the window" do
+  test "refresh_due returns active credentials expiring inside the window, refreshable or not" do
     due = build_credential(provider: "due", status: :active, refresh_token: "rt", expires_at: 5.minutes.from_now)
     due.save!
     far = build_credential(provider: "far", status: :active, refresh_token: "rt", expires_at: 1.hour.from_now)
@@ -317,7 +317,10 @@ class OauthCredentialTest < ActiveSupport::TestCase
     result = OauthCredential.refresh_due
     assert_includes result, due
     assert_not_includes result, far
-    assert_not_includes result, no_refresh
+    # A credential with no refresh token is swept precisely so the sweep can escalate
+    # it (Oauth::TokenService.fresh records the failure); excluding it left the row
+    # :active until its access token silently lapsed.
+    assert_includes result, no_refresh
     assert_not_includes result, not_active
     assert_not_includes result, null_expiry
   end

--- a/test/services/oauth/token_service_test.rb
+++ b/test/services/oauth/token_service_test.rb
@@ -98,12 +98,29 @@ module Oauth
     # == fresh: reauth-required paths ==
 
     test "raises ReauthRequired without a network call when the credential is unrefreshable" do
-      build_credential(owner: @user, access_token: "old-token",
-                       refresh_token: nil, expires_at: 1.minute.ago)
+      cred = build_credential(owner: @user, access_token: "old-token",
+                              refresh_token: nil, expires_at: 1.minute.ago)
 
       assert_raises(Oauth::ReauthRequired) do
         Oauth::TokenService.access_token_for(owner: @user, provider: "sentry", user: @user)
       end
+      assert_not_requested :post, TOKEN_ENDPOINT
+      # Recorded like any other refresh failure: an authorization server that issues no
+      # refresh_token (Railway, without consented offline access) otherwise leaves the
+      # credential :active with a 0 failure count until its access token lapses.
+      assert_equal 1, cred.reload.refresh_failure_count
+      assert cred.refresh_error.present?
+    end
+
+    test "escalates an unrefreshable credential to error after MAX_REFRESH_FAILURES sweeps" do
+      cred = build_credential(owner: @user, access_token: "old-token",
+                              refresh_token: nil, expires_at: 1.minute.ago)
+
+      OauthCredential::MAX_REFRESH_FAILURES.times do
+        assert_equal :error, Oauth::TokenService.refresh_credential(cred)
+      end
+
+      assert cred.reload.error?, "the sweep must surface a Reconnect state, not wait for a dead connection"
       assert_not_requested :post, TOKEN_ENDPOINT
     end
 


### PR DESCRIPTION
## Why

The Railway MCP connection dropped back to a **Connect** button roughly once an hour. The credential in dev told the whole story:

```
expires_at   = 2026-08-06T11:45:23Z
last_refresh = 2026-08-06T10:45:23Z   → 1h access-token TTL
refresh_token = absent
scopes = openid profile email workspace:member    ← offline_access missing
```

The `oauth_clients` row records what we *asked* for — `openid profile email offline_access workspace:member` — so Railway granted that scope as "no", silently, and returned a token set with no `refresh_token`.

That is spec-sanctioned: OIDC Core §11 lets an authorization server ignore an `offline_access` request unless it obtains explicit consent, and [Railway's docs](https://docs.railway.com/integrations/oauth/login-and-tokens) require `offline_access` **and** `prompt=consent` together. We sent the scope and no `prompt`.

The second half of the bug is why nobody was told: `OauthCredential.refresh_due` filtered on `encrypted_refresh_token IS NOT NULL`, so the sweep never looked at a credential that had no refresh token. It sat `active` with `refresh_failure_count = 0` until the access token lapsed.

## What changed

- `Web::OauthController#consent_prompt_for` sends `prompt=consent`, gated on the requested scope actually containing `offline_access`, so a plain OAuth 2.1 server never receives an OIDC-only parameter. Wired into both `#authorize` and `#mcp_connect`.
- `#authorize_url` drops our blank values **before** the merge instead of after, so a parameter we are not supplying leaves whatever the endpoint already carries for it intact. Railway ships its own query string on `authorization_endpoint`; a nil `prompt` would otherwise have erased it.
- `refresh_due` no longer filters on the refresh token, and `TokenService.fresh` records the failure for an unrefreshable credential. Such a row now escalates to `status:error` and notifies through the existing `mark_refresh_error!` / `OauthMailer#refresh_failed` path, then leaves the scope via `with_status(:active)` so the sweep does not loop on it.
- `docs/design/oauth-implementation.md` §6 updated to match.

## Note for whoever connects Railway next

An existing credential with no refresh token is not repaired by this — it has nothing to refresh from. One manual **Connect** is needed; the consent screen now appears, the response carries a `refresh_token` (Railway rotates it, 1-year TTL), and the `*/5` sweep keeps it alive from there.

## Tests

Four new cases (consent sent with `offline_access`; `prompt` absent without it; an unrefreshable credential records a failure; it escalates to `error` after `MAX_REFRESH_FAILURES` sweeps) plus the widened `refresh_due` assertion. `make check_all` green: rails-test, system-test, rubocop, brakeman, eslint, typescript, vitest, vite-build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
