### PR TITLE
fix(sessions): stop losing session outputs with long file names

### DIFF
--- a/app/services/container_runtime/base_runtime.rb
+++ b/app/services/container_runtime/base_runtime.rb
@@ -120,14 +120,30 @@ module ContainerRuntime
       tar_io
     end
 
-    def extract_from_tar(tar_data, filename)
+    # Both runtimes tar up ONE path per read_file, so the first regular-file entry
+    # is the answer; `filename` is only a preference for a multi-entry tar, never a
+    # filter. Filtering on it silently lost every file whose header name overflowed
+    # tar's 100-byte name field: GNU/busybox tar (k8s `tar -cf -`, which tars the
+    # full path) then emits a `././@LongLink` entry and truncates the real entry's
+    # name, while Docker's Go writer emits a PAX `x` header and garbles it — either
+    # way the basename stopped matching and read_file returned nil. Cyrillic names
+    # (2 bytes/char) overflow at ~40 characters, so human-titled outputs vanished.
+    def extract_from_tar(tar_data, filename = nil)
+      first_file = nil
+
       io = StringIO.new(tar_data)
       Gem::Package::TarReader.new(io) do |tar|
         tar.each do |entry|
-          return entry.read if entry.file? && File.basename(entry.full_name) == filename
+          # Long-name (`L`) and PAX (`x`, `g`) headers are metadata, not content.
+          next unless entry.file?
+
+          return entry.read if filename.present? && File.basename(entry.full_name) == filename
+
+          first_file ||= entry.read
         end
       end
-      nil
+
+      first_file
     rescue StandardError => e
       Rails.logger.warn("[#{self.class.name}] extract_from_tar failed: #{e.message}")
       nil

--- a/app/services/container_strategies/agent_session_strategy.rb
+++ b/app/services/container_strategies/agent_session_strategy.rb
@@ -225,7 +225,12 @@ module ContainerStrategies
         relative = file_path.sub("#{output_dir}/", "")
         filename = File.basename(relative)
         content = read_file_from_container(container, file_path)
-        next if content.blank?
+        if content.blank?
+          # A dropped output used to leave no trace at all — the asset simply never
+          # appeared. Log it, so an unreadable file is distinguishable from an empty one.
+          Rails.logger.warn("[AgentSession] Skipped output #{file_path}: #{content.nil? ? 'unreadable' : 'empty'}")
+          next
+        end
 
         tmpfile = Tempfile.new([ "output-", File.extname(filename) ])
         tmpfile.binmode

--- a/app/services/container_strategies/workflow_step_strategy.rb
+++ b/app/services/container_strategies/workflow_step_strategy.rb
@@ -110,7 +110,10 @@ module ContainerStrategies
       files.each do |file_path|
         relative = file_path.sub("#{output_dir}/", "")
         content = read_file_from_container(container, file_path)
-        next if content.blank?
+        if content.blank?
+          Rails.logger.warn("[WorkflowStepStrategy] Skipped output #{file_path}: #{content.nil? ? 'unreadable' : 'empty'}")
+          next
+        end
 
         tmpfile = Tempfile.new([ "wf_output_", File.extname(relative) ])
         tmpfile.binmode

--- a/app/services/session_context_service.rb
+++ b/app/services/session_context_service.rb
@@ -492,7 +492,11 @@ class SessionContextService
       ids = session.repository_ids
       return if ids.blank?
 
-      repos = Repository.where(id: ids).includes(:integration).to_a
+      # Ordered: an unordered `where` lets Postgres hand back rows in whatever order
+      # it likes, which reshuffles the `repositories:` list sent to GitHub for the
+      # group token and the order repositories clone in — a difference that shows up
+      # as a test failing only on some runs.
+      repos = Repository.where(id: ids).order(:id).includes(:integration).to_a
       return if repos.empty?
 
       adapter = adapter_for(session)

