### PR TITLE
fix(container-runtime): honor the timeout option on Docker exec

### DIFF
--- a/app/services/bmad_method_injector.rb
+++ b/app/services/bmad_method_injector.rb
@@ -75,7 +75,7 @@ class BmadMethodInjector
 
   def run_bmad_install
     cmd = build_install_command
-    result = runtime.exec(container_id, [ "sh", "-c", cmd ])
+    result = runtime.exec(container_id, [ "sh", "-c", cmd ], timeout: INSTALL_TIMEOUT)
     exit_code = result[2].to_i
 
     if exit_code.zero?

--- a/app/services/container_runtime/docker_runtime.rb
+++ b/app/services/container_runtime/docker_runtime.rb
@@ -61,8 +61,15 @@ module ContainerRuntime
 
     # -- Execution ------------------------------------------------------------
 
+    # `timeout:` is the runtime-agnostic option (KubernetesRuntime reads it
+    # directly). docker-api spells it `wait:`, which it forwards to Excon as the
+    # read timeout; without it long execs die on Excon's 60s default with
+    # "read timeout reached".
     def exec(id, cmd, opts = {})
       container = resolve_container(id)
+      opts = opts.dup
+      timeout = opts.delete(:timeout)
+      opts[:wait] = timeout if timeout.present?
       container.exec(cmd, opts)
     end
 

--- a/test/services/bmad_method_injector_test.rb
+++ b/test/services/bmad_method_injector_test.rb
@@ -178,6 +178,23 @@ class BmadMethodInjectorTest < ActiveSupport::TestCase
     BmadMethodInjector.new("cid-1", session, runtime: @runtime).inject!
   end
 
+  # The install pulls external modules over the network and routinely outruns
+  # the runtime's default exec read timeout, which surfaced as a bogus
+  # "read timeout reached" failure mid-install.
+  test "passes INSTALL_TIMEOUT to the runtime so the exec is not cut short" do
+    session = build_bmad_session(agent_type: "claude_code")
+
+    captured_opts = nil
+    @runtime.expects(:exec).with do |_cid, _cmd, opts|
+      captured_opts = opts
+      true
+    end.returns([ [], [], 0 ])
+
+    BmadMethodInjector.new("cid-1", session, runtime: @runtime).inject!
+
+    assert_equal BmadMethodInjector::INSTALL_TIMEOUT, captured_opts[:timeout]
+  end
+
   # ====================================================================
   # AC 1: Install fails with non-zero exit → warn logged, session proceeds
   # ====================================================================

--- a/test/services/container_runtime/docker_runtime_test.rb
+++ b/test/services/container_runtime/docker_runtime_test.rb
@@ -175,6 +175,27 @@ module ContainerRuntime
       assert_equal [ [ "hi\n" ], [], 0 ], result
     end
 
+    test "exec translates the runtime-agnostic timeout option into docker-api's wait" do
+      container_mock = mock("container")
+      container_mock.expects(:exec)
+        .with([ "sleep", "120" ], { wait: 300 })
+        .returns([ [], [], 0 ])
+      Docker::Container.stubs(:get).with("cid").returns(container_mock)
+
+      @runtime.exec("cid", [ "sleep", "120" ], timeout: 300)
+    end
+
+    test "exec leaves the caller's options hash untouched" do
+      container_mock = mock("container")
+      container_mock.stubs(:exec).returns([ [], [], 0 ])
+      Docker::Container.stubs(:get).with("cid").returns(container_mock)
+
+      opts = { timeout: 300 }
+      @runtime.exec("cid", [ "echo", "hi" ], opts)
+
+      assert_equal({ timeout: 300 }, opts)
+    end
+
     test "read_file extracts the file body matching basename from the tar archive" do
       tar_bytes = build_test_tar("tmp/hello.txt", "file body")
       container_mock = mock("container")


### PR DESCRIPTION
## What

`DockerRuntime#exec` now honours the `timeout:` option, and `BmadMethodInjector` passes `INSTALL_TIMEOUT` when it runs the BMAD install.

## Why

`DockerRuntime#exec` forwarded its options straight to docker-api, which has no `timeout` key — it spells the Excon read timeout `wait`. The option was silently merged into the exec-create body and ignored, so every long exec ran against Excon's 60s default. `KubernetesRuntime` already reads `timeout:` (defaulting to 30s), and `SessionContextService` already passes it, so the key was established — Docker just dropped it.

Found while smoke-testing the BMAD 6.10.0 bump (#46) in a live session: 6.10.0 fetches `bmb`/`cis`/`wds` from GitHub and takes ~62s, so the install exec died at 60s and the session recorded:

```
bmad_install_status = failed
bmad_install_error  = "read timeout reached"
```

## Verification

Same flow through the UI after the fix — Claude Code session with BMAD enabled, Demo Alpha project:

- `bmad_install_status = success`
- container has `_bmad/_config/manifest.yaml → version: 6.10.0` and 76 skills in `/workspace/.claude/skills`
- agent invoked `Skill(bmad-help)`, `Skill(wds-agent-freya-ux)` and `Skill(bmad-cis-agent-storyteller)` — all loaded, including the two external modules

`docker compose exec -T web make check_all` — all green (rails-test, rubocop, brakeman, system-test, eslint, typescript, fe-test, vite-build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
