### PR TITLE
feat(catalog): ship the curated connector and skill seed in the repo

### DIFF
--- a/app/services/catalog/featured_seed.rb
+++ b/app/services/catalog/featured_seed.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+module Catalog
+  # The committed slice of the two mirrored catalogs.
+  #
+  # WHY THIS EXISTS: both mirrors are filled by sweeps over someone else's registry
+  # (MCP::ConnectorCatalogSync, Skills::CatalogSync). A deployment that has never run
+  # one — a self-hosted install on its first boot above all — opens the Connectors and
+  # Skills pages on an empty grid and stays there until a Temporal worker is up and a
+  # weekly schedule fires. Worse for skills: descriptions are backfilled from GitHub,
+  # which without a read token is 60 requests per hour for the whole deployment, so a
+  # cold catalog stays a wall of untitled cards for weeks.
+  #
+  # So the curated seed both catalogs already rank first (Connector::FEATURED,
+  # CatalogSkill::FEATURED) is committed to the repo as JSON and loaded at boot. No
+  # network, no token, no worker, no registry load.
+  #
+  # This is a DISPLAY seed, not an install path: MCP::ConnectorInstaller re-fetches the
+  # manifest from the registry at install time and falls back to the mirrored copy only
+  # when the registry is unreachable.
+  class FeaturedSeed
+    DIR = Rails.root.join("db/seeds/catalog")
+
+    # Columns that travel. Deliberately explicit rather than "every attribute minus a
+    # few": the file is persisted data, so a new column must be an intentional addition
+    # to it instead of something a dump quietly starts emitting.
+    #
+    # What is absent matters more than what is present:
+    #   install_count       — demand on THIS platform. A fresh deployment has none, and
+    #                         shipping someone else's would corrupt the ranking's only
+    #                         first-party signal.
+    #   featured            — derived from the constants at load time, so the curated
+    #                         list stays the single source of truth and a stale file
+    #                         cannot leave `featured: true` on a dropped entry.
+    #   registry_updated_at — see #connector_rows. Load-bearing NULL.
+    #   audit, audit_risk   — a security verdict frozen in git would keep asserting
+    #                         "safe" months after the providers changed their minds.
+    #                         Absent reads as "nobody audited this", which is honest and
+    #                         is a state CatalogSkill already distinguishes from safe.
+    CONNECTOR_COLUMNS = %i[
+      name title description repository_url version status is_latest
+      bulk_publisher normalizer_version manifest
+    ].freeze
+
+    SKILL_COLUMNS = %i[
+      registry_id source slug title description installs bulk_publisher registry_synced_at
+    ].freeze
+
+    Result = Struct.new(:connectors, :skills, keyword_init: true) do
+      def to_s = "connectors=#{connectors} skills=#{skills}"
+    end
+
+    def self.load!(dir: DIR) = new(dir: dir).load!
+    def self.dump!(dir: DIR) = new(dir: dir).dump!
+
+    def initialize(dir: DIR)
+      @dir = Pathname.new(dir)
+    end
+
+    # Inserts what is missing and updates nothing. Idempotent by construction, and safe
+    # to run on every boot: a row a sweep has already written is fresher than anything
+    # committed to the repo and must never be downgraded to it.
+    def load!
+      result = Result.new(
+        connectors: insert(Connector, :name, connector_rows),
+        skills: insert(CatalogSkill, :registry_id, skill_rows)
+      )
+      Rails.logger.info("[Catalog::FeaturedSeed] Loaded #{result}")
+      result
+    end
+
+    # Regenerates the committed files from this database's mirror. A maintenance task,
+    # run by hand after editing either FEATURED list — see lib/tasks/catalog.rake.
+    def dump!
+      FileUtils.mkdir_p(@dir)
+      connectors = dump_rows(Connector.where(name: Connector::FEATURED).order(:name), CONNECTOR_COLUMNS)
+      skills = dump_rows(CatalogSkill.where(registry_id: CatalogSkill::FEATURED).order(:registry_id), SKILL_COLUMNS)
+
+      write(connectors_path, connectors)
+      write(skills_path, skills)
+      Result.new(connectors: connectors.size, skills: skills.size)
+    end
+
+    def connectors_path = @dir.join("connectors.json")
+    def skills_path = @dir.join("skills.json")
+
+    private
+
+    def connector_rows
+      now = Time.current
+
+      read(connectors_path).filter_map do |entry|
+        next unless Connector::FEATURED.include?(entry["name"])
+
+        row(entry, CONNECTOR_COLUMNS).merge(
+          featured: true,
+          # NOT the dumped value, and this is the whole reason the column is listed
+          # here: ConnectorCatalogSync#watermark resumes from MAX(registry_updated_at).
+          # A seed claiming a recent registry timestamp would make the very first sync
+          # ask the registry for "everything changed since then", mirror nothing, and
+          # freeze the catalog at these few dozen rows permanently. NULL states what is
+          # actually true — a snapshot committed to a repo knows nothing about the
+          # registry's current state — and produces a full walk.
+          registry_updated_at: nil,
+          created_at: now,
+          updated_at: now
+        )
+      end
+    end
+
+    def skill_rows
+      now = Time.current
+
+      read(skills_path).filter_map do |entry|
+        next unless CatalogSkill::FEATURED.include?(entry["registry_id"])
+
+        # `registry_synced_at` IS kept, unlike its connector counterpart. It is not a
+        # watermark — the skills sweep has none — and Skills::CatalogSync destroys rows
+        # that carry NULL there, reading it as "no sweep has ever seen this upstream".
+        # A dump was taken from a swept mirror, so the timestamp is true, and it keeps
+        # the seed out of the phantom-dropper.
+        row(entry, SKILL_COLUMNS).merge(featured: true, created_at: now, updated_at: now)
+      end
+    end
+
+    def row(entry, columns) = columns.index_with { |column| entry[column.to_s] }
+
+    def dump_rows(scope, columns)
+      scope.map { |record| columns.index_with { |column| dump_value(record[column]) } }
+    end
+
+    # Times go out as ISO8601 rather than through Time#to_s, so the file says what it
+    # means in every locale and reads back the same way it was written.
+    def dump_value(value) = value.is_a?(Time) ? value.utc.iso8601 : value
+
+    def insert(model, unique_by, rows)
+      return 0 if rows.empty?
+
+      model.insert_all(rows, unique_by: unique_by, record_timestamps: false).length
+    end
+
+    # A missing or unreadable seed degrades the first impression; it must never stop a
+    # deployment from booting, so both are logged and treated as "no seed".
+    def read(path)
+      unless path.exist?
+        Rails.logger.warn("[Catalog::FeaturedSeed] Missing seed file #{path}")
+        return []
+      end
+
+      JSON.parse(path.read).fetch("entries", [])
+    rescue JSON::ParserError => e
+      Rails.logger.error("[Catalog::FeaturedSeed] Unreadable seed file #{path}: #{e.message}")
+      []
+    end
+
+    def write(path, entries)
+      payload = { "generated_at" => Time.current.utc.iso8601, "count" => entries.size, "entries" => entries }
+      path.write("#{JSON.pretty_generate(payload)}\n")
+    end
+  end
+end

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -29,5 +29,8 @@ bundle check || bundle install
 corepack install
 yarn install
 bundle exec rails db:prepare
+# Curated MCP connectors and skills, so the catalogs are browsable before the first
+# sweep ever runs. Idempotent, inserts only what is missing — see Catalog::FeaturedSeed.
+bundle exec rails catalog:featured:load
 
 exec "$@"