--- a/test/services/container_runtime/base_runtime_test.rb
+++ b/test/services/container_runtime/base_runtime_test.rb
@@ -71,5 +71,79 @@ module ContainerRuntime
     test "container_logs raises NotImplementedError" do
       assert_raises(NotImplementedError) { @runtime.container_logs("id") }
     end
+
+    # -- Tar extraction --
+    #
+    # A tar header's name field is 100 bytes. Longer paths are carried out-of-band:
+    # GNU/busybox tar (what `KubernetesRuntime#copy_from` runs) writes a `L`
+    # long-name entry, Docker's Go writer a PAX `x` header — and in both cases the
+    # following real entry's name is truncated/garbled. Matching entries on the
+    # requested basename therefore dropped every long-named file, read_file returned
+    # nil, and session outputs silently never became assets (Cyrillic titles at 2
+    # bytes/char overflow at ~40 characters).
+
+    test "extract_from_tar returns the entry when the name fits the tar header" do
+      tar = tar_bytes([ [ "workspace/outputs/report.md", "SHORT" ] ])
+
+      assert_equal "SHORT", @runtime.send(:extract_from_tar, tar, "report.md")
+    end
+
+    test "extract_from_tar reads a GNU long-name entry whose real header name is truncated" do
+      long_path = "workspace/outputs/report dir/#{'a' * 80} final report.md"
+      tar = tar_bytes([
+        [ "././@LongLink", "#{long_path}\0", "L" ],
+        [ long_path.byteslice(0, 100), "LONG" ]
+      ])
+
+      assert_equal "LONG", @runtime.send(:extract_from_tar, tar, File.basename(long_path))
+    end
+
+    test "extract_from_tar reads a PAX-prefixed entry with a garbled real header name" do
+      tar = tar_bytes([
+        [ "PaxHeaders.0/report", "30 path=workspace/outputs/x.md\n", "x" ],
+        [ "        7  2026   .md", "PAX" ]
+      ])
+
+      assert_equal "PAX", @runtime.send(:extract_from_tar, tar, "Итоговый отчет.md")
+    end
+
+    test "extract_from_tar prefers the requested basename over the first entry" do
+      tar = tar_bytes([
+        [ "workspace/outputs/other.md", "OTHER" ],
+        [ "workspace/outputs/wanted.md", "WANTED" ]
+      ])
+
+      assert_equal "WANTED", @runtime.send(:extract_from_tar, tar, "wanted.md")
+    end
+
+    test "extract_from_tar returns nil when the tar carries no file entry" do
+      tar = tar_bytes([ [ "workspace/outputs/", "", "5" ] ])
+
+      assert_nil @runtime.send(:extract_from_tar, tar, "report.md")
+    end
+
+    private
+
+    # Builds raw tar bytes entry by entry so each header layout (regular file, GNU
+    # `L` long name, PAX `x`) is spelled out in the test rather than depending on
+    # whichever tar binary the environment ships.
+    def tar_bytes(entries)
+      buffer = +"".b
+
+      entries.each do |name, content, typeflag|
+        body = content.to_s.b
+        header = Gem::Package::TarHeader.new(
+          name: name, mode: 0o644, size: body.bytesize, prefix: "",
+          uid: 0, gid: 0, typeflag: (typeflag || "0"), mtime: Time.now
+        )
+        buffer << header.to_s
+        buffer << body
+        padding = (512 - (body.bytesize % 512)) % 512
+        buffer << ("\0" * padding)
+      end
+
+      buffer << ("\0" * 1024)
+      buffer
+    end
   end
 end

--- a/test/services/container_runtime/docker_runtime_test.rb
+++ b/test/services/container_runtime/docker_runtime_test.rb
@@ -184,10 +184,21 @@ module ContainerRuntime
       assert_equal "file body", @runtime.read_file("cid", "/tmp/hello.txt")
     end
 
