### PR TITLE
ci: stop cancelling develop runs when merges land back to back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,14 @@ permissions:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseding a pull request's run is free — only the tip of a branch under
+  # review is worth a verdict. Superseding a develop push is not: that run is
+  # the record of whether an integrated commit was green, and it publishes the
+  # coverage badges. Three merges inside fifteen minutes cancelled all three
+  # runs and left the README claiming a failing build with no badges behind it.
+  # Pushes therefore queue on this group instead, which also serialises the
+  # badge job's writes to the `badges` branch.
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   build-image:


### PR DESCRIPTION
## What

```diff
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'push' }}
```

Pull request runs still supersede each other. Pushes to `develop` queue instead.

## Why

Three merges landed on `develop` inside fifteen minutes today (#47, #49, #48). Each one cancelled the run before it, so all three finished as `cancelled`:

- the README's CI badge reports the newest conclusion, so it showed a failing build for commits that were never actually tested
- `coverage-badges` (added in #49) never started, so the `badges` branch was never created and both coverage badges rendered as unavailable

A pull request's older run is genuinely worthless — only the tip of the branch under review needs a verdict. A develop run is not: it is the record of whether an integrated commit was green, and it is the only writer of the coverage badges.

Queueing also serialises the badge job, so two develop runs can never race on pushing to the `badges` branch.

## Cost

A burst of merges now runs sequentially rather than in parallel, at roughly 13 minutes per run. That is the price of getting a verdict per integrated commit.

## Verification

- `actionlint` clean (the one remaining warning is pre-existing, in `images.yml`)
- `docker compose exec -T web make check_all` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