--- a/db/seeds/catalog/connectors.json
+++ b/db/seeds/catalog/connectors.json
@@ -1,0 +1,5383 @@
+{
+  "generated_at": "2026-08-06T18:28:22Z",
+  "count": 64,
+  "entries": [
+    {
+      "name": "app.linear/linear",
+      "title": null,
+      "description": "MCP server for Linear project management and issue tracking",
+      "repository_url": null,
+      "version": "1.0.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "app.linear/linear",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.linear.app/mcp",
+            "url": "https://mcp.linear.app/mcp",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:sse:https://mcp.linear.app/sse",
+            "url": "https://mcp.linear.app/sse",
+            "kind": "remote",
+            "inputs": [],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          }
+        ],
+        "version": "1.0.0",
+        "is_latest": true,
+        "updated_at": "2025-09-18T15:51:15.598862Z",
+        "description": "MCP server for Linear project management and issue tracking",
+        "published_at": "2025-09-18T15:51:15.598862Z",
+        "repository_url": null,
+        "schema_version": "2025-09-29",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "co.huggingface/hf-mcp-server",
+      "title": "Hugging Face",
+      "description": "Connect to Hugging Face Hub and thousands of Gradio AI Applications",
+      "repository_url": null,
+      "version": "0.2.33",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "co.huggingface/hf-mcp-server",
+        "title": "Hugging Face",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://huggingface.co/mcp?login",
+            "url": "https://huggingface.co/mcp?login",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://huggingface.co/mcp",
+            "url": "https://huggingface.co/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authorization",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Hugging Face API token for authentication",
+                "placeholder": "Bearer hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://huggingface.co/mcp",
+            "url": "https://huggingface.co/mcp",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "0.2.33",
+        "is_latest": true,
+        "updated_at": "2025-10-22T10:55:52.98995Z",
+        "description": "Connect to Hugging Face Hub and thousands of Gradio AI Applications",
+        "published_at": "2025-10-22T10:55:52.98995Z",
+        "repository_url": null,
+        "schema_version": "2025-10-17",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.airtable/mcp",
+      "title": null,
+      "description": "Official Airtable MCP server — database and operations layer for agents.",
+      "repository_url": null,
+      "version": "0.1.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.airtable/mcp",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.airtable.com/mcp",
+            "url": "https://mcp.airtable.com/mcp",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "0.1.0",
+        "is_latest": true,
+        "updated_at": "2026-05-08T19:18:18.585221Z",
+        "description": "Official Airtable MCP server — database and operations layer for agents.",
+        "published_at": "2026-05-08T19:18:18.585221Z",
+        "repository_url": null,
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.atlassian/atlassian-mcp-server",
+      "title": "Atlassian Rovo MCP Server",
+      "description": "Connect to Atlassian Jira, Confluence, and Compass to search, create, and manage your work.",
+      "repository_url": "https://github.com/atlassian/atlassian-mcp-server",
+      "version": "1.1.3",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.atlassian/atlassian-mcp-server",
+        "title": "Atlassian Rovo MCP Server",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.atlassian.com/v1/mcp",
+            "url": "https://mcp.atlassian.com/v1/mcp",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://mcp.atlassian.com/v1/mcp/authv2",
+            "url": "https://mcp.atlassian.com/v1/mcp/authv2",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "1.1.3",
+        "is_latest": true,
+        "updated_at": "2026-07-08T00:01:55.705871Z",
+        "description": "Connect to Atlassian Jira, Confluence, and Compass to search, create, and manage your work.",
+        "published_at": "2026-07-08T00:01:55.705871Z",
+        "repository_url": "https://github.com/atlassian/atlassian-mcp-server",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.auth0/mcp",
+      "title": "Auth0 MCP Server",
+      "description": "Auth0 MCP Server: Manage Auth0 applications, APIs, actions, logs, and forms using natural language",
+      "repository_url": "https://github.com/auth0/auth0-mcp-server",
+      "version": "0.1.0-beta.10",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.auth0/mcp",
+        "title": "Auth0 MCP Server",
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:@auth0/auth0-mcp-server",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "npx",
+            "version": "0.1.0-beta.10",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "@auth0/auth0-mcp-server",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "run"
+              }
+            ],
+            "runtime_arguments": [
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "-y"
+              }
+            ],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.1.0-beta.10",
+        "is_latest": true,
+        "updated_at": "2026-03-26T15:32:18.592492Z",
+        "description": "Auth0 MCP Server: Manage Auth0 applications, APIs, actions, logs, and forms using natural language",
+        "published_at": "2026-03-26T15:32:18.592492Z",
+        "repository_url": "https://github.com/auth0/auth0-mcp-server",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.browser-use/browser-use",
+      "title": null,
+      "description": "Control a real Chrome browser to complete any task: fill forms, extract data, book flights.",
+      "repository_url": "https://github.com/browser-use/browser-use",
+      "version": "0.13.5",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.browser-use/browser-use",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:pypi:browser-use",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "uvx",
+            "version": "0.13.5",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "browser-use",
+            "file_sha256": null,
+            "registry_type": "pypi",
+            "version_pinned": true,
+            "package_arguments": [
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "--cli-mcp"
+              }
+            ],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.13.5",
+        "is_latest": true,
+        "updated_at": "2026-07-17T01:17:22.802703Z",
+        "description": "Control a real Chrome browser to complete any task: fill forms, extract data, book flights.",
+        "published_at": "2026-07-17T01:17:22.802703Z",
+        "repository_url": "https://github.com/browser-use/browser-use",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.cloudflare.mcp/mcp",
+      "title": null,
+      "description": "Cloudflare MCP servers",
+      "repository_url": "https://github.com/cloudflare/mcp-server-cloudflare",
+      "version": "1.0.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.cloudflare.mcp/mcp",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://docs.mcp.cloudflare.com/mcp",
+            "url": "https://docs.mcp.cloudflare.com/mcp",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://observability.mcp.cloudflare.com/mcp",
+            "url": "https://observability.mcp.cloudflare.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://bindings.mcp.cloudflare.com/mcp",
+            "url": "https://bindings.mcp.cloudflare.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://builds.mcp.cloudflare.com/mcp",
+            "url": "https://builds.mcp.cloudflare.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://radar.mcp.cloudflare.com/mcp",
+            "url": "https://radar.mcp.cloudflare.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://containers.mcp.cloudflare.com/mcp",
+            "url": "https://containers.mcp.cloudflare.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://browser.mcp.cloudflare.com/mcp",
+            "url": "https://browser.mcp.cloudflare.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://logs.mcp.cloudflare.com/mcp",
+            "url": "https://logs.mcp.cloudflare.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://ai-gateway.mcp.cloudflare.com/mcp",
+            "url": "https://ai-gateway.mcp.cloudflare.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://autorag.mcp.cloudflare.com/mcp",
+            "url": "https://autorag.mcp.cloudflare.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://auditlogs.mcp.cloudflare.com/mcp",
+            "url": "https://auditlogs.mcp.cloudflare.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://dns-analytics.mcp.cloudflare.com/mcp",
+            "url": "https://dns-analytics.mcp.cloudflare.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://dex.mcp.cloudflare.com/mcp",
+            "url": "https://dex.mcp.cloudflare.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://casb.mcp.cloudflare.com/mcp",
+            "url": "https://casb.mcp.cloudflare.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:http:https://graphql.mcp.cloudflare.com/mcp",
+            "url": "https://graphql.mcp.cloudflare.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:sse:https://docs.mcp.cloudflare.com/sse",
+            "url": "https://docs.mcp.cloudflare.com/sse",
+            "kind": "remote",
+            "inputs": [],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          },
+          {
+            "id": "remote:sse:https://observability.mcp.cloudflare.com/sse",
+            "url": "https://observability.mcp.cloudflare.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          },
+          {
+            "id": "remote:sse:https://bindings.mcp.cloudflare.com/sse",
+            "url": "https://bindings.mcp.cloudflare.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          },
+          {
+            "id": "remote:sse:https://builds.mcp.cloudflare.com/sse",
+            "url": "https://builds.mcp.cloudflare.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          },
+          {
+            "id": "remote:sse:https://radar.mcp.cloudflare.com/sse",
+            "url": "https://radar.mcp.cloudflare.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          },
+          {
+            "id": "remote:sse:https://containers.mcp.cloudflare.com/sse",
+            "url": "https://containers.mcp.cloudflare.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          },
+          {
+            "id": "remote:sse:https://browser.mcp.cloudflare.com/sse",
+            "url": "https://browser.mcp.cloudflare.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          },
+          {
+            "id": "remote:sse:https://logs.mcp.cloudflare.com/sse",
+            "url": "https://logs.mcp.cloudflare.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          },
+          {
+            "id": "remote:sse:https://ai-gateway.mcp.cloudflare.com/sse",
+            "url": "https://ai-gateway.mcp.cloudflare.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          },
+          {
+            "id": "remote:sse:https://autorag.mcp.cloudflare.com/sse",
+            "url": "https://autorag.mcp.cloudflare.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          },
+          {
+            "id": "remote:sse:https://auditlogs.mcp.cloudflare.com/sse",
+            "url": "https://auditlogs.mcp.cloudflare.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          },
+          {
+            "id": "remote:sse:https://dns-analytics.mcp.cloudflare.com/sse",
+            "url": "https://dns-analytics.mcp.cloudflare.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          },
+          {
+            "id": "remote:sse:https://dex.mcp.cloudflare.com/sse",
+            "url": "https://dex.mcp.cloudflare.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          },
+          {
+            "id": "remote:sse:https://casb.mcp.cloudflare.com/sse",
+            "url": "https://casb.mcp.cloudflare.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          },
+          {
+            "id": "remote:sse:https://graphql.mcp.cloudflare.com/sse",
+            "url": "https://graphql.mcp.cloudflare.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authentication",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Optional Cloudflare API key for authentication if not using OAuth. Can use User or Account owned tokens as a Bearer token.",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          }
+        ],
+        "version": "1.0.0",
+        "is_latest": true,
+        "updated_at": "2025-09-16T22:06:29.987729Z",
+        "description": "Cloudflare MCP servers",
+        "published_at": "2025-09-16T22:06:29.987729Z",
+        "repository_url": "https://github.com/cloudflare/mcp-server-cloudflare",
+        "schema_version": "2025-09-29",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.figma.mcp/mcp",
+      "title": "Figma MCP Server",
+      "description": "The Figma MCP server brings Figma design context directly into your AI workflow.",
+      "repository_url": "https://github.com/figma/mcp-server-guide",
+      "version": "1.0.3",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.figma.mcp/mcp",
+        "title": "Figma MCP Server",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.figma.com/mcp",
+            "url": "https://mcp.figma.com/mcp",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "1.0.3",
+        "is_latest": true,
+        "updated_at": "2025-10-16T17:40:56.949472Z",
+        "description": "The Figma MCP server brings Figma design context directly into your AI workflow.",
+        "published_at": "2025-10-16T17:40:56.949472Z",
+        "repository_url": "https://github.com/figma/mcp-server-guide",
+        "schema_version": "2025-09-29",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.microsoft/azure",
+      "title": "Azure MCP Server",
+      "description": "All Azure MCP tools to create a seamless connection between AI agents and Azure services.",
+      "repository_url": "https://github.com/microsoft/mcp",
+      "version": "3.0.0-beta.6",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.microsoft/azure",
+        "title": "Azure MCP Server",
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:pypi:msmcp-azure",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "uvx",
+            "version": "3.0.0-beta.6",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "msmcp-azure",
+            "file_sha256": null,
+            "registry_type": "pypi",
+            "version_pinned": true,
+            "package_arguments": [
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "server"
+              },
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "start"
+              }
+            ],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:npm:@azure/mcp",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "npx",
+            "version": "3.0.0-beta.6",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "@azure/mcp",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "server"
+              },
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "start"
+              }
+            ],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:nuget:Azure.Mcp",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": "3.0.0-beta.6",
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "Azure.Mcp",
+            "file_sha256": null,
+            "registry_type": "nuget",
+            "version_pinned": true,
+            "package_arguments": [
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "server"
+              },
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "start"
+              }
+            ],
+            "runtime_arguments": [],
+            "unsupported_reason": "NuGet packages need the .NET runtime, which agent containers do not have",
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:mcpb:https://github.com/microsoft/mcp/releases/download/Azure.Mcp.Server-3.0.0-beta.6/Azure.Mcp.Server-win-x64.mcpb",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "https://github.com/microsoft/mcp/releases/download/Azure.Mcp.Server-3.0.0-beta.6/Azure.Mcp.Server-win-x64.mcpb",
+            "file_sha256": "0beb99eff0c73a27edee5d66ae935f91c57a49c18f0f34565e6ad6dacc5b3dfa",
+            "registry_type": "mcpb",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "no known runtime for mcpb packages",
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:mcpb:https://github.com/microsoft/mcp/releases/download/Azure.Mcp.Server-3.0.0-beta.6/Azure.Mcp.Server-win-arm64.mcpb",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "https://github.com/microsoft/mcp/releases/download/Azure.Mcp.Server-3.0.0-beta.6/Azure.Mcp.Server-win-arm64.mcpb",
+            "file_sha256": "c062aa482fb8eb6e55577a2c7beebb793bf8b7a9511ba0c8539366ccf14de421",
+            "registry_type": "mcpb",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "no known runtime for mcpb packages",
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:mcpb:https://github.com/microsoft/mcp/releases/download/Azure.Mcp.Server-3.0.0-beta.6/Azure.Mcp.Server-linux-x64.mcpb",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "https://github.com/microsoft/mcp/releases/download/Azure.Mcp.Server-3.0.0-beta.6/Azure.Mcp.Server-linux-x64.mcpb",
+            "file_sha256": "36d0888187ca74154a02f860defa528278db5717a998179f348a0d02aea6ef4d",
+            "registry_type": "mcpb",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "no known runtime for mcpb packages",
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:mcpb:https://github.com/microsoft/mcp/releases/download/Azure.Mcp.Server-3.0.0-beta.6/Azure.Mcp.Server-linux-arm64.mcpb",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "https://github.com/microsoft/mcp/releases/download/Azure.Mcp.Server-3.0.0-beta.6/Azure.Mcp.Server-linux-arm64.mcpb",
+            "file_sha256": "d8c59c074f9efd837694b138ed73bb0bab9c6af3506ec70b4066b7925294fbe8",
+            "registry_type": "mcpb",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "no known runtime for mcpb packages",
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:mcpb:https://github.com/microsoft/mcp/releases/download/Azure.Mcp.Server-3.0.0-beta.6/Azure.Mcp.Server-osx-x64.mcpb",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "https://github.com/microsoft/mcp/releases/download/Azure.Mcp.Server-3.0.0-beta.6/Azure.Mcp.Server-osx-x64.mcpb",
+            "file_sha256": "5df7f61aa9bd686470eb79ad5e9edc45de4dd7d42648ecc4e66cb1ea31c925c8",
+            "registry_type": "mcpb",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "no known runtime for mcpb packages",
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:mcpb:https://github.com/microsoft/mcp/releases/download/Azure.Mcp.Server-3.0.0-beta.6/Azure.Mcp.Server-osx-arm64.mcpb",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "https://github.com/microsoft/mcp/releases/download/Azure.Mcp.Server-3.0.0-beta.6/Azure.Mcp.Server-osx-arm64.mcpb",
+            "file_sha256": "52dc8eda170df606f75a38dc48a6c7c928222152ad2b9f8d57f79a8241f117c0",
+            "registry_type": "mcpb",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "no known runtime for mcpb packages",
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "3.0.0-beta.6",
+        "is_latest": true,
+        "updated_at": "2026-04-29T03:10:03.717272Z",
+        "description": "All Azure MCP tools to create a seamless connection between AI agents and Azure services.",
+        "published_at": "2026-04-29T03:10:03.717272Z",
+        "repository_url": "https://github.com/microsoft/mcp",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.mock-server/mockserver",
+      "title": null,
+      "description": "Mock, record/replay, verify and chaos-test any HTTP, REST, gRPC or LLM dependency over MCP.",
+      "repository_url": "https://github.com/mock-server/mockserver-monorepo",
+      "version": "7.5.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.mock-server/mockserver",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:http:oci:docker.io/mockserver/mockserver:7.5.0",
+            "url": "http://localhost:1080/mockserver/mcp",
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "http",
+            "identifier": "docker.io/mockserver/mockserver:7.5.0",
+            "file_sha256": null,
+            "registry_type": "oci",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "OCI packages need Docker, which agent containers do not have",
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "7.5.0",
+        "is_latest": true,
+        "updated_at": "2026-07-29T18:30:27.26516Z",
+        "description": "Mock, record/replay, verify and chaos-test any HTTP, REST, gRPC or LLM dependency over MCP.",
+        "published_at": "2026-07-29T18:30:27.26516Z",
+        "repository_url": "https://github.com/mock-server/mockserver-monorepo",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.monday/monday.com",
+      "title": null,
+      "description": "MCP server for monday.com integration.",
+      "repository_url": "https://github.com/mondaycom/mcp",
+      "version": "0.0.1",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.monday/monday.com",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.monday.com/mcp",
+            "url": "https://mcp.monday.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authorization",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "monday.com API token (format: 'Bearer your_token_here' or just 'your_token_here')",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:sse:https://mcp.monday.com/sse",
+            "url": "https://mcp.monday.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authorization",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "monday.com API token (format: 'Bearer your_token_here' or just 'your_token_here')",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          }
+        ],
+        "version": "0.0.1",
+        "is_latest": true,
+        "updated_at": "2025-10-23T14:57:35.277178Z",
+        "description": "MCP server for monday.com integration.",
+        "published_at": "2025-10-23T14:57:35.277178Z",
+        "repository_url": "https://github.com/mondaycom/mcp",
+        "schema_version": "2025-10-17",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.notion/mcp",
+      "title": null,
+      "description": "Official Notion MCP server",
+      "repository_url": null,
+      "version": "1.0.1",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.notion/mcp",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.notion.com/mcp",
+            "url": "https://mcp.notion.com/mcp",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:sse:https://mcp.notion.com/sse",
+            "url": "https://mcp.notion.com/sse",
+            "kind": "remote",
+            "inputs": [],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          }
+        ],
+        "version": "1.0.1",
+        "is_latest": true,
+        "updated_at": "2025-09-11T22:25:50.737872Z",
+        "description": "Official Notion MCP server",
+        "published_at": "2025-09-11T22:25:50.737872Z",
+        "repository_url": null,
+        "schema_version": "2025-09-29",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.paypal.mcp/mcp",
+      "title": null,
+      "description": "PayPal MCP server provides access to PayPal services and operations for AI assistants",
+      "repository_url": null,
+      "version": "1.0.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.paypal.mcp/mcp",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.paypal.com/mcp",
+            "url": "https://mcp.paypal.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authorization",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "description": "OAuth Bearer token for API authentication (format: Bearer <token>)",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:sse:https://mcp.paypal.com/sse",
+            "url": "https://mcp.paypal.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authorization",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "description": "OAuth Bearer token for API authentication (format: Bearer <token>)",
+                "value_template": null
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          }
+        ],
+        "version": "1.0.0",
+        "is_latest": true,
+        "updated_at": "2025-10-28T19:34:19.455268Z",
+        "description": "PayPal MCP server provides access to PayPal services and operations for AI assistants",
+        "published_at": "2025-10-28T19:34:19.455268Z",
+        "repository_url": null,
+        "schema_version": "2025-10-17",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.railway/mcp",
+      "title": "Railway MCP",
+      "description": "Develop, manage, and debug Railway projects, services, and deployments from within agents.",
+      "repository_url": "https://github.com/railwayapp/mono",
+      "version": "1.0.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.railway/mcp",
+        "title": "Railway MCP",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.railway.com/",
+            "url": "https://mcp.railway.com/",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "1.0.0",
+        "is_latest": true,
+        "updated_at": "2026-04-22T14:41:31.685851Z",
+        "description": "Develop, manage, and debug Railway projects, services, and deployments from within agents.",
+        "published_at": "2026-04-22T14:41:31.685851Z",
+        "repository_url": "https://github.com/railwayapp/mono",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.stripe/mcp",
+      "title": null,
+      "description": "MCP server integrating with Stripe - tools for customers, products, payments, and more.",
+      "repository_url": "https://github.com/stripe/agent-toolkit",
+      "version": "0.2.4",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.stripe/mcp",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.stripe.com",
+            "url": "https://mcp.stripe.com",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "0.2.4",
+        "is_latest": true,
+        "updated_at": "2025-10-28T22:06:18.495159Z",
+        "description": "MCP server integrating with Stripe - tools for customers, products, payments, and more.",
+        "published_at": "2025-10-28T22:06:18.495159Z",
+        "repository_url": "https://github.com/stripe/agent-toolkit",
+        "schema_version": "2025-10-17",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.supabase/mcp",
+      "title": "Supabase",
+      "description": "MCP server for interacting with the Supabase platform",
+      "repository_url": "https://github.com/supabase/mcp",
+      "version": "0.9.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.supabase/mcp",
+        "title": "Supabase",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.supabase.com/mcp",
+            "url": "https://mcp.supabase.com/mcp",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "package:stdio:npm:@supabase/mcp-server-supabase",
+            "url": null,
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "SUPABASE_ACCESS_TOKEN",
+                "kind": "env",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "description": "Personal access token for Supabase API",
+                "value_template": null
+              }
+            ],
+            "runtime": "npx",
+            "version": "0.9.0",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "@supabase/mcp-server-supabase",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [
+              {
+                "key": "--project-ref",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Supabase project reference ID",
+                "value_template": null
+              },
+              {
+                "key": "--read-only",
+                "kind": "arg",
+                "format": "boolean",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Enable read-only mode",
+                "value_template": null
+              },
+              {
+                "key": "--features",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Comma-separated list of features to enable",
+                "value_template": null
+              },
+              {
+                "key": "--api-url",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Custom API URL",
+                "value_template": null
+              }
+            ],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.9.0",
+        "is_latest": true,
+        "updated_at": "2026-07-17T09:08:22.938853Z",
+        "description": "MCP server for interacting with the Supabase platform",
+        "published_at": "2026-07-17T09:08:22.938853Z",
+        "repository_url": "https://github.com/supabase/mcp",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.vercel/vercel-mcp",
+      "title": null,
+      "description": "An MCP server for Vercel",
+      "repository_url": "https://github.com/vercel/vercel-mcp-overview",
+      "version": "0.0.3",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.vercel/vercel-mcp",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.vercel.com",
+            "url": "https://mcp.vercel.com",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "0.0.3",
+        "is_latest": true,
+        "updated_at": "2026-01-14T18:38:33.404454Z",
+        "description": "An MCP server for Vercel",
+        "published_at": "2026-01-14T18:38:33.404454Z",
+        "repository_url": "https://github.com/vercel/vercel-mcp-overview",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.webflow/mcp",
+      "title": null,
+      "description": "AI-powered design and management for Webflow Sites",
+      "repository_url": "https://github.com/webflow/mcp-server",
+      "version": "2.0.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.webflow/mcp",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.webflow.com/mcp",
+            "url": "https://mcp.webflow.com/mcp",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "2.0.0",
+        "is_latest": true,
+        "updated_at": "2025-10-27T21:00:28.378216Z",
+        "description": "AI-powered design and management for Webflow Sites",
+        "published_at": "2025-10-27T21:00:28.378216Z",
+        "repository_url": "https://github.com/webflow/mcp-server",
+        "schema_version": "2025-10-17",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "com.zapier/mcp",
+      "title": "Zapier",
+      "description": "Hosted MCP server connecting AI assistants to 9,000+ apps and 40,000+ actions via Zapier.",
+      "repository_url": "https://github.com/zapier/zapier-mcp",
+      "version": "1.0.1",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "com.zapier/mcp",
+        "title": "Zapier",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.zapier.com/api/v1/connect",
+            "url": "https://mcp.zapier.com/api/v1/connect",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "1.0.1",
+        "is_latest": true,
+        "updated_at": "2026-07-29T18:56:40.112909Z",
+        "description": "Hosted MCP server connecting AI assistants to 9,000+ apps and 40,000+ actions via Zapier.",
+        "published_at": "2026-07-29T18:56:40.112909Z",
+        "repository_url": "https://github.com/zapier/zapier-mcp",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.54yyyu/zotero-mcp",
+      "title": "Zotero MCP",
+      "description": "Search, read, annotate, and add to your Zotero research library, local or web.",
+      "repository_url": "https://github.com/54yyyu/zotero-mcp",
+      "version": "0.9.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.54yyyu/zotero-mcp",
+        "title": "Zotero MCP",
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:pypi:zotero-mcp-server",
+            "url": null,
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "ZOTERO_LOCAL",
+                "kind": "env",
+                "format": "boolean",
+                "secret": false,
+                "default": "true",
+                "required": false,
+                "description": "Read from the local Zotero desktop app instead of the web API. Requires Zotero 7+ with the local API enabled in Settings > Advanced.",
+                "value_template": null
+              },
+              {
+                "key": "ZOTERO_API_KEY",
+                "kind": "env",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Zotero Web API key from https://www.zotero.org/settings/keys. Only needed when ZOTERO_LOCAL is false, or for write operations in hybrid mode.",
+                "value_template": null
+              },
+              {
+                "key": "ZOTERO_LIBRARY_ID",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "required": false,
+                "description": "Zotero user or group library ID. Only needed when ZOTERO_LOCAL is false, or for write operations in hybrid mode.",
+                "value_template": null
+              },
+              {
+                "key": "ZOTERO_LIBRARY_TYPE",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "choices": [
+                  "user",
+                  "group"
+                ],
+                "default": "user",
+                "required": false,
+                "description": "Whether ZOTERO_LIBRARY_ID refers to a personal or a group library.",
+                "value_template": null
+              },
+              {
+                "key": "ZOTERO_MCP_TOOLSETS",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "required": false,
+                "description": "Which optional tool groups to expose, as a comma-separated list. Every tool is sent to the model on each request, so optional capabilities are off by default. Use 'all' for the full surface, 'none' for core only, named groups (scite, duplicates, discovery, feeds, relations, libraries, search-admin, pdf-geometry) to add them, or a leading '-' to subtract.",
+                "value_template": null
+              }
+            ],
+            "runtime": "uvx",
+            "version": "0.9.0",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "zotero-mcp-server",
+            "file_sha256": null,
+            "registry_type": "pypi",
+            "version_pinned": true,
+            "package_arguments": [
+              {
+                "key": "serve",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": "serve",
+                "value_template": "serve"
+              }
+            ],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.9.0",
+        "is_latest": true,
+        "updated_at": "2026-08-03T17:05:30.752637Z",
+        "description": "Search, read, annotate, and add to your Zotero research library, local or web.",
+        "published_at": "2026-08-03T17:05:30.752637Z",
+        "repository_url": "https://github.com/54yyyu/zotero-mcp",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.Ataraxy-Labs/sem",
+      "title": null,
+      "description": "Entity-level code intelligence: semantic diff, impact analysis, blame, and context for AI agents",
+      "repository_url": "https://github.com/Ataraxy-Labs/sem",
+      "version": "0.21.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.Ataraxy-Labs/sem",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:@ataraxy-labs/sem",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "npx",
+            "version": "0.21.0",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "@ataraxy-labs/sem",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "mcp"
+              }
+            ],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.21.0",
+        "is_latest": true,
+        "updated_at": "2026-07-10T11:34:17.335945Z",
+        "description": "Entity-level code intelligence: semantic diff, impact analysis, blame, and context for AI agents",
+        "published_at": "2026-07-10T11:34:17.335945Z",
+        "repository_url": "https://github.com/Ataraxy-Labs/sem",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.ChromeDevTools/chrome-devtools-mcp",
+      "title": "Chrome DevTools MCP",
+      "description": "MCP server for Chrome DevTools",
+      "repository_url": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
+      "version": "1.6.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.ChromeDevTools/chrome-devtools-mcp",
+        "title": "Chrome DevTools MCP",
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:chrome-devtools-mcp",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "npx",
+            "version": "1.6.0",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "chrome-devtools-mcp",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "1.6.0",
+        "is_latest": true,
+        "updated_at": "2026-07-14T11:27:01.61933Z",
+        "description": "MCP server for Chrome DevTools",
+        "published_at": "2026-07-14T11:27:01.61933Z",
+        "repository_url": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.CursorTouch/Windows-MCP",
+      "title": null,
+      "description": "An MCP Server for computer-use in Windows OS",
+      "repository_url": "https://github.com/CursorTouch/Windows-MCP",
+      "version": "1.0.1",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.CursorTouch/Windows-MCP",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:pypi:windows-mcp",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "uvx",
+            "version": "0.8.1",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "windows-mcp",
+            "file_sha256": null,
+            "registry_type": "pypi",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "1.0.1",
+        "is_latest": true,
+        "updated_at": "2026-05-22T08:13:34.000818Z",
+        "description": "An MCP Server for computer-use in Windows OS",
+        "published_at": "2026-05-22T08:13:34.000818Z",
+        "repository_url": "https://github.com/CursorTouch/Windows-MCP",
+        "schema_version": "2025-07-09",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.D4Vinci/Scrapling",
+      "title": "Scrapling MCP Server",
+      "description": "Web scraping with stealth HTTP, real browsers, and Cloudflare bypass. CSS selectors supported.",
+      "repository_url": "https://github.com/D4Vinci/Scrapling",
+      "version": "0.4.12",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.D4Vinci/Scrapling",
+        "title": "Scrapling MCP Server",
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:pypi:scrapling",
+            "url": null,
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "mcp",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": "mcp",
+                "value_template": null
+              }
+            ],
+            "runtime": "uvx",
+            "version": "0.4.12",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "scrapling",
+            "file_sha256": null,
+            "registry_type": "pypi",
+            "version_pinned": true,
+            "package_arguments": [
+              {
+                "key": "mcp",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": "mcp",
+                "value_template": null
+              }
+            ],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:oci:ghcr.io/d4vinci/scrapling",
+            "url": null,
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "mcp",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": "mcp",
+                "value_template": null
+              }
+            ],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "ghcr.io/d4vinci/scrapling",
+            "file_sha256": null,
+            "registry_type": "oci",
+            "version_pinned": false,
+            "package_arguments": [
+              {
+                "key": "mcp",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": "mcp",
+                "value_template": null
+              }
+            ],
+            "runtime_arguments": [],
+            "unsupported_reason": "OCI packages need Docker, which agent containers do not have",
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.4.12",
+        "is_latest": true,
+        "updated_at": "2026-07-27T09:50:50.561854Z",
+        "description": "Web scraping with stealth HTTP, real browsers, and Cloudflare bypass. CSS selectors supported.",
+        "published_at": "2026-07-27T09:50:50.561854Z",
+        "repository_url": "https://github.com/D4Vinci/Scrapling",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.DeusData/codebase-memory-mcp",
+      "title": "Codebase Memory",
+      "description": "Codebase knowledge graph for AI agents — 159 languages, sub-ms queries, 99% fewer tokens.",
+      "repository_url": "https://github.com/DeusData/codebase-memory-mcp",
+      "version": "0.9.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.DeusData/codebase-memory-mcp",
+        "title": "Codebase Memory",
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:codebase-memory-mcp",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "npx",
+            "version": "0.9.0",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "codebase-memory-mcp",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:pypi:codebase-memory-mcp",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "uvx",
+            "version": "0.9.0",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "codebase-memory-mcp",
+            "file_sha256": null,
+            "registry_type": "pypi",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.9.0",
+        "is_latest": true,
+        "updated_at": "2026-07-08T11:16:26.744452Z",
+        "description": "Codebase knowledge graph for AI agents — 159 languages, sub-ms queries, 99% fewer tokens.",
+        "published_at": "2026-07-08T11:16:26.744452Z",
+        "repository_url": "https://github.com/DeusData/codebase-memory-mcp",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.GLips/Figma-Context-MCP",
+      "title": null,
+      "description": "Give your coding agent access to your Figma data. Implement designs in any framework in one-shot.",
+      "repository_url": "https://github.com/GLips/Figma-Context-MCP",
+      "version": "0.13.2",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.GLips/Figma-Context-MCP",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:figma-developer-mcp",
+            "url": null,
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "FIGMA_API_KEY",
+                "kind": "env",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "description": "Your Figma Personal Access Token, learn more here: https://www.figma.com/developers/api#access-tokens",
+                "value_template": null
+              }
+            ],
+            "runtime": "npx",
+            "version": "0.13.2",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "figma-developer-mcp",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "--stdio"
+              }
+            ],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.13.2",
+        "is_latest": true,
+        "updated_at": "2026-06-18T16:38:55.772349Z",
+        "description": "Give your coding agent access to your Figma data. Implement designs in any framework in one-shot.",
+        "published_at": "2026-06-18T16:38:55.772349Z",
+        "repository_url": "https://github.com/GLips/Figma-Context-MCP",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.IvanMurzak/Unity-MCP",
+      "title": null,
+      "description": "Make 3D games in Unity Engine with AI. MCP Server + Plugin for Unity Editor and Unity games.",
+      "repository_url": "https://github.com/IvanMurzak/Unity-MCP",
+      "version": "0.17.1",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.IvanMurzak/Unity-MCP",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:oci:docker.io/ivanmurzakdev/unity-mcp-server:0.17.1",
+            "url": null,
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "UNITY_MCP_PORT",
+                "kind": "env",
+                "format": "number",
+                "secret": false,
+                "required": false,
+                "description": "Client -> Server <- Plugin connection port (default: 8080)",
+                "value_template": null
+              },
+              {
+                "key": "UNITY_MCP_PLUGIN_TIMEOUT",
+                "kind": "env",
+                "format": "number",
+                "secret": false,
+                "required": false,
+                "description": "Plugin -> Server connection timeout (ms) (default: 10000)",
+                "value_template": null
+              },
+              {
+                "key": "UNITY_MCP_CLIENT_TRANSPORT",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "default": "stdio",
+                "required": false,
+                "description": "Client -> Server transport type: stdio or http (default: http)",
+                "value_template": null
+              }
+            ],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "docker.io/ivanmurzakdev/unity-mcp-server:0.17.1",
+            "file_sha256": null,
+            "registry_type": "oci",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "OCI packages need Docker, which agent containers do not have",
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.17.1",
+        "is_latest": true,
+        "updated_at": "2025-09-12T11:41:26.282067Z",
+        "description": "Make 3D games in Unity Engine with AI. MCP Server + Plugin for Unity Editor and Unity games.",
+        "published_at": "2025-09-12T11:41:26.282067Z",
+        "repository_url": "https://github.com/IvanMurzak/Unity-MCP",
+        "schema_version": "2025-09-29",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.JerBouma/financetoolkit",
+      "title": "Finance Toolkit",
+      "description": "200+ transparent financial metrics calculated from raw statements, not third-party endpoints.",
+      "repository_url": "https://github.com/JerBouma/FinanceToolkit",
+      "version": "2.1.2",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.JerBouma/financetoolkit",
+        "title": "Finance Toolkit",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://financetoolkit.jeroenbouma.com/mcp",
+            "url": "https://financetoolkit.jeroenbouma.com/mcp",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "package:stdio:pypi:financetoolkit",
+            "url": null,
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "FINANCIAL_MODELING_PREP_API_KEY",
+                "kind": "env",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "description": "Financial Modeling Prep API key, get a key over at https://www.jeroenbouma.com/fmp",
+                "value_template": null
+              }
+            ],
+            "runtime": "uvx",
+            "version": "2.1.2",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "financetoolkit",
+            "file_sha256": null,
+            "registry_type": "pypi",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "2.1.2",
+        "is_latest": true,
+        "updated_at": "2026-06-23T19:44:17.201672Z",
+        "description": "200+ transparent financial metrics calculated from raw statements, not third-party endpoints.",
+        "published_at": "2026-06-23T19:44:17.201672Z",
+        "repository_url": "https://github.com/JerBouma/FinanceToolkit",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.KnockOutEZ/wigolo",
+      "title": null,
+      "description": "Local-first web intelligence MCP server for AI coding agents",
+      "repository_url": "https://github.com/KnockOutEZ/wigolo",
+      "version": "0.2.1",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.KnockOutEZ/wigolo",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:wigolo",
+            "url": null,
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "YOUR_API_KEY",
+                "kind": "env",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "description": "Your API key for the service",
+                "value_template": null
+              }
+            ],
+            "runtime": "npx",
+            "version": "0.2.1",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "wigolo",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.2.1",
+        "is_latest": true,
+        "updated_at": "2026-07-19T11:31:57.677433Z",
+        "description": "Local-first web intelligence MCP server for AI coding agents",
+        "published_at": "2026-07-19T11:31:57.677433Z",
+        "repository_url": "https://github.com/KnockOutEZ/wigolo",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.MervinPraison/praisonai",
+      "title": "PraisonAI",
+      "description": "AI Agents Framework with Self Reflection and MCP support",
+      "repository_url": "https://github.com/MervinPraison/PraisonAI",
+      "version": "2.3.42",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.MervinPraison/praisonai",
+        "title": "PraisonAI",
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:pypi:praisonai",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "uvx",
+            "version": "2.3.42",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "praisonai",
+            "file_sha256": null,
+            "registry_type": "pypi",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "2.3.42",
+        "is_latest": true,
+        "updated_at": "2025-12-18T22:14:22.379891Z",
+        "description": "AI Agents Framework with Self Reflection and MCP support",
+        "published_at": "2025-12-18T22:14:22.379891Z",
+        "repository_url": "https://github.com/MervinPraison/PraisonAI",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.PostHog/mcp",
+      "title": "PostHog MCP Server",
+      "description": "Official PostHog MCP Server for product analytics, feature flags, experiments, and more.",
+      "repository_url": "https://github.com/PostHog/posthog",
+      "version": "1.0.1",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.PostHog/mcp",
+        "title": "PostHog MCP Server",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.posthog.com/mcp",
+            "url": "https://mcp.posthog.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authorization",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "variables": {
+                  "api_key": {
+                    "isSecret": true,
+                    "isRequired": true,
+                    "description": "Your PostHog personal API key"
+                  }
+                },
+                "description": "Bearer token with your PostHog personal API key. Create one at https://us.posthog.com/settings/user-api-keys with the 'MCP Server' preset.",
+                "value_template": "Bearer {api_key}"
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:sse:https://mcp.posthog.com/sse",
+            "url": "https://mcp.posthog.com/sse",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authorization",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "variables": {
+                  "api_key": {
+                    "isSecret": true,
+                    "isRequired": true,
+                    "description": "Your PostHog personal API key"
+                  }
+                },
+                "description": "Bearer token with your PostHog personal API key. Create one at https://us.posthog.com/settings/user-api-keys with the 'MCP Server' preset.",
+                "value_template": "Bearer {api_key}"
+              }
+            ],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          }
+        ],
+        "version": "1.0.1",
+        "is_latest": true,
+        "updated_at": "2026-01-07T16:34:40.847754Z",
+        "description": "Official PostHog MCP Server for product analytics, feature flags, experiments, and more.",
+        "published_at": "2026-01-07T16:34:40.847754Z",
+        "repository_url": "https://github.com/PostHog/posthog",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.Skyvern-AI/skyvern",
+      "title": "Skyvern",
+      "description": "AI-powered browser automation — navigate, click, fill forms, and extract data from any website.",
+      "repository_url": "https://github.com/Skyvern-AI/skyvern",
+      "version": "1.0.23",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.Skyvern-AI/skyvern",
+        "title": "Skyvern",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://api.skyvern.com/mcp/",
+            "url": "https://api.skyvern.com/mcp/",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "x-api-key",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "description": "Your Skyvern API key. Get one at https://app.skyvern.com/settings.",
+                "value_template": "{SKYVERN_API_KEY}"
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "1.0.23",
+        "is_latest": true,
+        "updated_at": "2026-03-13T03:08:33.117806Z",
+        "description": "AI-powered browser automation — navigate, click, fill forms, and extract data from any website.",
+        "published_at": "2026-03-13T03:08:33.117806Z",
+        "repository_url": "https://github.com/Skyvern-AI/skyvern",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.airweave-ai/search",
+      "title": "Airweave Search",
+      "description": "MCP server for searching Airweave collections with natural language queries.",
+      "repository_url": "https://github.com/airweave-ai/airweave",
+      "version": "0.9.62",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.airweave-ai/search",
+        "title": "Airweave Search",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.airweave.ai/mcp",
+            "url": "https://mcp.airweave.ai/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "X-API-Key",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "description": "Your Airweave API key",
+                "value_template": null
+              },
+              {
+                "key": "X-Collection-Readable-ID",
+                "kind": "header",
+                "format": "string",
+                "secret": false,
+                "required": true,
+                "description": "The Airweave collection readable ID to search",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "package:stdio:npm:airweave-mcp-search",
+            "url": null,
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "AIRWEAVE_API_KEY",
+                "kind": "env",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "description": "Your Airweave API key for authentication",
+                "value_template": null
+              },
+              {
+                "key": "AIRWEAVE_COLLECTION",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "required": true,
+                "description": "The Airweave collection to search",
+                "value_template": null
+              },
+              {
+                "key": "AIRWEAVE_BASE_URL",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "required": false,
+                "description": "Airweave API base URL (defaults to https://api.airweave.ai)",
+                "value_template": null
+              }
+            ],
+            "runtime": "npx",
+            "version": "0.9.62",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "airweave-mcp-search",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.9.62",
+        "is_latest": true,
+        "updated_at": "2026-04-07T17:48:14.839407Z",
+        "description": "MCP server for searching Airweave collections with natural language queries.",
+        "published_at": "2026-04-07T17:48:14.839407Z",
+        "repository_url": "https://github.com/airweave-ai/airweave",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.amruthpillai/reactive-resume",
+      "title": "Reactive Resume",
+      "description": "Free open-source resume builder with remote MCP tools for resumes and job applications.",
+      "repository_url": "https://github.com/amruthpillai/reactive-resume",
+      "version": "5.2.2",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.amruthpillai/reactive-resume",
+        "title": "Reactive Resume",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://rxresu.me/mcp",
+            "url": "https://rxresu.me/mcp",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "5.2.2",
+        "is_latest": true,
+        "updated_at": "2026-07-07T16:47:02.051001Z",
+        "description": "Free open-source resume builder with remote MCP tools for resumes and job applications.",
+        "published_at": "2026-07-07T16:47:02.051001Z",
+        "repository_url": "https://github.com/amruthpillai/reactive-resume",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.antvis/mcp-server-chart",
+      "title": null,
+      "description": "A Model Context Protocol server for generating charts using AntV.",
+      "repository_url": "https://github.com/antvis/mcp-server-chart",
+      "version": "1.0.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.antvis/mcp-server-chart",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:@antv/mcp-server-chart",
+            "url": null,
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "VIS_REQUEST_SERVER",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "default": "https://antv-studio.alipay.com/api/gpt-vis",
+                "required": false,
+                "description": "Custom chart generation service URL for private deployment",
+                "value_template": null
+              },
+              {
+                "key": "SERVICE_ID",
+                "kind": "env",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Service identifier for chart generation records",
+                "value_template": null
+              },
+              {
+                "key": "DISABLED_TOOLS",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "required": false,
+                "description": "Comma-separated list of tool names to disable",
+                "value_template": null
+              }
+            ],
+            "runtime": "npx",
+            "version": "0.9.0-beta.1",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "@antv/mcp-server-chart",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "1.0.0",
+        "is_latest": true,
+        "updated_at": "2025-09-15T12:44:26.492264Z",
+        "description": "A Model Context Protocol server for generating charts using AntV.",
+        "published_at": "2025-09-15T12:44:26.492264Z",
+        "repository_url": "https://github.com/antvis/mcp-server-chart",
+        "schema_version": "2025-09-29",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.basicmachines-co/basic-memory",
+      "title": null,
+      "description": "Local-first knowledge management with bi-directional LLM sync via Markdown files.",
+      "repository_url": "https://github.com/basicmachines-co/basic-memory.git",
+      "version": "0.22.1",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.basicmachines-co/basic-memory",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:pypi:basic-memory",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "uvx",
+            "version": "0.22.1",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "basic-memory",
+            "file_sha256": null,
+            "registry_type": "pypi",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "basic-memory"
+              },
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "mcp"
+              }
+            ],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.22.1",
+        "is_latest": true,
+        "updated_at": "2026-06-13T03:40:27.473628Z",
+        "description": "Local-first knowledge management with bi-directional LLM sync via Markdown files.",
+        "published_at": "2026-06-13T03:40:27.473628Z",
+        "repository_url": "https://github.com/basicmachines-co/basic-memory.git",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.browserbase/mcp-server-browserbase",
+      "title": null,
+      "description": "MCP server for AI web browser automation using Browserbase and Stagehand",
+      "repository_url": "https://github.com/browserbase/mcp-server-browserbase",
+      "version": "2.1.1",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.browserbase/mcp-server-browserbase",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:@browserbasehq/mcp-server-browserbase",
+            "url": null,
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "BROWSERBASE_API_KEY",
+                "kind": "env",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "description": "Your Browserbase API key",
+                "value_template": null
+              },
+              {
+                "key": "BROWSERBASE_PROJECT_ID",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "required": true,
+                "description": "Your Browserbase Project ID",
+                "value_template": null
+              },
+              {
+                "key": "GEMINI_API_KEY",
+                "kind": "env",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "description": "Your Gemini API key (default model)",
+                "value_template": null
+              }
+            ],
+            "runtime": "npx",
+            "version": "2.1.1",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "@browserbasehq/mcp-server-browserbase",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "2.1.1",
+        "is_latest": true,
+        "updated_at": "2025-09-12T21:10:44.068065Z",
+        "description": "MCP server for AI web browser automation using Browserbase and Stagehand",
+        "published_at": "2025-09-12T21:10:44.068065Z",
+        "repository_url": "https://github.com/browserbase/mcp-server-browserbase",
+        "schema_version": "2025-09-29",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.bytedance/mcp-server-browser",
+      "title": null,
+      "description": "MCP server for browser use access",
+      "repository_url": "https://github.com/bytedance/UI-TARS-desktop",
+      "version": "1.0.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.bytedance/mcp-server-browser",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:@agent-infra/mcp-server-browser",
+            "url": null,
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "DISPLAY",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "required": false,
+                "description": "DISPLAY environment variable for browser rendering",
+                "value_template": null
+              },
+              {
+                "key": "browser",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "browser or chrome channel to use, possible values: chrome, edge, firefox.",
+                "value_template": null
+              },
+              {
+                "key": "cdp-endpoint",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Chrome DevTools Protocol endpoint URL",
+                "value_template": null
+              },
+              {
+                "key": "ws-endpoint",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "WebSocket endpoint to connect to, for example",
+                "value_template": null
+              },
+              {
+                "key": "executable-path",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Path to the browser executable",
+                "value_template": null
+              },
+              {
+                "key": "output-dir",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Path to the output directory",
+                "value_template": null
+              },
+              {
+                "key": "proxy-bypass",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Comma-separated list of patterns to bypass the proxy",
+                "value_template": null
+              },
+              {
+                "key": "proxy-server",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Proxy server address",
+                "value_template": null
+              },
+              {
+                "key": "vision",
+                "kind": "arg",
+                "format": "boolean",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Run server that uses screenshots (Aria snapshots are used by default)",
+                "value_template": null
+              }
+            ],
+            "runtime": "npx",
+            "version": "latest",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "@agent-infra/mcp-server-browser",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": false,
+            "package_arguments": [
+              {
+                "key": "browser",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "browser or chrome channel to use, possible values: chrome, edge, firefox.",
+                "value_template": null
+              },
+              {
+                "key": "cdp-endpoint",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Chrome DevTools Protocol endpoint URL",
+                "value_template": null
+              },
+              {
+                "key": "ws-endpoint",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "WebSocket endpoint to connect to, for example",
+                "value_template": null
+              },
+              {
+                "key": "executable-path",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Path to the browser executable",
+                "value_template": null
+              },
+              {
+                "key": "output-dir",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Path to the output directory",
+                "value_template": null
+              },
+              {
+                "key": "proxy-bypass",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Comma-separated list of patterns to bypass the proxy",
+                "value_template": null
+              },
+              {
+                "key": "proxy-server",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Proxy server address",
+                "value_template": null
+              },
+              {
+                "key": "vision",
+                "kind": "arg",
+                "format": "boolean",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Run server that uses screenshots (Aria snapshots are used by default)",
+                "value_template": null
+              }
+            ],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:http:npm:@agent-infra/mcp-server-browser",
+            "url": "http://127.0.0.1:{port}/mcp",
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "DISPLAY",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "required": false,
+                "description": "DISPLAY environment variable for browser rendering",
+                "value_template": null
+              },
+              {
+                "key": "port",
+                "kind": "arg",
+                "format": "number",
+                "secret": false,
+                "default": "8089",
+                "arg_type": "named",
+                "repeated": false,
+                "required": true,
+                "value_hint": null,
+                "description": "Server port number",
+                "value_template": null
+              },
+              {
+                "key": "browser",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "browser or chrome channel to use, possible values: chrome, edge, firefox.",
+                "value_template": null
+              },
+              {
+                "key": "cdp-endpoint",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Chrome DevTools Protocol endpoint URL",
+                "value_template": null
+              },
+              {
+                "key": "ws-endpoint",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "WebSocket endpoint to connect to, for example",
+                "value_template": null
+              },
+              {
+                "key": "executable-path",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Path to the browser executable",
+                "value_template": null
+              },
+              {
+                "key": "output-dir",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Path to the output directory",
+                "value_template": null
+              },
+              {
+                "key": "proxy-bypass",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Comma-separated list of patterns to bypass the proxy",
+                "value_template": null
+              },
+              {
+                "key": "proxy-server",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Proxy server address",
+                "value_template": null
+              },
+              {
+                "key": "vision",
+                "kind": "arg",
+                "format": "boolean",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Run server that uses screenshots (Aria snapshots are used by default)",
+                "value_template": null
+              }
+            ],
+            "runtime": "npx",
+            "version": "latest",
+            "supported": false,
+            "transport": "http",
+            "identifier": "@agent-infra/mcp-server-browser",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": false,
+            "package_arguments": [
+              {
+                "key": "port",
+                "kind": "arg",
+                "format": "number",
+                "secret": false,
+                "default": "8089",
+                "arg_type": "named",
+                "repeated": false,
+                "required": true,
+                "value_hint": null,
+                "description": "Server port number",
+                "value_template": null
+              },
+              {
+                "key": "browser",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "browser or chrome channel to use, possible values: chrome, edge, firefox.",
+                "value_template": null
+              },
+              {
+                "key": "cdp-endpoint",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Chrome DevTools Protocol endpoint URL",
+                "value_template": null
+              },
+              {
+                "key": "ws-endpoint",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "WebSocket endpoint to connect to, for example",
+                "value_template": null
+              },
+              {
+                "key": "executable-path",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Path to the browser executable",
+                "value_template": null
+              },
+              {
+                "key": "output-dir",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Path to the output directory",
+                "value_template": null
+              },
+              {
+                "key": "proxy-bypass",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Comma-separated list of patterns to bypass the proxy",
+                "value_template": null
+              },
+              {
+                "key": "proxy-server",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Proxy server address",
+                "value_template": null
+              },
+              {
+                "key": "vision",
+                "kind": "arg",
+                "format": "boolean",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Run server that uses screenshots (Aria snapshots are used by default)",
+                "value_template": null
+              }
+            ],
+            "runtime_arguments": [],
+            "unsupported_reason": "http package transports require launching and connecting separately, which agent MCP config cannot express",
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:sse:npm:@agent-infra/mcp-server-browser",
+            "url": "http://127.0.0.1:{port}/sse",
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "DISPLAY",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "required": false,
+                "description": "DISPLAY environment variable for browser rendering",
+                "value_template": null
+              },
+              {
+                "key": "port",
+                "kind": "arg",
+                "format": "number",
+                "secret": false,
+                "default": "8089",
+                "arg_type": "named",
+                "repeated": false,
+                "required": true,
+                "value_hint": null,
+                "description": "Server port number",
+                "value_template": null
+              },
+              {
+                "key": "browser",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "browser or chrome channel to use, possible values: chrome, edge, firefox.",
+                "value_template": null
+              },
+              {
+                "key": "cdp-endpoint",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Chrome DevTools Protocol endpoint URL",
+                "value_template": null
+              },
+              {
+                "key": "ws-endpoint",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "WebSocket endpoint to connect to, for example",
+                "value_template": null
+              },
+              {
+                "key": "executable-path",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Path to the browser executable",
+                "value_template": null
+              },
+              {
+                "key": "output-dir",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Path to the output directory",
+                "value_template": null
+              },
+              {
+                "key": "proxy-bypass",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Comma-separated list of patterns to bypass the proxy",
+                "value_template": null
+              },
+              {
+                "key": "proxy-server",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Proxy server address",
+                "value_template": null
+              },
+              {
+                "key": "vision",
+                "kind": "arg",
+                "format": "boolean",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Run server that uses screenshots (Aria snapshots are used by default)",
+                "value_template": null
+              }
+            ],
+            "runtime": "npx",
+            "version": "latest",
+            "supported": false,
+            "transport": "sse",
+            "identifier": "@agent-infra/mcp-server-browser",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": false,
+            "package_arguments": [
+              {
+                "key": "port",
+                "kind": "arg",
+                "format": "number",
+                "secret": false,
+                "default": "8089",
+                "arg_type": "named",
+                "repeated": false,
+                "required": true,
+                "value_hint": null,
+                "description": "Server port number",
+                "value_template": null
+              },
+              {
+                "key": "browser",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "browser or chrome channel to use, possible values: chrome, edge, firefox.",
+                "value_template": null
+              },
+              {
+                "key": "cdp-endpoint",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Chrome DevTools Protocol endpoint URL",
+                "value_template": null
+              },
+              {
+                "key": "ws-endpoint",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "WebSocket endpoint to connect to, for example",
+                "value_template": null
+              },
+              {
+                "key": "executable-path",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Path to the browser executable",
+                "value_template": null
+              },
+              {
+                "key": "output-dir",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Path to the output directory",
+                "value_template": null
+              },
+              {
+                "key": "proxy-bypass",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Comma-separated list of patterns to bypass the proxy",
+                "value_template": null
+              },
+              {
+                "key": "proxy-server",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Proxy server address",
+                "value_template": null
+              },
+              {
+                "key": "vision",
+                "kind": "arg",
+                "format": "boolean",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Run server that uses screenshots (Aria snapshots are used by default)",
+                "value_template": null
+              }
+            ],
+            "runtime_arguments": [],
+            "unsupported_reason": "sse package transports require launching and connecting separately, which agent MCP config cannot express",
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "1.0.0",
+        "is_latest": true,
+        "updated_at": "2025-09-09T06:16:24.728253Z",
+        "description": "MCP server for browser use access",
+        "published_at": "2025-09-09T06:16:24.728253Z",
+        "repository_url": "https://github.com/bytedance/UI-TARS-desktop",
+        "schema_version": "2025-09-29",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.coder/coder",
+      "title": "Coder",
+      "description": "Manage Coder workspaces, templates, and cloud development environments",
+      "repository_url": "https://github.com/coder/coder",
+      "version": "2.33.9",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.coder/coder",
+        "title": "Coder",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://{coder_hostname}/api/experimental/mcp/http",
+            "url": "https://{coder_hostname}/api/experimental/mcp/http",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "2.33.9",
+        "is_latest": true,
+        "updated_at": "2026-06-26T16:34:01.921139Z",
+        "description": "Manage Coder workspaces, templates, and cloud development environments",
+        "published_at": "2026-06-26T16:34:01.921139Z",
+        "repository_url": "https://github.com/coder/coder",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.droidrun/mobilerun",
+      "title": null,
+      "description": "Control real Android and iOS devices with LLM agents — tap, swipe, type, automate flows.",
+      "repository_url": "https://github.com/droidrun/mobilerun",
+      "version": "1.0.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.droidrun/mobilerun",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://api.mobilerun.ai/v1/mcp",
+            "url": "https://api.mobilerun.ai/v1/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authorization",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "description": "Bearer token — Mobilerun API key (dr_sk_...), from the app under AI & Agents.",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "1.0.0",
+        "is_latest": true,
+        "updated_at": "2026-07-24T16:41:08.514186Z",
+        "description": "Control real Android and iOS devices with LLM agents — tap, swipe, type, automate flows.",
+        "published_at": "2026-07-24T16:41:08.514186Z",
+        "repository_url": "https://github.com/droidrun/mobilerun",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.firebase/firebase-mcp",
+      "title": null,
+      "description": "Gives AI development tools Firebase-specific capabilities and expertise.",
+      "repository_url": "https://github.com/firebase/firebase-tools",
+      "version": "0.3.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.firebase/firebase-mcp",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:firebase-tools",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "npx",
+            "version": "14.27.0",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "firebase-tools",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "mcp"
+              }
+            ],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.3.0",
+        "is_latest": true,
+        "updated_at": "2025-12-04T17:56:29.057916Z",
+        "description": "Gives AI development tools Firebase-specific capabilities and expertise.",
+        "published_at": "2025-12-04T17:56:29.057916Z",
+        "repository_url": "https://github.com/firebase/firebase-tools",
+        "schema_version": "2025-10-17",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.firecrawl/firecrawl-mcp-server",
+      "title": "Firecrawl MCP Server",
+      "description": "MCP server for Firecrawl — search, scrape, and interact with the web.",
+      "repository_url": "https://github.com/firecrawl/firecrawl-mcp-server.git",
+      "version": "3.23.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.firecrawl/firecrawl-mcp-server",
+        "title": "Firecrawl MCP Server",
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:firecrawl-mcp",
+            "url": null,
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "FIRECRAWL_API_KEY",
+                "kind": "env",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Your API key for Firecrawl",
+                "value_template": null
+              }
+            ],
+            "runtime": "npx",
+            "version": "3.23.0",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "firecrawl-mcp",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "3.23.0",
+        "is_latest": true,
+        "updated_at": "2026-07-29T09:37:25.834355Z",
+        "description": "MCP server for Firecrawl — search, scrape, and interact with the web.",
+        "published_at": "2026-07-29T09:37:25.834355Z",
+        "repository_url": "https://github.com/firecrawl/firecrawl-mcp-server.git",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.github/github-mcp-server",
+      "title": "GitHub",
+      "description": "Connect AI assistants to GitHub - manage repos, issues, PRs, and workflows through natural language.",
+      "repository_url": "https://github.com/github/github-mcp-server",
+      "version": "1.8.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.github/github-mcp-server",
+        "title": "GitHub",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://api.githubcopilot.com/mcp/",
+            "url": "https://api.githubcopilot.com/mcp/",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authorization",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Authorization header with authentication token (PAT or App token)",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "package:stdio:oci:ghcr.io/github/github-mcp-server:1.8.0",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "ghcr.io/github/github-mcp-server:1.8.0",
+            "file_sha256": null,
+            "registry_type": "oci",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [
+              {
+                "key": "-p",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Publish the OAuth callback port to loopback so the in-container login callback is reachable",
+                "value_template": "127.0.0.1:8085:8085"
+              },
+              {
+                "key": "-e",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Fixed OAuth callback port, matching the published port above",
+                "value_template": "GITHUB_OAUTH_CALLBACK_PORT=8085"
+              },
+              {
+                "key": "-e",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "variables": {
+                  "token": {
+                    "format": "string",
+                    "isSecret": true
+                  }
+                },
+                "value_hint": null,
+                "description": "Optional GitHub Personal Access Token. Omit to log in with OAuth on first use.",
+                "value_template": "GITHUB_PERSONAL_ACCESS_TOKEN={token}"
+              }
+            ],
+            "unsupported_reason": "OCI packages need Docker, which agent containers do not have",
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "1.8.0",
+        "is_latest": true,
+        "updated_at": "2026-07-30T13:29:46.13263Z",
+        "description": "Connect AI assistants to GitHub - manage repos, issues, PRs, and workflows through natural language.",
+        "published_at": "2026-07-30T13:29:46.13263Z",
+        "repository_url": "https://github.com/github/github-mcp-server",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.googleapis/mcp-toolbox",
+      "title": "MCP Toolbox for Databases",
+      "description": "MCP Toolbox for Databases enables your agent to connect to your database.",
+      "repository_url": "https://github.com/googleapis/mcp-toolbox",
+      "version": "1.8.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.googleapis/mcp-toolbox",
+        "title": "MCP Toolbox for Databases",
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:http:oci:us-central1-docker.pkg.dev/database-toolbox/toolbox/toolbox:1.8.0",
+            "url": "http://{host}:{port}/mcp",
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "http",
+            "identifier": "us-central1-docker.pkg.dev/database-toolbox/toolbox/toolbox:1.8.0",
+            "file_sha256": null,
+            "registry_type": "oci",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [
+              {
+                "key": "--config",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "default": "tools.yaml",
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "File path specifying the tool configuration.",
+                "value_template": null
+              },
+              {
+                "key": "--configs",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Multiple file paths specifying tool configurations. Files will be merged. Cannot be used with –-config or –-config-folder.",
+                "value_template": null
+              },
+              {
+                "key": "--config-folder",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Directory path containing YAML tool configuration files. All .yaml and .yml files in the directory will be loaded and merged. Cannot be used with –-config or –-configs.",
+                "value_template": null
+              },
+              {
+                "key": "--address",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "variables": {
+                  "host": {
+                    "default": "127.0.0.1",
+                    "isRequired": true,
+                    "description": "ip address"
+                  }
+                },
+                "value_hint": "host",
+                "description": "Address of the interface the server will listen on.",
+                "value_template": "{host}"
+              },
+              {
+                "key": "--port",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "variables": {
+                  "port": {
+                    "default": "5000",
+                    "isRequired": true,
+                    "description": "port"
+                  }
+                },
+                "value_hint": "port",
+                "description": "Port the server will listen on.",
+                "value_template": "{port}"
+              },
+              {
+                "key": "--log-level",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "choices": [
+                  "debug",
+                  "info",
+                  "warn",
+                  "error"
+                ],
+                "default": "info",
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Specify the minimum level logged.",
+                "value_template": null
+              },
+              {
+                "key": "--logging-format",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "choices": [
+                  "standard",
+                  "json"
+                ],
+                "default": "standard",
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Specify logging format to use.",
+                "value_template": null
+              },
+              {
+                "key": "--disable-reload",
+                "kind": "arg",
+                "format": "boolean",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Disables dynamic reloading of config.",
+                "value_template": null
+              },
+              {
+                "key": "--prebuilt",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Use a prebuilt tool configuration by source type.",
+                "value_template": null
+              },
+              {
+                "key": "--stdio",
+                "kind": "arg",
+                "format": "boolean",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Listens via MCP STDIO instead of acting as a remote HTTP server.",
+                "value_template": null
+              },
+              {
+                "key": "--telemetry-gcp",
+                "kind": "arg",
+                "format": "boolean",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Enable exporting directly to Google Cloud Monitoring.",
+                "value_template": null
+              },
+              {
+                "key": "--telemetry-otlp",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Enable exporting using OpenTelemetry Protocol (OTLP) to the specified endpoint (e.g. 'http://127.0.0.1:4318').",
+                "value_template": null
+              },
+              {
+                "key": "--telemetry-service-name",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "default": "toolbox",
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Sets the value of the service.name resource attribute for telemetry data.",
+                "value_template": null
+              },
+              {
+                "key": "--ui",
+                "kind": "arg",
+                "format": "boolean",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Launches the Toolbox UI web server.",
+                "value_template": null
+              },
+              {
+                "key": "--allowed-origins",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "default": "*",
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Specifies a list of origins permitted to access this server.",
+                "value_template": null
+              },
+              {
+                "key": "--help",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Show help for toolbox",
+                "value_template": null
+              },
+              {
+                "key": "--version",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Show version for toolbox",
+                "value_template": null
+              }
+            ],
+            "unsupported_reason": "OCI packages need Docker, which agent containers do not have",
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "1.8.0",
+        "is_latest": true,
+        "updated_at": "2026-07-28T01:52:35.401375Z",
+        "description": "MCP Toolbox for Databases enables your agent to connect to your database.",
+        "published_at": "2026-07-28T01:52:35.401375Z",
+        "repository_url": "https://github.com/googleapis/mcp-toolbox",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.grafana/mcp-grafana",
+      "title": null,
+      "description": "An MCP server giving access to Grafana dashboards, data and more.",
+      "repository_url": "https://github.com/grafana/mcp-grafana",
+      "version": "v1.0.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.grafana/mcp-grafana",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.grafana.com/mcp",
+            "url": "https://mcp.grafana.com/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "X-Grafana-URL",
+                "kind": "header",
+                "format": "string",
+                "secret": false,
+                "required": false,
+                "description": "URL of your Grafana Cloud instance",
+                "placeholder": "https://<instance>.grafana.net",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "package:stdio:oci:docker.io/grafana/mcp-grafana:1.0.0",
+            "url": null,
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "GRAFANA_URL",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "required": true,
+                "description": "URL to your Grafana instance",
+                "value_template": null
+              },
+              {
+                "key": "GRAFANA_SERVICE_ACCOUNT_TOKEN",
+                "kind": "env",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Service account token used to authenticate with your Grafana instance",
+                "value_template": null
+              },
+              {
+                "key": "GRAFANA_USERNAME",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "required": false,
+                "description": "Username to authenticate with your Grafana instance",
+                "value_template": null
+              },
+              {
+                "key": "GRAFANA_PASSWORD",
+                "kind": "env",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "Password to authenticate with your Grafana instance",
+                "value_template": null
+              },
+              {
+                "key": "GRAFANA_ORG_ID",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "required": false,
+                "description": "Organization ID for multi-org support. Can also be set via X-Grafana-Org-Id header in SSE/streamable HTTP transports.",
+                "value_template": null
+              },
+              {
+                "key": "GRAFANA_EXTRA_HEADERS",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "required": false,
+                "description": "JSON object of additional HTTP headers to send with all Grafana API requests",
+                "value_template": null
+              },
+              {
+                "key": "GRAFANA_FORWARD_HEADERS",
+                "kind": "env",
+                "format": "string",
+                "secret": false,
+                "required": false,
+                "description": "Comma-separated list of HTTP header names to forward from the incoming request to Grafana (SSE/streamable-http only). Example: Cookie,X-Session-Id",
+                "value_template": null
+              }
+            ],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "docker.io/grafana/mcp-grafana:1.0.0",
+            "file_sha256": null,
+            "registry_type": "oci",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "OCI packages need Docker, which agent containers do not have",
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "v1.0.0",
+        "is_latest": true,
+        "updated_at": "2026-07-28T15:31:11.876023Z",
+        "description": "An MCP server giving access to Grafana dashboards, data and more.",
+        "published_at": "2026-07-28T15:31:11.876023Z",
+        "repository_url": "https://github.com/grafana/mcp-grafana",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.homeassistant-ai/ha-mcp",
+      "title": null,
+      "description": "Comprehensive Model Context Protocol server for managing Home Assistant through AI assistants.",
+      "repository_url": "https://github.com/homeassistant-ai/ha-mcp.git",
+      "version": "8.0.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.homeassistant-ai/ha-mcp",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:pypi:ha-mcp",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "uvx",
+            "version": "8.0.0",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "ha-mcp",
+            "file_sha256": null,
+            "registry_type": "pypi",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:oci:ghcr.io/homeassistant-ai/ha-mcp:8.0.0",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "ghcr.io/homeassistant-ai/ha-mcp:8.0.0",
+            "file_sha256": null,
+            "registry_type": "oci",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "OCI packages need Docker, which agent containers do not have",
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "8.0.0",
+        "is_latest": true,
+        "updated_at": "2026-08-02T06:32:08.038436Z",
+        "description": "Comprehensive Model Context Protocol server for managing Home Assistant through AI assistants.",
+        "published_at": "2026-08-02T06:32:08.038436Z",
+        "repository_url": "https://github.com/homeassistant-ai/ha-mcp.git",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.keploy/mcp",
+      "title": "Keploy",
+      "description": "End-to-end API testing — generate and run tests from OpenAPI, curl, Postman, or real user traffic.",
+      "repository_url": "https://github.com/keploy/keploy",
+      "version": "1.0.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.keploy/mcp",
+        "title": "Keploy",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://api.keploy.io/client/v1/mcp",
+            "url": "https://api.keploy.io/client/v1/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authorization",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "description": "Keploy API key as a Bearer token. Generate a one-time-viewable key at https://app.keploy.io/settings/api-keys, then paste the full header value including the 'Bearer ' prefix (e.g. 'Bearer kep_...').",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "1.0.0",
+        "is_latest": true,
+        "updated_at": "2026-04-17T19:10:01.598192Z",
+        "description": "End-to-end API testing — generate and run tests from OpenAPI, curl, Postman, or real user traffic.",
+        "published_at": "2026-04-17T19:10:01.598192Z",
+        "repository_url": "https://github.com/keploy/keploy",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.kubeshark/mcp",
+      "title": null,
+      "description": "Real-time Kubernetes network traffic visibility and API analysis for HTTP, gRPC, Redis, Kafka, DNS.",
+      "repository_url": "https://github.com/kubeshark/kubeshark",
+      "version": "53.3.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.kubeshark/mcp",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:mcpb:https://github.com/kubeshark/kubeshark/releases/download/v53.3.0/kubeshark-mcp_darwin_arm64.mcpb",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "https://github.com/kubeshark/kubeshark/releases/download/v53.3.0/kubeshark-mcp_darwin_arm64.mcpb",
+            "file_sha256": "62c3b7e778bd7ddeae0d88508ec3d18b7c28698190ee4fa5eb3c7f4b5a701c80",
+            "registry_type": "mcpb",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "no known runtime for mcpb packages",
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:mcpb:https://github.com/kubeshark/kubeshark/releases/download/v53.3.0/kubeshark-mcp_darwin_amd64.mcpb",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "https://github.com/kubeshark/kubeshark/releases/download/v53.3.0/kubeshark-mcp_darwin_amd64.mcpb",
+            "file_sha256": "df30804004fae4ae31f144d369730f6a46620b5de75e3a7b4e573015c9b9047e",
+            "registry_type": "mcpb",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "no known runtime for mcpb packages",
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:mcpb:https://github.com/kubeshark/kubeshark/releases/download/v53.3.0/kubeshark-mcp_linux_arm64.mcpb",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "https://github.com/kubeshark/kubeshark/releases/download/v53.3.0/kubeshark-mcp_linux_arm64.mcpb",
+            "file_sha256": "fc5d6f7dbcdd9a7b36f436ce1da0d2288f2be8bcff9ef5a4abe3ac1c6e9ca669",
+            "registry_type": "mcpb",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "no known runtime for mcpb packages",
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:mcpb:https://github.com/kubeshark/kubeshark/releases/download/v53.3.0/kubeshark-mcp_linux_amd64.mcpb",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "https://github.com/kubeshark/kubeshark/releases/download/v53.3.0/kubeshark-mcp_linux_amd64.mcpb",
+            "file_sha256": "4e1715b92f2a3c4a63a80e1cc31a51ce43d93b9e0b18bf3968730e5ac678e23e",
+            "registry_type": "mcpb",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "no known runtime for mcpb packages",
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:mcpb:https://github.com/kubeshark/kubeshark/releases/download/v53.3.0/kubeshark-mcp_windows_amd64.mcpb",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "https://github.com/kubeshark/kubeshark/releases/download/v53.3.0/kubeshark-mcp_windows_amd64.mcpb",
+            "file_sha256": "36e9ba1e618638807a2c8aa2bc092293fad6883fe118fbf2501bf033495b2999",
+            "registry_type": "mcpb",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "no known runtime for mcpb packages",
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "53.3.0",
+        "is_latest": true,
+        "updated_at": "2026-05-19T09:18:26.168746Z",
+        "description": "Real-time Kubernetes network traffic visibility and API analysis for HTTP, gRPC, Redis, Kafka, DNS.",
+        "published_at": "2026-05-19T09:18:26.168746Z",
+        "repository_url": "https://github.com/kubeshark/kubeshark",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.metabase/mcp",
+      "title": "Metabase",
+      "description": "Lets AI clients search, explore, query, and visualize data in a Metabase instance.",
+      "repository_url": "https://github.com/metabase/metabase",
+      "version": "0.1.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.metabase/mcp",
+        "title": "Metabase",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://{metabase_host}/api/mcp",
+            "url": "https://{metabase_host}/api/mcp",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "0.1.0",
+        "is_latest": true,
+        "updated_at": "2026-05-06T13:03:37.702206Z",
+        "description": "Lets AI clients search, explore, query, and visualize data in a Metabase instance.",
+        "published_at": "2026-05-06T13:03:37.702206Z",
+        "repository_url": "https://github.com/metabase/metabase",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.microsoft/playwright-mcp",
+      "title": null,
+      "description": "Playwright Tools for MCP",
+      "repository_url": "https://github.com/microsoft/playwright-mcp",
+      "version": "0.0.78",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.microsoft/playwright-mcp",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:@playwright/mcp",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "npx",
+            "version": "0.0.78",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "@playwright/mcp",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.0.78",
+        "is_latest": true,
+        "updated_at": "2026-07-09T19:14:34.945927Z",
+        "description": "Playwright Tools for MCP",
+        "published_at": "2026-07-09T19:14:34.945927Z",
+        "repository_url": "https://github.com/microsoft/playwright-mcp",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.mobile-next/mobile-mcp",
+      "title": null,
+      "description": "MCP server for iOS and Android Mobile Development, Automation and Testing",
+      "repository_url": "https://github.com/mobile-next/mobile-mcp",
+      "version": "1.0.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.mobile-next/mobile-mcp",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:@mobilenext/mobile-mcp",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "npx",
+            "version": "1.0.0",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "@mobilenext/mobile-mcp",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "1.0.0",
+        "is_latest": true,
+        "updated_at": "2026-08-02T16:49:40.95615Z",
+        "description": "MCP server for iOS and Android Mobile Development, Automation and Testing",
+        "published_at": "2026-08-02T16:49:40.95615Z",
+        "repository_url": "https://github.com/mobile-next/mobile-mcp",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.modelscope/funasr-mcp",
+      "title": "FunASR",
+      "description": "Transcribe local audio with FunASR and SenseVoice using private, on-device inference.",
+      "repository_url": "https://github.com/modelscope/FunASR",
+      "version": "0.1.2",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.modelscope/funasr-mcp",
+        "title": "FunASR",
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:oci:ghcr.io/modelscope/funasr-mcp:0.1.2",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "ghcr.io/modelscope/funasr-mcp:0.1.2",
+            "file_sha256": null,
+            "registry_type": "oci",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [
+              {
+                "key": "--mount",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "variables": {
+                  "audio_directory": {
+                    "format": "filepath",
+                    "isRequired": true,
+                    "description": "Host directory containing audio files. Use /audio/<file> when calling the tool.",
+                    "placeholder": "/path/to/audio"
+                  }
+                },
+                "value_hint": null,
+                "description": "Mount the host audio directory read-only at /audio in the container.",
+                "value_template": "type=bind,src={audio_directory},dst=/audio,readonly"
+              },
+              {
+                "key": "--mount",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Persist downloaded ModelScope model files between container runs.",
+                "value_template": "type=volume,src=funasr-mcp-cache,dst=/root/.cache/modelscope"
+              }
+            ],
+            "unsupported_reason": "OCI packages need Docker, which agent containers do not have",
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.1.2",
+        "is_latest": true,
+        "updated_at": "2026-07-26T12:13:35.527546Z",
+        "description": "Transcribe local audio with FunASR and SenseVoice using private, on-device inference.",
+        "published_at": "2026-07-26T12:13:35.527546Z",
+        "repository_url": "https://github.com/modelscope/FunASR",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.netdata/mcp-server",
+      "title": "Netdata",
+      "description": "Real-time infrastructure monitoring with metrics, logs, alerts, and ML-based anomaly detection.",
+      "repository_url": "https://github.com/netdata/netdata",
+      "version": "2.10.4",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.netdata/mcp-server",
+        "title": "Netdata",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://app.netdata.cloud/api/v1/mcp",
+            "url": "https://app.netdata.cloud/api/v1/mcp",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "Authorization",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "variables": {
+                  "NETDATA_CLOUD_API_TOKEN": {
+                    "isSecret": true,
+                    "description": "Netdata Cloud API token (create at app.netdata.cloud > User Settings > API Tokens with scope:mcp)"
+                  }
+                },
+                "description": "Netdata Cloud API token with scope:mcp",
+                "value_template": "Bearer {NETDATA_CLOUD_API_TOKEN}"
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "2.10.4",
+        "is_latest": true,
+        "updated_at": "2026-07-15T14:49:50.76542Z",
+        "description": "Real-time infrastructure monitoring with metrics, logs, alerts, and ML-based anomaly detection.",
+        "published_at": "2026-07-15T14:49:50.76542Z",
+        "repository_url": "https://github.com/netdata/netdata",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.open-metadata/openmetadata-mcp",
+      "title": "OpenMetadata",
+      "description": "Official OpenMetadata MCP: governed context and business semantics for AI assistants and agents.",
+      "repository_url": "https://github.com/open-metadata/OpenMetadata",
+      "version": "1.1.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.open-metadata/openmetadata-mcp",
+        "title": "OpenMetadata",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://{openmetadata_host}/mcp",
+            "url": "https://{openmetadata_host}/mcp",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "1.1.0",
+        "is_latest": true,
+        "updated_at": "2026-05-08T08:22:27.266917Z",
+        "description": "Official OpenMetadata MCP: governed context and business semantics for AI assistants and agents.",
+        "published_at": "2026-05-08T08:22:27.266917Z",
+        "repository_url": "https://github.com/open-metadata/OpenMetadata",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.oraios/serena",
+      "title": "Serena MCP: the IDE for your agent",
+      "description": "A powerful toolkit for coding, providing semantic retrieval and editing capabilities.",
+      "repository_url": "https://github.com/oraios/serena",
+      "version": "1.5.3",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.oraios/serena",
+        "title": "Serena MCP: the IDE for your agent",
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:pypi:serena-agent",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "uvx",
+            "version": "1.5.3",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "serena-agent",
+            "file_sha256": null,
+            "registry_type": "pypi",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [
+              {
+                "key": "-p",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "Select the python version",
+                "value_template": "3.13"
+              },
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "start-mcp-server"
+              },
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "--project-from-cwd"
+              },
+              {
+                "key": "--context",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "default": "desktop-app",
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "description": "The name of a markdown file representing Serena's execution context, typically related to the executing client.  Allowed values are: agent, antigravity, chatgpt, claude-code, codex, context.template, copilot-cli, desktop-app, ide, jb-ai-assistant, jb-copilot-plugin, junie, oaicompat-agent, vscode ",
+                "value_template": null
+              }
+            ],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "1.5.3",
+        "is_latest": true,
+        "updated_at": "2026-05-26T19:08:05.780271Z",
+        "description": "A powerful toolkit for coding, providing semantic retrieval and editing capabilities.",
+        "published_at": "2026-05-26T19:08:05.780271Z",
+        "repository_url": "https://github.com/oraios/serena",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.revolist/revogrid-mcp",
+      "title": "RevoGrid DataGrid MCP",
+      "description": "Hosted MCP server for RevoGrid DataGrid docs, examples, feature checks, and migration guidance.",
+      "repository_url": "https://github.com/revolist/revogrid",
+      "version": "1.0.1",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.revolist/revogrid-mcp",
+        "title": "RevoGrid DataGrid MCP",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://mcp.rv-grid.com",
+            "url": "https://mcp.rv-grid.com",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "1.0.1",
+        "is_latest": true,
+        "updated_at": "2026-05-16T19:14:00.254688Z",
+        "description": "Hosted MCP server for RevoGrid DataGrid docs, examples, feature checks, and migration guidance.",
+        "published_at": "2026-05-16T19:14:00.254688Z",
+        "repository_url": "https://github.com/revolist/revogrid",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.screenpipe/screenpipe-mcp",
+      "title": "screenpipe",
+      "description": "Search your local screen recordings, audio transcripts, and computer activity from screenpipe.",
+      "repository_url": "https://github.com/screenpipe/screenpipe",
+      "version": "0.19.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.screenpipe/screenpipe-mcp",
+        "title": "screenpipe",
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:screenpipe-mcp",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "npx",
+            "version": "0.19.0",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "screenpipe-mcp",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.19.0",
+        "is_latest": true,
+        "updated_at": "2026-07-29T22:47:40.156472Z",
+        "description": "Search your local screen recordings, audio transcripts, and computer activity from screenpipe.",
+        "published_at": "2026-07-29T22:47:40.156472Z",
+        "repository_url": "https://github.com/screenpipe/screenpipe",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.t8y2/dbx",
+      "title": null,
+      "description": "Query databases from AI agents using connections configured in DBX.",
+      "repository_url": "https://github.com/t8y2/dbx",
+      "version": "0.1.3",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.t8y2/dbx",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:@dbx-app/mcp-server",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "npx",
+            "version": "0.1.3",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "@dbx-app/mcp-server",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.1.3",
+        "is_latest": true,
+        "updated_at": "2026-05-03T06:58:19.340506Z",
+        "description": "Query databases from AI agents using connections configured in DBX.",
+        "published_at": "2026-05-03T06:58:19.340506Z",
+        "repository_url": "https://github.com/t8y2/dbx",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.tldraw/tldraw",
+      "title": null,
+      "description": "Draw and visually collaborate with your agents on tldraw's canvas.",
+      "repository_url": "https://github.com/tldraw/tldraw",
+      "version": "0.1.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.tldraw/tldraw",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://tldraw-mcp-app.tldraw.workers.dev/mcp",
+            "url": "https://tldraw-mcp-app.tldraw.workers.dev/mcp",
+            "kind": "remote",
+            "inputs": [],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          },
+          {
+            "id": "remote:sse:https://tldraw-mcp-app.tldraw.workers.dev/sse",
+            "url": "https://tldraw-mcp-app.tldraw.workers.dev/sse",
+            "kind": "remote",
+            "inputs": [],
+            "supported": false,
+            "transport": "sse",
+            "unsupported_reason": "the SSE transport is deprecated and cannot be verified from here — add this server by hand if you need it"
+          }
+        ],
+        "version": "0.1.0",
+        "is_latest": true,
+        "updated_at": "2026-03-06T10:01:58.127181Z",
+        "description": "Draw and visually collaborate with your agents on tldraw's canvas.",
+        "published_at": "2026-03-06T10:01:58.127181Z",
+        "repository_url": "https://github.com/tldraw/tldraw",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.tolgee/tolgee",
+      "title": "Tolgee",
+      "description": "Your app's translations in Tolgee: search keys, create translations, trigger machine translation",
+      "repository_url": "https://github.com/tolgee/tolgee-platform",
+      "version": "1.0.0",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.tolgee/tolgee",
+        "title": "Tolgee",
+        "status": "active",
+        "targets": [
+          {
+            "id": "remote:http:https://app.tolgee.io/mcp/developer",
+            "url": "https://app.tolgee.io/mcp/developer",
+            "kind": "remote",
+            "inputs": [
+              {
+                "key": "X-API-Key",
+                "kind": "header",
+                "format": "string",
+                "secret": true,
+                "required": true,
+                "description": "Tolgee Personal Access Token (tgpat_...) or Project API Key (tgpak_...)",
+                "value_template": null
+              }
+            ],
+            "supported": true,
+            "transport": "http",
+            "unsupported_reason": null
+          }
+        ],
+        "version": "1.0.0",
+        "is_latest": true,
+        "updated_at": "2026-04-09T18:47:01.137395Z",
+        "description": "Your app's translations in Tolgee: search keys, create translations, trigger machine translation",
+        "published_at": "2026-04-09T18:47:01.137395Z",
+        "repository_url": "https://github.com/tolgee/tolgee-platform",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.txn2/kubefwd",
+      "title": null,
+      "description": "Kubernetes port forwarding for local development with automatic /etc/hosts entries.",
+      "repository_url": "https://github.com/txn2/kubefwd",
+      "version": "1.25.16",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.txn2/kubefwd",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:mcpb:https://github.com/txn2/kubefwd/releases/download/v1.25.16/kubefwd-1.25.16-darwin-arm64.mcpb",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "https://github.com/txn2/kubefwd/releases/download/v1.25.16/kubefwd-1.25.16-darwin-arm64.mcpb",
+            "file_sha256": "e85758e61ed7d103c440228cfade14c237ba5aa4149be86ecb99b73e29aee1b7",
+            "registry_type": "mcpb",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "no known runtime for mcpb packages",
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:mcpb:https://github.com/txn2/kubefwd/releases/download/v1.25.16/kubefwd-1.25.16-darwin-amd64.mcpb",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "https://github.com/txn2/kubefwd/releases/download/v1.25.16/kubefwd-1.25.16-darwin-amd64.mcpb",
+            "file_sha256": "bfb98168988b915a6fe250dad30c67a7baf7aec22de7476632888cfe9ab32079",
+            "registry_type": "mcpb",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "no known runtime for mcpb packages",
+            "runtime_prefix_args": []
+          },
+          {
+            "id": "package:stdio:mcpb:https://github.com/txn2/kubefwd/releases/download/v1.25.16/kubefwd-1.25.16-windows-amd64.mcpb",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": null,
+            "version": null,
+            "supported": false,
+            "transport": "stdio",
+            "identifier": "https://github.com/txn2/kubefwd/releases/download/v1.25.16/kubefwd-1.25.16-windows-amd64.mcpb",
+            "file_sha256": "2d1f7717c6db7e01acad27cb3e9c5f903d9dadc6c80371234dde3194da59191e",
+            "registry_type": "mcpb",
+            "version_pinned": false,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": "no known runtime for mcpb packages",
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "1.25.16",
+        "is_latest": true,
+        "updated_at": "2026-06-20T01:50:49.226358Z",
+        "description": "Kubernetes port forwarding for local development with automatic /etc/hosts entries.",
+        "published_at": "2026-06-20T01:50:49.226358Z",
+        "repository_url": "https://github.com/txn2/kubefwd",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.upstash/context7",
+      "title": "Context7",
+      "description": "Up-to-date code docs for any prompt",
+      "repository_url": "https://github.com/upstash/context7",
+      "version": "1.0.31",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.upstash/context7",
+        "title": "Context7",
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:@upstash/context7-mcp",
+            "url": null,
+            "kind": "package",
+            "inputs": [
+              {
+                "key": "CONTEXT7_API_KEY",
+                "kind": "env",
+                "format": "string",
+                "secret": true,
+                "required": false,
+                "description": "API key for authentication",
+                "value_template": null
+              }
+            ],
+            "runtime": "npx",
+            "version": "1.0.31",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "@upstash/context7-mcp",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "1.0.31",
+        "is_latest": true,
+        "updated_at": "2025-11-28T12:23:38.345348Z",
+        "description": "Up-to-date code docs for any prompt",
+        "published_at": "2025-11-28T12:23:38.345348Z",
+        "repository_url": "https://github.com/upstash/context7",
+        "schema_version": "2025-10-17",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.github.wonderwhy-er/desktop-commander",
+      "title": "Desktop Commander",
+      "description": "MCP server for terminal commands, file operations, and process management",
+      "repository_url": "https://github.com/wonderwhy-er/DesktopCommanderMCP",
+      "version": "0.2.44",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.github.wonderwhy-er/desktop-commander",
+        "title": "Desktop Commander",
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:@wonderwhy-er/desktop-commander",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "npx",
+            "version": "0.2.44",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "@wonderwhy-er/desktop-commander",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "0.2.44",
+        "is_latest": true,
+        "updated_at": "2026-07-09T20:04:18.853383Z",
+        "description": "MCP server for terminal commands, file operations, and process management",
+        "published_at": "2026-07-09T20:04:18.853383Z",
+        "repository_url": "https://github.com/wonderwhy-er/DesktopCommanderMCP",
+        "schema_version": "2025-12-11",
+        "normalizer_version": 3
+      }
+    },
+    {
+      "name": "io.snyk/mcp",
+      "title": null,
+      "description": "Easily find and fix security issues in your applications leveraging Snyk platform capabilities.",
+      "repository_url": "https://github.com/snyk/studio-mcp",
+      "version": "1.1304.2",
+      "status": "active",
+      "is_latest": true,
+      "bulk_publisher": false,
+      "normalizer_version": "3",
+      "manifest": {
+        "name": "io.snyk/mcp",
+        "title": null,
+        "status": "active",
+        "targets": [
+          {
+            "id": "package:stdio:npm:snyk",
+            "url": null,
+            "kind": "package",
+            "inputs": [],
+            "runtime": "npx",
+            "version": "1.1304.2",
+            "supported": true,
+            "transport": "stdio",
+            "identifier": "snyk",
+            "file_sha256": null,
+            "registry_type": "npm",
+            "version_pinned": true,
+            "package_arguments": [
+              {
+                "key": null,
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "positional",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "mcp"
+              },
+              {
+                "key": "-t",
+                "kind": "arg",
+                "format": "string",
+                "secret": false,
+                "arg_type": "named",
+                "repeated": false,
+                "required": false,
+                "value_hint": null,
+                "value_template": "stdio"
+              }
+            ],
+            "runtime_arguments": [],
+            "unsupported_reason": null,
+            "runtime_prefix_args": []
+          }
+        ],
+        "version": "1.1304.2",
+        "is_latest": true,
+        "updated_at": "2026-05-06T18:44:18.118349Z",
+        "description": "Easily find and fix security issues in your applications leveraging Snyk platform capabilities.",
+        "published_at": "2026-05-06T18:44:18.118349Z",
+        "repository_url": "https://github.com/snyk/studio-mcp",
+        "schema_version": "2025-09-16",
+        "normalizer_version": 3
+      }
+    }
+  ]
+}