-    test "read_file returns nil when the requested file is absent from the tar" do
-      tar_bytes = build_test_tar("tmp/other.txt", "unrelated")
+    # archive_out tars the requested path, so its single file entry IS the answer even
+    # when the header name doesn't match: past 100 bytes tar truncates that name (see
+    # BaseRuntime#extract_from_tar), and trusting it dropped long-named session outputs.
+    test "read_file returns the archive's file entry even when the header name differs" do
+      tar_bytes = build_test_tar("tmp/truncated-by-tar", "file body")
       container_mock = mock("container")
       container_mock.stubs(:archive_out).with("/tmp/hello.txt").yields(tar_bytes)
+      Docker::Container.stubs(:get).with("cid").returns(container_mock)
+
+      assert_equal "file body", @runtime.read_file("cid", "/tmp/hello.txt")
+    end
+
+    test "read_file returns nil when the tar carries no file entry" do
+      container_mock = mock("container")
+      container_mock.stubs(:archive_out).with("/tmp/hello.txt").yields(build_empty_tar)
       Docker::Container.stubs(:get).with("cid").returns(container_mock)
 
       assert_nil @runtime.read_file("cid", "/tmp/hello.txt")
@@ -282,6 +293,13 @@ module ContainerRuntime
       Gem::Package::TarWriter.new(io) do |tar|
         tar.add_file_simple(filename, 0o644, content.bytesize) { |f| f.write(content) }
       end
+      io.string
+    end
+
+    def build_empty_tar
+      io = StringIO.new
+      io.binmode
+      Gem::Package::TarWriter.new(io) { |tar| tar.mkdir("tmp", 0o755) }
       io.string
     end
 


### PR DESCRIPTION
## Problem

A session could finish with an empty Assets list even though the agent wrote files to `/workspace/outputs`. The files were found by `find`, read back, and then silently dropped — no log line, nothing to grep for.

`read_file` tars the requested path and picked the entry out of the archive by comparing `File.basename(entry.full_name)` against the requested basename. A tar header's name field is **100 bytes**; past that the name travels out-of-band:

- GNU/busybox tar — what `KubernetesRuntime#copy_from` runs, and prod is `CONTAINER_RUNTIME=k8s` — emits a `././@LongLink` entry and truncates the real entry's name.
- Docker's Go tar writer emits a PAX `x` header and garbles it.

Either way the comparison failed, `extract_from_tar` returned `nil`, and `collect_outputs` hit `next if content.blank?`.

On k8s the whole path is tarred, so the budget is ~82 bytes after `workspace/outputs/`. A Cyrillic title (2 bytes per character) overflows that at ~40 characters — which is why human-named deliverables vanished while machine-named ones came through. Reproduced against the real busybox tar in the container:

```
PATH bytes=108 workspace/outputs/report dir/Final report on the results of the security audit performed on 7 August 2026.md
  entry typeflag=L file?=false full_name="././@LongLink"
  entry typeflag=0 file?=true  full_name="workspace/outputs/report dir/Final report on the results of the security audit performed on 7 August"
  extract_from_tar => nil
```

## Fix

Both runtimes tar exactly one path per read, so the first regular-file entry **is** the answer — the header name never needed to be trusted. The requested basename stays as a preference so a multi-entry archive still resolves correctly; `L`/`x`/`g` metadata entries are skipped via `entry.file?`.

Same real busybox tar, after the fix:

```
bytes=108 => "LONG"
bytes=138 => "CYR"     # Cyrillic path
```

Both `collect_outputs` paths now log the skip and separate `unreadable` from `empty` — the previous silence is what made this invisible in production.

## Tests

`base_runtime_test.rb` builds the raw tar bytes header by header (regular, GNU `L`, PAX `x`, directory-only), so the cases don't depend on which tar binary the environment ships. Fail-first confirmed: without the fix exactly the two long-name tests fail.

One existing test pinned the old behaviour — a tar whose single entry has a different basename must yield `nil`. That premise cannot occur: `archive_out` always returns the tar of the path asked for. It now asserts the real contract: content wins over a mismatched header name, `nil` only when the archive carries no file entry at all.

`docker compose exec -T web make check_all` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
