### PR TITLE
chore(bmad): bump BMAD Method to 6.10.0

### DIFF
--- a/app/services/bmad_method_injector.rb
+++ b/app/services/bmad_method_injector.rb
@@ -41,9 +41,11 @@ class BmadMethodInjector
 
   # Pinned to match _bmad/_config/manifest.yaml; bumping requires re-validating
   # skill target directories (cursor/codex/gemini moved to .agents/skills in 6.6.0).
-  BMAD_METHOD_VERSION = "6.6.0"
+  # Since 6.10.0 bmb/cis/wds are external modules fetched from GitHub during
+  # install, so the container needs outbound access to github.com.
+  BMAD_METHOD_VERSION = "6.10.0"
 
-  INSTALL_TIMEOUT = 180
+  INSTALL_TIMEOUT = 300
 
   class InstallError < StandardError; end
 

--- a/test/services/bmad_e2e_all_runtimes_test.rb
+++ b/test/services/bmad_e2e_all_runtimes_test.rb
@@ -8,7 +8,7 @@ require "shellwords"
 # Validates the full BMAD pipeline for each of the 4 agent runtimes:
 #   session create → BmadMethodInjector.inject! → context assembly → filesystem verification
 #
-# Agent type → BMAD tool flag → skill directory mapping (bmad-method 6.6.0):
+# Agent type → BMAD tool flag → skill directory mapping (bmad-method 6.10.0):
 #   cursor_cli  → --tools cursor       → /workspace/.agents/skills/
 #   claude_code → --tools claude-code  → /workspace/.claude/skills/
 #   codex       → --tools codex        → /workspace/.agents/skills/

--- a/test/services/bmad_method_injector_test.rb
+++ b/test/services/bmad_method_injector_test.rb
@@ -474,8 +474,8 @@ class BmadMethodInjectorTest < ActiveSupport::TestCase
   # INSTALL_TIMEOUT constant
   # ====================================================================
 
-  test "INSTALL_TIMEOUT is 180 seconds" do
-    assert_equal 180, BmadMethodInjector::INSTALL_TIMEOUT
+  test "INSTALL_TIMEOUT is 300 seconds" do
+    assert_equal 300, BmadMethodInjector::INSTALL_TIMEOUT
   end
 
   private


### PR DESCRIPTION
## What

Bumps the pinned `bmad-method` version installed into agent containers from **6.6.0** to **6.10.0**, and raises `INSTALL_TIMEOUT` from 180s to 300s.

## Why

Since 6.10.0, `bmb`, `cis` and `wds` are **external** modules the installer fetches from GitHub rather than built-ins shipped in the npm tarball. That makes install slower and dependent on outbound `github.com` access from the agent container, so the timeout gets headroom for slower networks.

## Verification

Ran the injector's exact command inside the real `aixle/claude-code:latest` image:

```
npx -y bmad-method@6.10.0 install --directory /workspace --tools claude-code \
  --modules bmm,bmb,cis,wds --user-name ... --communication-language Russian \
  --document-output-language English --output-folder outputs --yes
```

- exit 0 in ~62s
- modules installed: core 6.10.0, bmm 6.10.0, bmb v2.1.0, cis v0.2.1, wds v0.4.3
- **76 skills → `/workspace/.claude/skills`**, every `SKILL.md` has valid `name:`/`description:` frontmatter
- paths the app depends on unchanged: `_bmad/core/config.yaml` (context builder) and `_bmad/_config/manifest.yaml`
- `--list-tools` confirms cursor/codex/gemini still target `.agents/skills`, so `BMAD_HIDDEN_PATHS` is still correct
- all CLI flags we pass still exist in 6.10.0; the agent image already has `uv`/`uvx`, which newer BMAD workflows expect

`docker compose exec -T web make check_all` — all green (rails-test, rubocop, brakeman, system-test, eslint, typescript, fe-test, vite-build).

## Not covered

The in-app browser run (log in, start a session with BMAD enabled, invoke a skill in the terminal) was **not** performed — the local Playwright browser profile was locked by a stale Chrome instance. Container-level install and the skill payload are verified, but end-to-end skill invocation through a live session still wants a manual smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