--- a/db/seeds/catalog/skills.json
+++ b/db/seeds/catalog/skills.json
@@ -1,0 +1,336 @@
+{
+  "generated_at": "2026-08-06T18:28:22Z",
+  "count": 33,
+  "entries": [
+    {
+      "registry_id": "anthropics/skills/algorithmic-art",
+      "source": "anthropics/skills",
+      "slug": "algorithmic-art",
+      "title": "algorithmic-art",
+      "description": "Creating algorithmic art using p5.js with seeded randomness and interactive parameter exploration. Use this when users request creating art using code, generative art, algorithmic art, flow fields, or particle systems. Create original algorithmic art rather than copying existing artists' work to avoid copyright violations.",
+      "installs": 71102,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:03 UTC"
+    },
+    {
+      "registry_id": "anthropics/skills/brand-guidelines",
+      "source": "anthropics/skills",
+      "slug": "brand-guidelines",
+      "title": "brand-guidelines",
+      "description": "Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply.",
+      "installs": 72234,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:02 UTC"
+    },
+    {
+      "registry_id": "anthropics/skills/canvas-design",
+      "source": "anthropics/skills",
+      "slug": "canvas-design",
+      "title": "canvas-design",
+      "description": "Create beautiful visual art in .png and .pdf documents using design philosophy. You should use this skill when the user asks to create a poster, piece of art, design, or other static piece. Create original visual designs, never copying existing artists' work to avoid copyright violations.",
+      "installs": 93722,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:31:58 UTC"
+    },
+    {
+      "registry_id": "anthropics/skills/claude-api",
+      "source": "anthropics/skills",
+      "slug": "claude-api",
+      "title": "claude-api",
+      "description": "Reference for the Claude API / Anthropic SDK — model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration.\nTRIGGER — read BEFORE opening the target file; don't skip because it \"looks like a one-liner\" — whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) — never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).\nSKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIR...",
+      "installs": 54667,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:05 UTC"
+    },
+    {
+      "registry_id": "anthropics/skills/doc-coauthoring",
+      "source": "anthropics/skills",
+      "slug": "doc-coauthoring",
+      "title": "doc-coauthoring",
+      "description": "Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar structured content. This workflow helps users efficiently transfer context, refine content through iteration, and verify the doc works for readers. Trigger when user mentions writing docs, creating proposals, drafting specs, or similar documentation tasks.",
+      "installs": 73182,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:02 UTC"
+    },
+    {
+      "registry_id": "anthropics/skills/docx",
+      "source": "anthropics/skills",
+      "slug": "docx",
+      "title": "docx",
+      "description": "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files) or Word templates (.dotx files). Triggers include: any mention of 'Word doc', 'word document', '.docx', '.dotx', or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx or .dotx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, or converting content into a polished Word document. If the user asks for a 'report', 'memo', 'letter', 'template', or similar deliverable as a Word or .docx file, use this skill. Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation.",
+      "installs": 164543,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:31:52 UTC"
+    },
+    {
+      "registry_id": "anthropics/skills/frontend-design",
+      "source": "anthropics/skills",
+      "slug": "frontend-design",
+      "title": "frontend-design",
+      "description": "Guidance for distinctive, intentional visual design when building new UI or reshaping an existing one. Helps with aesthetic direction, typography, and making choices that don't read as templated defaults.",
+      "installs": 735238,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:31:47 UTC"
+    },
+    {
+      "registry_id": "anthropics/skills/mcp-builder",
+      "source": "anthropics/skills",
+      "slug": "mcp-builder",
+      "title": "mcp-builder",
+      "description": "Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).",
+      "installs": 96988,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:31:57 UTC"
+    },
+    {
+      "registry_id": "anthropics/skills/pdf",
+      "source": "anthropics/skills",
+      "slug": "pdf",
+      "title": "pdf",
+      "description": "Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.",
+      "installs": 171320,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:31:51 UTC"
+    },
+    {
+      "registry_id": "anthropics/skills/pptx",
+      "source": "anthropics/skills",
+      "slug": "pptx",
+      "title": "pptx",
+      "description": "Use this skill any time a .pptx or .potx file is involved in any way — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx or .potx file (even if the extracted content will be used elsewhere, like in an email or summary); editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates (.potx), layouts, speaker notes, or comments. Trigger whenever the user mentions \"deck,\" \"slides,\" \"presentation,\" or references a .pptx or .potx filename, regardless of what they plan to do with the content afterward. If a .pptx or .potx file needs to be opened, created, or touched, use this skill.",
+      "installs": 192972,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:31:50 UTC"
+    },
+    {
+      "registry_id": "anthropics/skills/skill-creator",
+      "source": "anthropics/skills",
+      "slug": "skill-creator",
+      "title": "skill-creator",
+      "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.",
+      "installs": 338254,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:31:49 UTC"
+    },
+    {
+      "registry_id": "anthropics/skills/theme-factory",
+      "source": "anthropics/skills",
+      "slug": "theme-factory",
+      "title": "theme-factory",
+      "description": "Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly.",
+      "installs": 73504,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:00 UTC"
+    },
+    {
+      "registry_id": "anthropics/skills/web-artifacts-builder",
+      "source": "anthropics/skills",
+      "slug": "web-artifacts-builder",
+      "title": "web-artifacts-builder",
+      "description": "Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui). Use for complex artifacts requiring state management, routing, or shadcn/ui components - not for simple single-file HTML/JSX artifacts.",
+      "installs": 87896,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:31:59 UTC"
+    },
+    {
+      "registry_id": "anthropics/skills/webapp-testing",
+      "source": "anthropics/skills",
+      "slug": "webapp-testing",
+      "title": "webapp-testing",
+      "description": "Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.",
+      "installs": 126184,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:31:55 UTC"
+    },
+    {
+      "registry_id": "anthropics/skills/xlsx",
+      "source": "anthropics/skills",
+      "slug": "xlsx",
+      "title": "xlsx",
+      "description": "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .xltx, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \"the xlsx in my downloads\") — and wants something done to it or produced from it. Also trigger for cleaning or restructuring messy tabular data files (malformed rows, misplaced headers, junk data) into proper spreadsheets. The deliverable must be a spreadsheet file. Do NOT trigger when the primary deliverable is a Word document, HTML report, standalone Python script, database pipeline, or Google Sheets API integration, even if tabular data is involved.",
+      "installs": 146008,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:31:54 UTC"
+    },
+    {
+      "registry_id": "ast-grep/agent-skill/ast-grep",
+      "source": "ast-grep/agent-skill",
+      "slug": "ast-grep",
+      "title": "ast-grep",
+      "description": "Guide for writing ast-grep rules to perform structural code search and analysis. Use when users need to search codebases using Abstract Syntax Tree (AST) patterns, find specific code structures, or perform complex code queries that go beyond simple text search. This skill should be used when users ask to search for code patterns, find specific language constructs, or locate code with particular structural characteristics.",
+      "installs": 0,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:31:43 UTC"
+    },
+    {
+      "registry_id": "currents-dev/playwright-best-practices-skill/playwright-best-practices",
+      "source": "currents-dev/playwright-best-practices-skill",
+      "slug": "playwright-best-practices",
+      "title": "playwright-best-practices",
+      "description": "Use when writing Playwright tests, fixing flaky tests, debugging failures, implementing Page Object Model, configuring CI/CD, optimizing performance, mocking APIs, handling authentication or OAuth, testing accessibility (axe-core), file uploads/downloads, date/time mocking, WebSockets, geolocation, permissions, multi-tab/popup flows, mobile/responsive layouts, touch gestures, GraphQL, error handling, offline mode, multi-user collaboration, third-party services (payments, email verification), console error monitoring, global setup/teardown, test annotations (skip, fixme, slow), test tags (@smoke, @fast, @critical, filtering with --grep), project dependencies, security testing (XSS, CSRF, auth), performance budgets (Web Vitals, Lighthouse), iframes, component testing, canvas/WebGL, service workers/PWA, test coverage, i18n/localization, Electron apps, or browser extension testing. Covers E2E, component, API, visual, accessibility, security, Electron, and extension testing.",
+      "installs": 67504,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:21 UTC"
+    },
+    {
+      "registry_id": "emilkowalski/skills/emil-design-eng",
+      "source": "emilkowalski/skills",
+      "slug": "emil-design-eng",
+      "title": "emil-design-eng",
+      "description": "This skill encodes Emil Kowalski's philosophy on UI polish, component design, animation decisions, and the invisible details that make software feel great.",
+      "installs": 181121,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:23 UTC"
+    },
+    {
+      "registry_id": "firebase/agent-skills/developing-genkit-python",
+      "source": "firebase/agent-skills",
+      "slug": "developing-genkit-python",
+      "title": "developing-genkit-python",
+      "description": "Develop AI-powered applications using Genkit in Python. Use when the user asks about Genkit, AI agents, flows, or tools in Python, or when encountering Genkit errors, import issues, or API problems.",
+      "installs": 33472,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:17 UTC"
+    },
+    {
+      "registry_id": "leonxlnx/taste-skill/design-taste-frontend",
+      "source": "leonxlnx/taste-skill",
+      "slug": "design-taste-frontend",
+      "title": "design-taste-frontend",
+      "description": "Anti-slop frontend skill for landing pages, portfolios, and redesigns. The agent reads the brief, infers the right design direction, and ships interfaces that do not look templated. Real design systems when applicable, audit-first on redesigns, strict pre-flight check.",
+      "installs": 317124,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:31:46 UTC"
+    },
+    {
+      "registry_id": "mattpocock/skills/grill-with-docs",
+      "source": "mattpocock/skills",
+      "slug": "grill-with-docs",
+      "title": "grill-with-docs",
+      "description": "A relentless interview to sharpen a plan or design, which also creates docs (ADR's and glossary) as we go.",
+      "installs": 626609,
+      "bulk_publisher": true,
+      "registry_synced_at": "2026-08-03 15:32:19 UTC"
+    },
+    {
+      "registry_id": "microsoft/azure-skills/azure-deploy",
+      "source": "microsoft/azure-skills",
+      "slug": "azure-deploy",
+      "title": "azure-deploy",
+      "description": "Execute Azure deployments for ALREADY-PREPARED applications that have existing .azure/deployment-plan.md and infrastructure files. DO NOT use this skill when the user asks to CREATE a new application — use azure-prepare instead. This skill runs azd up, azd deploy, terraform apply, and az deployment commands with built-in error recovery. Requires .azure/deployment-plan.md from azure-prepare and validated status from azure-validate. WHEN: \"run azd up\", \"run azd deploy\", \"execute deployment\", \"push to production\", \"push to cloud\", \"go live\", \"ship it\", \"bicep deploy\", \"terraform apply\", \"publish to Azure\", \"launch on Azure\". DO NOT USE WHEN: \"create and deploy\", \"build and deploy\", \"create a new app\", \"set up infrastructure\", \"create and deploy to Azure using Terraform\" — use azure-prepare for these.",
+      "installs": 496300,
+      "bulk_publisher": true,
+      "registry_synced_at": "2026-08-03 15:32:11 UTC"
+    },
+    {
+      "registry_id": "microsoft/playwright-cli/playwright-cli",
+      "source": "microsoft/playwright-cli",
+      "slug": "playwright-cli",
+      "title": "playwright-cli",
+      "description": "Automate browser interactions, test web pages and work with Playwright tests.",
+      "installs": 107297,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:12 UTC"
+    },
+    {
+      "registry_id": "nextlevelbuilder/ui-ux-pro-max-skill/ui-ux-pro-max",
+      "source": "nextlevelbuilder/ui-ux-pro-max-skill",
+      "slug": "ui-ux-pro-max",
+      "title": "ui-ux-pro-max",
+      "description": "UI/UX design intelligence for web and mobile. Searchable local database with 84 styles, 192 color palettes, 74 font pairings, 192 product types, 98 UX guidelines, 104 icon entries, 16 GSAP motion presets, and 25 chart types across 22 stacks (React, Next.js, Vue, Nuxt, Svelte, Astro, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, Jetpack Compose, Angular, Laravel, JavaFX, WPF, WinUI, Avalonia, Uno Platform, UWP, Three.js, and HTML/CSS). Use when designing, building, or reviewing UI: pages, components, color schemes, typography, layout, accessibility, animation, or data visualization.",
+      "installs": 298164,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:31:44 UTC"
+    },
+    {
+      "registry_id": "obra/superpowers/requesting-code-review",
+      "source": "obra/superpowers",
+      "slug": "requesting-code-review",
+      "title": "requesting-code-review",
+      "description": "Use when completing tasks, implementing major features, or before merging to verify work meets requirements",
+      "installs": 188408,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:13 UTC"
+    },
+    {
+      "registry_id": "obra/superpowers/test-driven-development",
+      "source": "obra/superpowers",
+      "slug": "test-driven-development",
+      "title": "test-driven-development",
+      "description": "Use when implementing any feature or bugfix, before writing implementation code",
+      "installs": 186715,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:14 UTC"
+    },
+    {
+      "registry_id": "shadcn/ui/shadcn",
+      "source": "shadcn/ui",
+      "slug": "shadcn",
+      "title": "shadcn",
+      "description": "Manages shadcn components and projects — adding, searching, fixing, debugging, styling, and composing UI, including chat interfaces. Provides project context, component docs, and usage examples. Applies when working with shadcn/ui, component registries, presets, --preset codes, or any project with a components.json file. Also triggers for \"shadcn init\", \"create an app with --preset\", or \"switch to --preset\".",
+      "installs": 264775,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:18 UTC"
+    },
+    {
+      "registry_id": "supabase/agent-skills/supabase-postgres-best-practices",
+      "source": "supabase/agent-skills",
+      "slug": "supabase-postgres-best-practices",
+      "title": "supabase-postgres-best-practices",
+      "description": "Postgres best practices maintained by Supabase, for Postgres running anywhere. Load this skill BEFORE writing or changing anything that lives in a Postgres database: creating or altering tables and columns (including choosing column types), schema design, migrations and declarative schema files, RLS policies and the tests that verify them, indexes, triggers, database functions, queues and scheduled jobs (pg_cron, pgmq), vector/semantic search (pgvector), and restoring dumps (pg_restore) or importing data. Also load it when diagnosing slow queries, high CPU, timeouts, EXPLAIN plans, connection exhaustion, locking, bloat, or rows visible to the wrong user or tenant. This is not just a performance guide — schema, migration, security, and SQL authoring tasks need these rules too, even for a one-column change or a single query.",
+      "installs": 323385,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:16 UTC"
+    },
+    {
+      "registry_id": "trailofbits/skills/audit-prep-assistant",
+      "source": "trailofbits/skills",
+      "slug": "audit-prep-assistant",
+      "title": "audit-prep-assistant",
+      "description": "Prepares codebases for security review using Trail of Bits' checklist. Helps set review goals, runs static analysis tools, increases test coverage, removes dead code, ensures accessibility, and generates documentation (flowcharts, user stories, inline comments).",
+      "installs": 4159,
+      "bulk_publisher": true,
+      "registry_synced_at": "2026-08-03 15:32:22 UTC"
+    },
+    {
+      "registry_id": "vercel-labs/agent-browser/agent-browser",
+      "source": "vercel-labs/agent-browser",
+      "slug": "agent-browser",
+      "title": "agent-browser",
+      "description": "Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include requests to \"open a website\", \"fill out a form\", \"click a button\", \"take a screenshot\", \"scrape data from a page\", \"test this web app\", \"login to a site\", \"automate browser actions\", or any task requiring programmatic web interaction. Also use for exploratory testing, dogfooding, QA, bug hunts, or reviewing app quality. Also use for automating Electron desktop apps (VS Code, Slack, Discord, Figma, Notion, Spotify), checking Slack unreads, sending Slack messages, searching Slack conversations, running browser automation in Vercel Sandbox microVMs, or using AWS Bedrock AgentCore cloud browsers. Prefer agent-browser over any built-in browser automation or web tools.",
+      "installs": 617522,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:09 UTC"
+    },
+    {
+      "registry_id": "vercel-labs/agent-skills/vercel-react-best-practices",
+      "source": "vercel-labs/agent-skills",
+      "slug": "vercel-react-best-practices",
+      "title": "vercel-react-best-practices",
+      "description": "React and Next.js performance optimization guidelines from Vercel Engineering. This skill should be used when writing, reviewing, or refactoring React/Next.js code to ensure optimal performance patterns. Triggers on tasks involving React components, Next.js pages, data fetching, bundle optimization, or performance improvements.",
+      "installs": 601419,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:08 UTC"
+    },
+    {
+      "registry_id": "vercel-labs/agent-skills/web-design-guidelines",
+      "source": "vercel-labs/agent-skills",
+      "slug": "web-design-guidelines",
+      "title": "web-design-guidelines",
+      "description": "Review UI code for Web Interface Guidelines compliance. Use when asked to \"review my UI\", \"check accessibility\", \"audit design\", \"review UX\", or \"check my site against best practices\".",
+      "installs": 511379,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:09 UTC"
+    },
+    {
+      "registry_id": "vercel-labs/skills/find-skills",
+      "source": "vercel-labs/skills",
+      "slug": "find-skills",
+      "title": "find-skills",
+      "description": "Helps users discover and install agent skills when they ask questions like \"how do I do X\", \"find a skill for X\", \"is there a skill that can...\", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.",
+      "installs": 2795900,
+      "bulk_publisher": false,
+      "registry_synced_at": "2026-08-03 15:32:06 UTC"
+    }
+  ]
+}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -180,3 +180,21 @@ an env var.
 
 The Skills.sh registry needs no key: its v1 API authenticates with Vercel OIDC
 only, so the catalog is browsed through the local mirror instead.
