### PR TITLE
fix: size the Active Record pool from Puma's thread budget

### DIFF
--- a/app/services/tools/mcp_request_handler.rb
+++ b/app/services/tools/mcp_request_handler.rb
@@ -52,9 +52,15 @@ module Tools
     end
 
     def tool_classes
-      entitled = session.available_tools(ctx: ctx)
-      available = entitled.select { |t| t.available?(ctx) && digest_intact?(t) }.sort_by(&:name)
+      available = entitled_tools.select { |t| t.available?(ctx) && digest_intact?(t) }.sort_by(&:name)
       available.map { |row| define_tool(row) }
+    end
+
+    # Memoized per request: a tools/call resolves the entitlement twice (the
+    # shim, then the server build), and holding a pooled connection for a
+    # duplicate query is what tips a busy MCP pod into checkout timeouts.
+    def entitled_tools
+      @entitled_tools ||= session.available_tools(ctx: ctx)
     end
 
     # Fail closed on tampered custom definitions: a tools row written past the
@@ -116,7 +122,7 @@ module Tools
       return nil unless body.is_a?(Hash) && body["method"] == "tools/call"
 
       requested = body.dig("params", "name").to_s
-      tool = session.available_tools(ctx: ctx).detect { |t| t.name == requested }
+      tool = entitled_tools.detect { |t| t.name == requested }
       return nil if tool.nil? || tool.available?(ctx)
 
       result = { exit_code: 1, stdout: "", stderr: tool.unavailable_message }

--- a/config/puma_mcp.rb
+++ b/config/puma_mcp.rb
@@ -1,7 +1,11 @@
 # Puma configuration for the dedicated MCP (Model Context Protocol) server.
 # Runs on a separate port to isolate MCP traffic from the main web server.
 
-max_threads_count = ENV.fetch("MCP_MAX_THREADS", 10)
+# Falls back to RAILS_MAX_THREADS, not to a private default: the Active Record
+# pool is sized from RAILS_MAX_THREADS (config/settings.yml), so a separate
+# default here silently oversubscribes the pool and every thread past the pool
+# size dies on ConnectionTimeoutError after the 5s checkout wait.
+max_threads_count = ENV.fetch("MCP_MAX_THREADS") { ENV.fetch("RAILS_MAX_THREADS", 10) }
 min_threads_count = ENV.fetch("MCP_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,7 +28,12 @@ database:
   name: <%= ENV['DB_NAME'] %>
   host: <%= ENV['DB_HOST'] || "127.0.0.1" %>
   port: <%= ENV['DB_PORT'] || 5432 %>
-  pool: <%= ENV['RAILS_MAX_THREADS'] || 5 %>
+  # One request thread checks out one connection, so the pool must cover the
+  # whole Puma thread budget (RAILS_MAX_THREADS, see config/puma.rb and
+  # config/puma_mcp.rb) plus headroom for checkouts that are not request-bound
+  # — an equal pool leaves none, and the overflow waits out the 5s checkout
+  # timeout and raises ConnectionTimeoutError. DB_POOL overrides outright.
+  pool: <%= ENV['DB_POOL'] || (ENV['RAILS_MAX_THREADS'] || 5).to_i + 3 %>
   username: <%= ENV['DB_USERNAME'] || "postgres" %>
   password: <%= ENV['DB_PASSWORD'] || "" %>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,10 @@ x-web-environment: &web-environment
   GEM_PATH: /bundle_cache
   COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
   RAILS_LOG_TO_STDOUT: 'true'
+  # Puma's thread budget and the value config/settings.yml sizes the Active
+  # Record pool from — matches the Puma default so dev doesn't run 10 request
+  # threads against a 5-connection pool. The worker overrides it.
+  RAILS_MAX_THREADS: '10'
   PORT: 4000
   REDIS_URL: redis://redis:6379/1
 


### PR DESCRIPTION
## What broke

`MCPController#handle` was raising `ActiveRecord::ConnectionTimeoutError` in production:

> could not obtain a connection from the pool within 5.000 seconds (waited 5.007 seconds)

Not a leak. The pool was structurally smaller than the number of request threads competing for it.

| | value | source |
|---|---|---|
| MCP Puma threads | **10** | `config/puma_mcp.rb` — private `MCP_MAX_THREADS` default |
| Active Record pool | **5** | `config/settings.yml` — `RAILS_MAX_THREADS` or 5, and that variable is set in no environment |
| checkout timeout | 5s (default) | matches the `waited 5.007 seconds` in the trace |

Five of the ten threads could never hold a connection and died on the checkout timeout. `config/puma.rb` had the same 10-vs-5 mismatch; the MCP endpoint just surfaced it first, because agent containers drive it far more concurrently than the web workload.

## The fix

- `MCP_MAX_THREADS` now falls back to `RAILS_MAX_THREADS` instead of its own default, so one knob drives both the thread count and the pool and the two cannot drift apart.
- The pool adds headroom on top of that budget for checkouts that are not request-bound — an equal pool leaves none. `DB_POOL` overrides outright.
- `MCPRequestHandler` memoizes the session entitlement. A `tools/call` resolved it twice (the unavailable-tool shim, then the server build), and holding a pooled connection for a duplicate query is what tips a busy MCP pod over the edge.
- `docker-compose.yml` sets the variable so dev matches: locally the web container also ran 10 Puma threads against a pool of 5.

## Deploy order

This needs its infra counterpart — palad-ai/aixle-infra#23 sets `RAILS_MAX_THREADS` on the `web` and `mcp` workloads. Effect of each half:

| | pool | threads | |
|---|---|---|---|
| today | 5 | 10 | 5 threads starve |
| infra only, current image | 10 | 10 | starvation gone, no headroom |
| this PR only | 8 | 10 | still 2 short |
| both | 13 | 10 | correct |

**The infra change can ship first and already stops the incident** — under the current image the old formula reads `RAILS_MAX_THREADS` directly, so it yields a pool of 10 against 10 threads without waiting for an image build.

Connection budget at full autoscale (web 6 + mcp 6 replicas) is ~156 against the ~450 `max_connections` of `db.t4g.medium`. The Temporal worker is deliberately untouched — it derives its own activity budget from the same variable, and the infra change keeps the variable off the shared configMap so worker concurrency does not change.

## Testing

`docker compose exec -T web make check_all` — green (rails-test, rubocop, brakeman, system-test, eslint, typescript, fe-test, vite-build). Existing `test/integration/mcp_controller_test.rb` covers both memoized paths: the shim (entitled-but-unavailable) and the server build (available).

No regression test added: the drift was *between* this repo and the infra repo, and a test here cannot see helm values. The structural guard is the single env key now feeding both threads and pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