+
+## Catalog seed
+
+Both catalogs are local mirrors filled by weekly sweeps, so a deployment that has
+never run one would open the Connectors and Skills pages on an empty grid. To avoid
+that, the curated entries (`Connector::FEATURED`, `CatalogSkill::FEATURED`) are
+committed to the repo as `db/seeds/catalog/*.json` and loaded at boot — no network,
+no token, no Temporal worker. The sweeps fill in the rest of the catalog later, and
+never overwrite a mirrored row with the committed copy.
+
+- `bin/docker-entrypoint` (the Compose entrypoint) runs `rails catalog:featured:load`
+  after `db:prepare`. Nothing to configure.
+- A deployment that does **not** use that entrypoint — Kubernetes, or any image
+  started straight on `bundle exec puma` — should run `rails catalog:featured:load`
+  wherever it runs migrations. The task is idempotent and safe to run on every deploy.
+- After editing either `FEATURED` list, regenerate the files with
+  `rails catalog:featured:dump` against a database whose mirror is already synced,
+  and commit the result. A test fails if the two drift apart.

--- a/lib/tasks/catalog.rake
+++ b/lib/tasks/catalog.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+namespace :catalog do
+  namespace :featured do
+    desc "Load the committed featured catalog seed (idempotent; never overwrites synced rows)"
+    task load: :environment do
+      result = Catalog::FeaturedSeed.load!
+      puts "Featured catalog seed inserted: #{result}"
+    end
+
+    desc "Regenerate db/seeds/catalog/*.json from this database's mirror (run after editing a FEATURED list)"
+    task dump: :environment do
+      seed = Catalog::FeaturedSeed.new
+      result = seed.dump!
+      puts "Wrote #{seed.connectors_path} and #{seed.skills_path}: #{result}"
+
+      missing_connectors = Connector::FEATURED - Connector.where(name: Connector::FEATURED).pluck(:name)
+      missing_skills = CatalogSkill::FEATURED - CatalogSkill.where(registry_id: CatalogSkill::FEATURED).pluck(:registry_id)
+      # A dump can only carry what this database mirrored. Silently emitting a short
+      # file is how a FEATURED entry disappears from every fresh deployment unnoticed.
+      if missing_connectors.any? || missing_skills.any?
+        warn "WARNING: not mirrored here, so absent from the seed — sync first, or drop them from FEATURED:"
+        missing_connectors.each { |name| warn "  connector #{name}" }
+        missing_skills.each { |id| warn "  skill #{id}" }
+      end
+    end
+  end
+end

--- a/test/services/catalog/featured_seed_test.rb
+++ b/test/services/catalog/featured_seed_test.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+module Catalog
+  # Sociable service tests on the real DB (testing doctrine R5): real models, real
+  # SQL, real files. There is no network boundary here — the point of this seed is
+  # that it needs none.
+  class FeaturedSeedTest < ActiveSupport::TestCase
+    def write_seed(dir, connectors: [], skills: [])
+      dir = Pathname.new(dir)
+      dir.join("connectors.json").write({ entries: connectors }.to_json)
+      dir.join("skills.json").write({ entries: skills }.to_json)
+      dir
+    end
+
+    # The committed files, not a fixture. A FEATURED entry added without re-running
+    # `rake catalog:featured:dump` would otherwise be missing from every fresh
+    # deployment, which is exactly the failure this seed exists to prevent.
+    test "the committed seed covers every curated entry" do
+      result = FeaturedSeed.load!
+
+      assert_equal Connector::FEATURED.size, result.connectors
+      assert_equal CatalogSkill::FEATURED.size, result.skills
+      assert_equal Connector::FEATURED.sort, Connector.pluck(:name).sort
+      assert_equal CatalogSkill::FEATURED.sort, CatalogSkill.pluck(:registry_id).sort
+      assert_equal [ true ], Connector.distinct.pluck(:featured)
+      assert_equal [ true ], CatalogSkill.distinct.pluck(:featured)
+    end
+
+    test "seeded rows are browsable and describable without a sync" do
+      FeaturedSeed.load!
+
+      assert_equal Connector::FEATURED.size, Connector.discoverable.count
+      assert_equal 0, Connector.where(description: nil).count, "a seeded connector card has nothing to render"
+      # Not all of them: a connector whose every target is unsupported is listed anyway
+      # and the UI explains why. Most of the grid has to be actionable, though.
+      assert_operator Connector.select(&:installable?).size, :>, Connector::FEATURED.size * 0.8
+      assert_includes Connector.search("linear"), Connector.find_by(name: "app.linear/linear")
+
+      skill = CatalogSkill.popular.first
+      assert skill.description.present?, "a seeded skill card has nothing to render"
+      refute_predicate skill, :audited?, "a security verdict must not be frozen into the repo"
+    end
+
+    # The load-bearing NULL. ConnectorCatalogSync#watermark resumes from
+    # MAX(registry_updated_at), so a seed carrying real registry timestamps would make
+    # the first sync ask for "everything changed since then" and permanently freeze the
+    # catalog at the seeded rows.
+    test "seeded connectors claim no registry timestamp, so the first sync still walks in full" do
+      FeaturedSeed.load!
+
+      assert_nil Connector.maximum(:registry_updated_at)
+    end
+
+    # Skills invert this: Skills::CatalogSync reads a NULL registry_synced_at as "no
+    # sweep has ever seen this row upstream" and destroys it.
+    test "seeded skills keep the provenance that saves them from the phantom-dropper" do
+      FeaturedSeed.load!
+
+      assert_equal 0, CatalogSkill.where(registry_synced_at: nil).count
+    end
+
+    test "the platform's own demand signal starts at zero" do
+      FeaturedSeed.load!
+
+      assert_equal [ 0 ], Connector.distinct.pluck(:install_count)
+      assert_equal [ 0 ], CatalogSkill.distinct.pluck(:install_count)
+    end
+
+    test "loading twice inserts nothing the second time" do
+      FeaturedSeed.load!
+
+      second = FeaturedSeed.load!
+
+      assert_equal 0, second.connectors
+      assert_equal 0, second.skills
+      assert_equal Connector::FEATURED.size, Connector.count
+      assert_equal CatalogSkill::FEATURED.size, CatalogSkill.count
+    end
+
+    test "a synced row is never downgraded to the committed copy" do
+      name = Connector::FEATURED.first
+      registry_id = CatalogSkill::FEATURED.first
+      synced_at = 1.day.ago
+      connector = create(:connector, name: name, description: "fresh from the registry",
+                         install_count: 7, registry_updated_at: synced_at)
+      skill = create(:catalog_skill, registry_id: registry_id, source: registry_id.rpartition("/").first,
+                     slug: registry_id.rpartition("/").last, description: "fresh from the sweep", installs: 42)
+
+      FeaturedSeed.load!
+
+      assert_equal "fresh from the registry", connector.reload.description
+      assert_equal 7, connector.install_count
+      assert_equal synced_at.to_i, connector.registry_updated_at.to_i
+      assert_equal "fresh from the sweep", skill.reload.description
+      assert_equal 42, skill.installs
+    end
+
+    test "an entry dropped from a FEATURED list is ignored even while it sits in the file" do
+      Dir.mktmpdir do |dir|
+        write_seed(dir,
+                   connectors: [ { name: "io.github.nobody/dropped", title: "Dropped", status: "active",
+                                   is_latest: true, manifest: { "targets" => [] } } ],
+                   skills: [ { registry_id: "nobody/skills/dropped", source: "nobody/skills", slug: "dropped" } ])
+
+        result = FeaturedSeed.load!(dir: dir)
+
+        assert_equal 0, result.connectors
+        assert_equal 0, result.skills
+        assert_equal 0, Connector.count
+      end
+    end
+
+    test "a missing or unreadable seed file leaves the deployment bootable" do
+      Dir.mktmpdir do |dir|
+        assert_equal 0, FeaturedSeed.load!(dir: dir).connectors
+
+        Pathname.new(dir).join("connectors.json").write("{ not json")
+        assert_equal 0, FeaturedSeed.load!(dir: dir).connectors
+      end
+    end
+
+    test "a dump round-trips what a card needs and drops what a deployment must earn" do
+      name = Connector::FEATURED.first
+      registry_id = CatalogSkill::FEATURED.first
+      create(:connector, :package, name: name, title: "Linear", description: "issue tracking",
+             install_count: 9, registry_updated_at: 2.days.ago)
+      create(:catalog_skill, registry_id: registry_id, source: registry_id.rpartition("/").first,
+             slug: registry_id.rpartition("/").last, description: "writes tests", installs: 500,
+             install_count: 3, audit: { "snyk" => { "risk" => "safe" } }, audit_risk: "safe")
+
+      Dir.mktmpdir do |dir|
+        FeaturedSeed.dump!(dir: dir)
+        Connector.delete_all
+        CatalogSkill.delete_all
+
+        FeaturedSeed.load!(dir: dir)
+
+        connector = Connector.sole
+        assert_equal "issue tracking", connector.description
+        assert_equal "npx", connector.manifest.dig("targets", 0, "runtime")
+        assert_equal 0, connector.install_count
+        assert_nil connector.registry_updated_at
+
+        skill = CatalogSkill.sole
+        assert_equal "writes tests", skill.description
+        assert_equal 500, skill.installs
+        assert_equal 0, skill.install_count
+        refute_predicate skill, :audited?
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why

Both catalogs are local mirrors filled by weekly sweeps over someone else's registry (`MCP::ConnectorCatalogSync`, `Skills::CatalogSync`). A deployment that has never run one opens the Connectors and Skills pages on an **empty grid** — and for skills it stays that way for weeks, because descriptions are backfilled from GitHub at 60 requests/hour without a read token. That is the first thing a self-hosted install sees, and fixing it currently means bringing up a Temporal worker and waiting.

It is also unkind to the upstreams: every self-hosted install walking ~19.6k registry entries is load nobody needs to generate for a first impression.

## What

The curated entries both catalogs already rank first (`Connector::FEATURED`, `CatalogSkill::FEATURED`) are committed as JSON and loaded at boot. No network, no token, no worker.

- `Catalog::FeaturedSeed` — `load!` (idempotent `insert_all ... DO NOTHING`) and `dump!` (regenerates the files from a synced mirror).
- `db/seeds/catalog/{connectors,skills}.json` — 64 connectors (195 KB) + 33 skills (24 KB), all described.
- `rake catalog:featured:load` / `catalog:featured:dump`; the load runs from `bin/docker-entrypoint` after `db:prepare`.
- `docs/reference/configuration.md` gains a Catalog seed section, including the note that a deployment not using that entrypoint (Kubernetes, plain puma) must call the task in its migrate step.

A row a sweep has already written is fresher than anything in the repo, so loading **never updates** — it only inserts what is missing.

### What deliberately does not travel

- `install_count` — demand on this platform; a fresh deployment has none, and shipping someone else's would corrupt the ranking's only first-party signal.
- `featured` — derived from the constants at load time, so the curated list stays the single source of truth.
- `audit` / `audit_risk` — a security verdict frozen in git would keep asserting "safe" months after the providers changed their minds. Absent reads as "nobody audited this", a state `CatalogSkill` already distinguishes from safe.

This is a **display** seed, not an install path: `MCP::ConnectorInstaller` re-fetches the manifest from the registry at install time and falls back to the mirrored copy only when the registry is unreachable.

## The trap this had to avoid

Seeded connectors carry `registry_updated_at: nil` on purpose. `ConnectorCatalogSync#watermark` resumes from `MAX(registry_updated_at)`, so a seed claiming a recent registry timestamp would make the very first sync ask for "everything changed since then", mirror nothing, and **freeze the catalog at the seeded rows permanently**.

Skills invert this and keep `registry_synced_at`: it is not a watermark (the skills sweep has none), and `Skills::CatalogSync#drop_unresolvable_seed` destroys rows with a NULL there, reading it as "no sweep has ever seen this row upstream". Both directions have their own test.

## Tests

`test/services/catalog/featured_seed_test.rb` — sociable, real DB, real files, no network:

- the committed files cover every `FEATURED` id (catches "added to the constant, forgot to re-dump")
- seeded rows are browsable, describable and searchable; >80% installable (a connector whose every target is unsupported is listed anyway — the UI explains why)
- the two provenance rules above
- idempotency; a synced row is never downgraded; an entry dropped from `FEATURED` is ignored even while it sits in the file
- a missing or unreadable seed file leaves the deployment bootable
- `dump!` round-trip keeps what a card needs and drops what a deployment must earn

`docker compose exec -T web make check_all` green: rails-test, rubocop, brakeman, system-test, vite-build, eslint, typescript, fe-test. Coverage 90.55% backend / 78.15% frontend.

## Not in this PR

Shipping the *whole* mirror (~3.8 MB gzipped for 19.8k connectors + 14.6k skills) as a weekly release artifact that fresh installs bootstrap from. That needs a redistribution-rights check against the skills.sh terms and artifact attestation on the download first; the curated seed is the part that needs neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
