### PR TITLE
feat(resources): unify Agents/Wrappers/Repositories/Integrations tables

### DIFF
--- a/app/frontend/pages/Projects/Integrations/IntegrationsPage.test.tsx
+++ b/app/frontend/pages/Projects/Integrations/IntegrationsPage.test.tsx
@@ -33,7 +33,7 @@ describe('Projects/Integrations/IntegrationsPage', () => {
     expect(screen.getByRole('button', { name: /GitLab/ })).toBeInTheDocument();
   });
 
-  it('lists project and company integrations in their scoped sections', () => {
+  it('lists project and company integrations in the unified table with a Scope badge', () => {
     renderAuthedPage(<IntegrationsPage />, {
       props: {
         project,
@@ -44,10 +44,10 @@ describe('Projects/Integrations/IntegrationsPage', () => {
       },
     });
 
-    expect(screen.getByText('This Project')).toBeInTheDocument();
-    expect(screen.getByText('Company-wide')).toBeInTheDocument();
     expect(screen.getByText('project-repo')).toBeInTheDocument();
     expect(screen.getByText('company-repo')).toBeInTheDocument();
+    expect(screen.getByText('project')).toBeInTheDocument();
+    expect(screen.getByText('company')).toBeInTheDocument();
   });
 
   it('opens the GitLab connect modal from the Connect menu and blocks submit with an empty token', async () => {

--- a/app/frontend/pages/Projects/Repositories/RepositoriesPage.test.tsx
+++ b/app/frontend/pages/Projects/Repositories/RepositoriesPage.test.tsx
@@ -44,10 +44,10 @@ describe('Projects/Repositories/RepositoriesPage', () => {
 
     expect(screen.getByText('octo/hangar')).toBeInTheDocument();
     expect(screen.getByText('main')).toBeInTheDocument();
-    expect(screen.getByText('This Project')).toBeInTheDocument();
+    expect(screen.getByText('project')).toBeInTheDocument();
   });
 
-  it('shows company-wide repositories as a separate read-only section', () => {
+  it('shows company-wide repositories in the unified table with a Scope badge', () => {
     renderAuthedPage(<RepositoriesPage />, {
       props: {
         project,
@@ -59,7 +59,7 @@ describe('Projects/Repositories/RepositoriesPage', () => {
     });
 
     expect(screen.getByText('octo/shared-lib')).toBeInTheDocument();
-    expect(screen.getByText('Company-wide')).toBeInTheDocument();
+    expect(screen.getByText('company')).toBeInTheDocument();
   });
 
   it('reloads edit branches when editing a project repository', async () => {
@@ -70,8 +70,7 @@ describe('Projects/Repositories/RepositoriesPage', () => {
       },
     });
 
-    await userEvent.click(screen.getByRole('button', { name: '' }));
-    await userEvent.click(await screen.findByRole('menuitem', { name: 'Edit' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }));
 
     expect(router.reload).toHaveBeenCalledWith({ data: { edit_repo_id: 7 }, only: ['editBranches'] });
   });
@@ -84,8 +83,7 @@ describe('Projects/Repositories/RepositoriesPage', () => {
       },
     });
 
-    await userEvent.click(screen.getByRole('button', { name: '' }));
-    await userEvent.click(await screen.findByRole('menuitem', { name: 'Remove' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
 
     const dialog = await screen.findByRole('dialog');
     expect(within(dialog).getByText('Remove Repository')).toBeInTheDocument();

--- a/app/frontend/shared/resources/agents/AgentFormModal.test.tsx
+++ b/app/frontend/shared/resources/agents/AgentFormModal.test.tsx
@@ -72,11 +72,11 @@ describe('AgentFormModal', () => {
     expect(router.post).not.toHaveBeenCalled();
   });
 
-  it('calls onClose when Cancel is clicked', async () => {
+  it('calls onClose when the drawer close button is clicked', async () => {
     const onClose = vi.fn();
     renderPage(<AgentFormModal opened onClose={onClose} basePath="/projects/1/agents" />);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Close' }));
 
     expect(onClose).toHaveBeenCalled();
   });

--- a/app/frontend/shared/resources/agents/AgentFormModal.tsx
+++ b/app/frontend/shared/resources/agents/AgentFormModal.tsx
@@ -1,11 +1,12 @@
 import { router } from '@inertiajs/react';
-import { Button, Group, Modal, Stack, TextInput, Textarea } from '@mantine/core';
+import { Button, Group, Stack, TextInput, Textarea } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { zod4Resolver as zodResolver } from 'mantine-form-zod-resolver';
 import { useEffect, useState, type FC } from 'react';
 import { z } from 'zod';
 
 import { EmojiPicker } from 'shared/ui/EmojiPicker';
+import { ResourceDrawer } from 'shared/ui/ResourceDrawer';
 
 const agentSchema = z.object({
   name: z
@@ -122,16 +123,24 @@ export const AgentFormModal: FC<AgentFormModalProps> = ({ opened, onClose, editA
   };
 
   return (
-    <Modal
+    <ResourceDrawer
       opened={opened}
       onClose={onClose}
       title={isEditMode ? 'Edit Agent' : duplicateAgent ? 'Duplicate Agent' : 'Create Agent'}
-      size="lg"
-      centered
+      footer={
+        <Button type="submit" form="agent-form" fullWidth loading={submitting}>
+          {isEditMode ? 'Save' : 'Create'}
+        </Button>
+      }
     >
-      <form onSubmit={form.onSubmit(handleSubmit)}>
+      <form id="agent-form" onSubmit={form.onSubmit(handleSubmit)}>
         <Stack gap="md">
           <Group align="flex-start" gap="md">
+            <EmojiPicker
+              value={form.values.icon}
+              onChange={(emoji) => form.setFieldValue('icon', emoji)}
+              disabled={submitting}
+            />
             <TextInput
               {...form.getInputProps('name')}
               onChange={(e) => handleNameChange(e.currentTarget.value)}
@@ -139,16 +148,12 @@ export const AgentFormModal: FC<AgentFormModalProps> = ({ opened, onClose, editA
               placeholder="my_agent"
               description="Unique identifier (lowercase, underscores)"
               style={{ flex: 1 }}
+              withAsterisk
               autoFocus
               disabled={isEditMode}
               styles={{
                 input: { fontFamily: '"JetBrains Mono", monospace' },
               }}
-            />
-            <EmojiPicker
-              value={form.values.icon}
-              onChange={(emoji) => form.setFieldValue('icon', emoji)}
-              disabled={submitting}
             />
           </Group>
 
@@ -157,6 +162,7 @@ export const AgentFormModal: FC<AgentFormModalProps> = ({ opened, onClose, editA
             label="Title"
             placeholder="Business Analyst"
             description="Display name for the agent"
+            withAsterisk
           />
 
           <Textarea
@@ -166,6 +172,7 @@ export const AgentFormModal: FC<AgentFormModalProps> = ({ opened, onClose, editA
             description="Who the agent is, their role and identity"
             minRows={4}
             autosize
+            withAsterisk
           />
 
           <Textarea
@@ -185,17 +192,8 @@ export const AgentFormModal: FC<AgentFormModalProps> = ({ opened, onClose, editA
             minRows={2}
             autosize
           />
-
-          <Group justify="flex-end" mt="md">
-            <Button variant="default" onClick={onClose} disabled={submitting}>
-              Cancel
-            </Button>
-            <Button type="submit" loading={submitting}>
-              {isEditMode ? 'Save' : 'Create'}
-            </Button>
-          </Group>
         </Stack>
       </form>
-    </Modal>
+    </ResourceDrawer>
   );
 };

--- a/app/frontend/shared/resources/agents/AgentsContent.tsx
+++ b/app/frontend/shared/resources/agents/AgentsContent.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from 'react';
 import { useProjectPermissions } from 'shared/lib/hooks/useProjectPermissions';
 import { EmptyState } from 'shared/ui/EmptyState';
 import { PageHeader } from 'shared/ui/PageHeader';
+import { ResourceCount, ResourceTableShell, ResourceTh } from 'shared/ui/ResourceTable';
 
 import { AgentFormModal } from './AgentFormModal';
 import { DeleteAgentModal } from './DeleteAgentModal';
@@ -87,14 +88,18 @@ export function AgentsContent({ agents, basePath, title, subtitle }: AgentsConte
         }
       />
 
-      <TextInput
-        placeholder="Search by name or title..."
-        leftSection={<IconSearch size={16} />}
-        value={search}
-        onChange={(e) => setSearch(e.currentTarget.value)}
-        mb="lg"
-        maw={300}
-      />
+      <Group gap="md" mb="lg">
+        <TextInput
+          placeholder="Search by name or title..."
+          leftSection={<IconSearch size={16} />}
+          value={search}
+          onChange={(e) => setSearch(e.currentTarget.value)}
+          maw={300}
+        />
+        <ResourceCount>
+          {agents.length} {agents.length === 1 ? 'agent' : 'agents'}
+        </ResourceCount>
+      </Group>
 
       {filtered.length === 0 ? (
         <Box
@@ -123,38 +128,16 @@ export function AgentsContent({ agents, basePath, title, subtitle }: AgentsConte
           />
         </Box>
       ) : (
-        <Box
-          style={{
-            border: '1px solid var(--app-border-default)',
-            borderRadius: 'var(--mantine-radius-md)',
-            overflow: 'hidden',
-          }}
-        >
+        <ResourceTableShell>
           <Table highlightOnHover>
             <Table.Thead style={{ backgroundColor: 'var(--app-bg-deep)' }}>
               <Table.Tr>
-                <Table.Th>
-                  <Text fz={12} fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: 0.5 }}>
-                    Agent
-                  </Text>
-                </Table.Th>
-                <Table.Th>
-                  <Text fz={12} fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: 0.5 }}>
-                    Persona
-                  </Text>
-                </Table.Th>
-                {isProjectContext && (
-                  <Table.Th>
-                    <Text fz={12} fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: 0.5 }}>
-                      Scope
-                    </Text>
-                  </Table.Th>
-                )}
-                <Table.Th w={120}>
-                  <Text fz={12} fw={600} c="dimmed" tt="uppercase" ta="right" style={{ letterSpacing: 0.5 }}>
-                    Actions
-                  </Text>
-                </Table.Th>
+                <ResourceTh>Agent</ResourceTh>
+                <ResourceTh>Persona</ResourceTh>
+                {isProjectContext && <ResourceTh>Scope</ResourceTh>}
+                <ResourceTh align="right" w={120}>
+                  Actions
+                </ResourceTh>
               </Table.Tr>
             </Table.Thead>
             <Table.Tbody>
@@ -221,7 +204,7 @@ export function AgentsContent({ agents, basePath, title, subtitle }: AgentsConte
                         </Tooltip>
                         <Tooltip label={isReadOnly(agent) ? 'Company-managed' : 'Edit'}>
                           <ActionIcon
-                            aria-label="Duplicate"
+                            aria-label="Edit"
                             variant="subtle"
                             size="sm"
                             disabled={isReadOnly(agent)}
@@ -232,7 +215,7 @@ export function AgentsContent({ agents, basePath, title, subtitle }: AgentsConte
                         </Tooltip>
                         <Tooltip label={isReadOnly(agent) ? 'Company-managed' : 'Delete'}>
                           <ActionIcon
-                            aria-label="Duplicate"
+                            aria-label="Delete"
                             variant="subtle"
                             size="sm"
                             color="red"
@@ -249,7 +232,7 @@ export function AgentsContent({ agents, basePath, title, subtitle }: AgentsConte
               ))}
             </Table.Tbody>
           </Table>
-        </Box>
+        </ResourceTableShell>
       )}
 
       <AgentFormModal

--- a/app/frontend/shared/resources/integrations/IntegrationsContent.test.tsx
+++ b/app/frontend/shared/resources/integrations/IntegrationsContent.test.tsx
@@ -22,7 +22,7 @@ const makeIntegration = (overrides: Partial<Integration> = {}): Integration => (
 });
 
 describe('IntegrationsContent', () => {
-  it('renders the title and a card for each seeded integration', () => {
+  it('renders the title and a row for each seeded integration', () => {
     renderPage(
       <IntegrationsContent
         title="Company Integrations"
@@ -38,8 +38,8 @@ describe('IntegrationsContent', () => {
     expect(screen.getByRole('heading', { name: 'Company Integrations' })).toBeInTheDocument();
     expect(screen.getByText('Acme GitHub')).toBeInTheDocument();
     expect(screen.getByText('Acme GitLab')).toBeInTheDocument();
-    // Both cards share the same connecting user, so the line appears once per card.
-    expect(screen.getAllByText(/Connected by Jane Doe/)).toHaveLength(2);
+    expect(screen.getAllByText(/Jane Doe/)).toHaveLength(2);
+    expect(screen.getByText('2 integrations')).toBeInTheDocument();
   });
 
   it('shows the empty state when there are no integrations', () => {
@@ -203,8 +203,8 @@ describe('IntegrationsContent', () => {
     expect(settingsLink).toHaveAttribute('target', '_blank');
   });
 
-  describe('project context sections', () => {
-    it('splits integrations into "This Project" and "Company-wide" sections', () => {
+  describe('project context scope filter', () => {
+    it('shows both project- and company-scoped integrations by default, with a scope badge', () => {
       renderPage(
         <IntegrationsContent
           title="Project Integrations"
@@ -217,29 +217,13 @@ describe('IntegrationsContent', () => {
         { props: settingsProps },
       );
 
-      expect(screen.getByText('This Project')).toBeInTheDocument();
-      expect(screen.getByText('Company-wide')).toBeInTheDocument();
       expect(screen.getByText('Project Scoped')).toBeInTheDocument();
       expect(screen.getByText('Org Wide')).toBeInTheDocument();
-    });
-
-    it('marks company-wide integrations read-only: a company badge but no Remove button', () => {
-      renderPage(
-        <IntegrationsContent
-          title="Project Integrations"
-          basePath="/projects/42/integrations"
-          integrations={[makeIntegration({ id: 2, name: 'Org Wide', scopeIndicator: 'company' })]}
-        />,
-        { props: settingsProps },
-      );
-
-      // The read-only "company" badge is present for a company-scoped integration in a project view.
       expect(screen.getByText('company')).toBeInTheDocument();
-      // Read-only cards hide the Remove action.
-      expect(screen.queryByRole('button', { name: /Remove/i })).not.toBeInTheDocument();
+      expect(screen.getByText('project')).toBeInTheDocument();
     });
 
-    it('shows an empty-scope message when the project has no project-scoped integrations', () => {
+    it('filtering to Project scope hides company-wide integrations and their Remove action stays hidden either way', async () => {
       renderPage(
         <IntegrationsContent
           title="Project Integrations"
@@ -249,6 +233,12 @@ describe('IntegrationsContent', () => {
         { props: settingsProps },
       );
 
+      // Company-scoped integrations in a project context are read-only: no Remove action.
+      expect(screen.queryByRole('button', { name: /Remove/i })).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('radio', { name: 'Project' }));
+
+      expect(screen.queryByText('Org Wide')).not.toBeInTheDocument();
       expect(screen.getByText('No integrations in this scope.')).toBeInTheDocument();
     });
 
@@ -319,15 +309,14 @@ describe('IntegrationsContent', () => {
               name: 'Org Wide',
               scopeIndicator: 'company',
               status: 'active',
-              // No installationId: the button still renders, but handleLinkToProject bails early.
+              // No installationId: the Link action does not render at all.
             }),
           ]}
         />,
         { props: settingsProps },
       );
 
-      await userEvent.click(screen.getByRole('button', { name: /Link to project/i }));
-
+      expect(screen.queryByRole('button', { name: /Link to project/i })).not.toBeInTheDocument();
       expect(router.post).not.toHaveBeenCalled();
     });
   });
@@ -597,7 +586,7 @@ describe('IntegrationsContent', () => {
       expect(screen.queryByRole('button', { name: 'GitHub' })).not.toBeInTheDocument();
     });
 
-    it('hides the Remove action on integration cards', () => {
+    it('hides the Remove action on integration rows', () => {
       renderPage(
         <IntegrationsContent
           title="Company Integrations"
@@ -607,14 +596,14 @@ describe('IntegrationsContent', () => {
         { props: readOnlyProps },
       );
 
-      // The card still renders, but its mutating controls are gone for a read-only viewer.
+      // The row still renders, but its mutating controls are gone for a read-only viewer.
       expect(screen.getByText('Acme GitHub')).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /Remove/i })).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Connect' })).not.toBeInTheDocument();
     });
   });
 
-  describe('connected integration card details', () => {
+  describe('connected integration row details', () => {
     it('shows the Slack request URL and a copy button for a Slack integration', () => {
       renderPage(
         <IntegrationsContent
@@ -636,7 +625,7 @@ describe('IntegrationsContent', () => {
       expect(screen.getByRole('button', { name: /Request URL/i })).toBeInTheDocument();
     });
 
-    it('shows the Coder instance URL on a Coder integration card', () => {
+    it('shows the Coder instance URL on a Coder integration row', () => {
       renderPage(
         <IntegrationsContent
           title="Company Integrations"

--- a/app/frontend/shared/resources/integrations/IntegrationsContent.tsx
+++ b/app/frontend/shared/resources/integrations/IntegrationsContent.tsx
@@ -1,20 +1,21 @@
 import { router } from '@inertiajs/react';
 import {
+  ActionIcon,
   Badge,
   Box,
   Button,
-  Card,
   CopyButton,
-  Divider,
   Group,
   Menu,
   Modal,
   NumberInput,
   PasswordInput,
+  SegmentedControl,
   Stack,
+  Table,
   Text,
   TextInput,
-  ThemeIcon,
+  Tooltip,
   UnstyledButton,
 } from '@mantine/core';
 import { modals } from '@mantine/modals';
@@ -28,6 +29,7 @@ import {
   IconCopy,
   IconLink,
   IconPlus,
+  IconSearch,
   IconSettings,
   IconTrash,
 } from '@tabler/icons-react';
@@ -35,7 +37,9 @@ import { useCallback, useMemo, useState } from 'react';
 
 import { useProjectPermissions } from 'shared/lib/hooks/useProjectPermissions';
 import { isValidHttpUrl } from 'shared/lib/urlValidation';
+import { EmptyState } from 'shared/ui/EmptyState';
 import { PageHeader } from 'shared/ui/PageHeader';
+import { ResourceCount, ResourceTableShell, ResourceTh } from 'shared/ui/ResourceTable';
 import { StatusBadge } from 'shared/ui/StatusBadge';
 
 export interface Integration {
@@ -66,7 +70,7 @@ const CoderIcon = ({ size = 20 }: { size?: number } = {}) => (
   <img src="/images/coder.svg" alt="Coder" width={size} height={size} />
 );
 
-const ProviderIcon = ({ provider, size = 20 }: { provider: string; size?: number }) => {
+const ProviderIcon = ({ provider, size = 18 }: { provider: string; size?: number }) => {
   if (provider === 'github') return <IconBrandGithub size={size} />;
   if (provider === 'gitlab') return <img src="/images/gitlab.svg" alt="GitLab" width={size} height={size} />;
   if (provider === 'coder') return <img src="/images/coder.svg" alt="Coder" width={size} height={size} />;
@@ -74,114 +78,28 @@ const ProviderIcon = ({ provider, size = 20 }: { provider: string; size?: number
   return <IconLink size={size} />;
 };
 
-const PROVIDER_ICON_COLORS: Record<string, string> = {
-  github: 'dark',
-  gitlab: 'orange',
-  coder: 'blue',
-  slack: 'grape',
+const PROVIDER_LABELS: Record<string, string> = {
+  github: 'GitHub',
+  gitlab: 'GitLab',
+  coder: 'Coder',
+  slack: 'Slack',
+};
+
+const SCOPE_COLORS: Record<string, string> = {
+  company: 'gray',
+  project: 'green',
 };
 
 const formatDate = (d: string) =>
   new Date(d).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
 
-const IntegrationCard = ({
-  integration,
-  readOnly,
-  canExecute,
-  onDelete,
-  onLink,
-}: {
-  integration: Integration;
-  readOnly?: boolean;
-  canExecute: boolean;
-  onDelete: (i: Integration) => void;
-  onLink?: (i: Integration) => void;
-}) => (
-  <Card withBorder p="md" radius="md">
-    <Group justify="space-between" wrap="nowrap">
-      <Group gap="md" wrap="nowrap">
-        <ThemeIcon variant="light" size="lg" radius="md" color={PROVIDER_ICON_COLORS[integration.provider] ?? 'gray'}>
-          <ProviderIcon provider={integration.provider} size={18} />
-        </ThemeIcon>
-        <Box>
-          <Group gap="xs">
-            <Text fw={600} size="sm">
-              {integration.name}
-            </Text>
-            <StatusBadge state={integration.status} size="sm" />
-            {readOnly && (
-              <Badge size="xs" variant="outline" color="gray">
-                company
-              </Badge>
-            )}
-          </Group>
-          <Text size="xs" c="dimmed">
-            Connected by {integration.connectedBy.name} on {formatDate(integration.createdAt)}
-          </Text>
-          {integration.provider === 'slack' && integration.slackRequestUrl && (
-            <Group gap={6} mt={4} wrap="nowrap">
-              <Text size="xs" c="dimmed" ff="monospace" truncate maw={280}>
-                {integration.slackRequestUrl}
-              </Text>
-              <CopyButton value={integration.slackRequestUrl}>
-                {({ copied, copy }) => (
-                  <Button
-                    variant="subtle"
-                    size="compact-xs"
-                    onClick={copy}
-                    leftSection={copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
-                  >
-                    {copied ? 'Copied' : 'Request URL'}
-                  </Button>
-                )}
-              </CopyButton>
-            </Group>
-          )}
-          {integration.provider === 'coder' && integration.coderUrl && (
-            <Text size="xs" c="dimmed" mt={2}>
-              {integration.coderUrl}
-            </Text>
-          )}
-        </Box>
-      </Group>
-
-      <Group gap="xs">
-        {canExecute && onLink && integration.status === 'active' && (
-          <Button variant="light" size="xs" leftSection={<IconLink size={14} />} onClick={() => onLink(integration)}>
-            Link to project
-          </Button>
-        )}
-        {integration.githubUrl && !readOnly && (
-          <Button
-            variant="subtle"
-            size="xs"
-            leftSection={<IconSettings size={14} />}
-            component="a"
-            href={integration.githubUrl}
-            target="_blank"
-          >
-            Settings
-          </Button>
-        )}
-        {canExecute && !readOnly && (
-          <Button
-            variant="subtle"
-            color="red"
-            size="xs"
-            leftSection={<IconTrash size={14} />}
-            onClick={() => onDelete(integration)}
-          >
-            Remove
-          </Button>
-        )}
-      </Group>
-    </Group>
-  </Card>
-);
-
 export const IntegrationsContent = ({ integrations, basePath, title }: IntegrationsContentProps) => {
   const { canExecute } = useProjectPermissions();
   const isProjectContext = basePath.includes('projects');
+  const [search, setSearch] = useState('');
+  const [scopeFilter, setScopeFilter] = useState('all');
+  const [connectMenuOpened, setConnectMenuOpened] = useState(false);
+
   const [gitlabOpen, setGitlabOpen] = useState(false);
   const [gitlabPat, setGitlabPat] = useState('');
   const [gitlabLoading, setGitlabLoading] = useState(false);
@@ -211,8 +129,30 @@ export const IntegrationsContent = ({ integrations, basePath, title }: Integrati
     resetCoderForm();
   }, [resetCoderForm]);
 
-  const projectIntegrations = useMemo(() => integrations.filter((i) => i.scopeIndicator === 'project'), [integrations]);
-  const companyIntegrations = useMemo(() => integrations.filter((i) => i.scopeIndicator === 'company'), [integrations]);
+  const filtered = useMemo(() => {
+    let result = integrations;
+
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter((i) => i.name.toLowerCase().includes(q));
+    }
+
+    if (scopeFilter !== 'all') {
+      result = result.filter((i) => i.scopeIndicator === scopeFilter);
+    }
+
+    return result;
+  }, [integrations, search, scopeFilter]);
+
+  const hasFilters = !!search || scopeFilter !== 'all';
+
+  const alreadyLinkedInstallationIds = useMemo(
+    () =>
+      new Set(
+        integrations.filter((i) => i.scopeIndicator === 'project' && i.installationId).map((i) => i.installationId),
+      ),
+    [integrations],
+  );
 
   const handleDelete = useCallback(
     (integration: Integration) => {
@@ -327,50 +267,6 @@ export const IntegrationsContent = ({ integrations, basePath, title }: Integrati
     window.location.href = `${basePath}/slack_oauth_start`;
   }, [basePath]);
 
-  const alreadyLinkedInstallationIds = useMemo(
-    () => new Set(projectIntegrations.filter((i) => i.installationId).map((i) => i.installationId)),
-    [projectIntegrations],
-  );
-
-  const renderSection = (
-    label: string,
-    items: Integration[],
-    options: { readOnly?: boolean; showLink?: boolean } = {},
-  ) => (
-    <Box>
-      <Group gap="xs" mb="sm">
-        <Text fw={600} size="sm" tt="uppercase" c="dimmed" lts={0.5}>
-          {label}
-        </Text>
-        <Badge size="xs" variant="light" color="gray">
-          {items.length}
-        </Badge>
-      </Group>
-      {items.length === 0 ? (
-        <Text c="dimmed" size="sm" mb="md">
-          {options.readOnly ? 'No company-wide integrations available.' : 'No integrations in this scope.'}
-        </Text>
-      ) : (
-        <Stack gap="sm" mb="md">
-          {items.map((integration) => (
-            <IntegrationCard
-              key={integration.id}
-              integration={integration}
-              readOnly={options.readOnly}
-              canExecute={canExecute}
-              onDelete={handleDelete}
-              onLink={
-                options.showLink && !alreadyLinkedInstallationIds.has(integration.installationId)
-                  ? handleLinkToProject
-                  : undefined
-              }
-            />
-          ))}
-        </Stack>
-      )}
-    </Box>
-  );
-
   return (
     <Box>
       <PageHeader
@@ -382,9 +278,22 @@ export const IntegrationsContent = ({ integrations, basePath, title }: Integrati
         }
         actions={
           canExecute && (
-            <Menu position="bottom-end" withArrow>
+            <Menu position="bottom-end" withArrow opened={connectMenuOpened} onChange={setConnectMenuOpened}>
               <Menu.Target>
-                <Button leftSection={<IconPlus size={16} />}>Connect</Button>
+                <Button
+                  leftSection={<IconPlus size={16} />}
+                  rightSection={
+                    <IconChevronDown
+                      size={14}
+                      style={{
+                        transition: 'transform 150ms ease',
+                        transform: connectMenuOpened ? 'rotate(180deg)' : 'none',
+                      }}
+                    />
+                  }
+                >
+                  Connect
+                </Button>
               </Menu.Target>
               <Menu.Dropdown>
                 <Menu.Item leftSection={<IconBrandGithub size={16} />} onClick={handleConnectGithub}>
@@ -407,58 +316,223 @@ export const IntegrationsContent = ({ integrations, basePath, title }: Integrati
         }
       />
 
-      {integrations.length === 0 ? (
-        <Card p="xl" withBorder radius="md">
-          <Stack align="center" gap="md" py="lg">
-            <ThemeIcon size={56} radius="xl" variant="light" color="gray">
-              <IconLink size={28} />
-            </ThemeIcon>
-            <Box ta="center">
-              <Text fw={500} size="lg">
-                No integrations connected
-              </Text>
-              <Text size="sm" c="dimmed" mt={4} maw={440}>
-                Connect GitHub or GitLab for repositories, Coder for workspaces, or Slack to trigger workflows from
-                messages.
-              </Text>
-            </Box>
-            {canExecute && (
-              <Group gap="sm" justify="center" wrap="wrap">
-                <Button variant="outline" leftSection={<IconBrandGithub size={16} />} onClick={handleConnectGithub}>
-                  GitHub
-                </Button>
-                <Button variant="outline" leftSection={<GitlabIcon />} onClick={() => setGitlabOpen(true)}>
-                  GitLab
-                </Button>
-                <Button variant="outline" leftSection={<CoderIcon size={16} />} onClick={() => setCoderOpen(true)}>
-                  Coder
-                </Button>
-                {isProjectContext && (
-                  <Button variant="outline" leftSection={<IconBrandSlack size={16} />} onClick={handleConnectSlack}>
-                    Slack
-                  </Button>
-                )}
-              </Group>
-            )}
-          </Stack>
-        </Card>
-      ) : isProjectContext ? (
-        <Stack gap="lg">
-          {renderSection('This Project', projectIntegrations)}
-          <Divider />
-          {renderSection('Company-wide', companyIntegrations, { readOnly: true, showLink: true })}
-        </Stack>
-      ) : (
-        <Stack gap="sm">
-          {integrations.map((integration) => (
-            <IntegrationCard
-              key={integration.id}
-              integration={integration}
-              canExecute={canExecute}
-              onDelete={handleDelete}
+      <Group gap="md" mb="lg">
+        <TextInput
+          placeholder="Search by name..."
+          leftSection={<IconSearch size={16} />}
+          value={search}
+          onChange={(e) => setSearch(e.currentTarget.value)}
+          maw={300}
+        />
+        {isProjectContext && (
+          <SegmentedControl
+            value={scopeFilter}
+            onChange={setScopeFilter}
+            data={[
+              { label: 'All', value: 'all' },
+              { label: 'Project', value: 'project' },
+              { label: 'Company', value: 'company' },
+            ]}
+            size="sm"
+          />
+        )}
+        <ResourceCount>
+          {filtered.length} {filtered.length === 1 ? 'integration' : 'integrations'}
+        </ResourceCount>
+      </Group>
+
+      {filtered.length === 0 ? (
+        <Box
+          style={{
+            border: '1px solid var(--app-border-default)',
+            borderRadius: 'var(--mantine-radius-md)',
+            backgroundColor: 'var(--app-bg-paper)',
+          }}
+        >
+          {hasFilters ? (
+            <EmptyState
+              icon={<IconLink size={22} />}
+              title={
+                scopeFilter !== 'all' && !search
+                  ? 'No integrations in this scope.'
+                  : 'No integrations match your search'
+              }
             />
-          ))}
-        </Stack>
+          ) : (
+            <EmptyState
+              icon={<IconLink size={22} />}
+              title="No integrations connected"
+              description="Connect GitHub or GitLab for repositories, Coder for workspaces, or Slack to trigger workflows from messages."
+              action={
+                canExecute && (
+                  <Group gap="sm" justify="center" wrap="wrap">
+                    <Button variant="outline" leftSection={<IconBrandGithub size={16} />} onClick={handleConnectGithub}>
+                      GitHub
+                    </Button>
+                    <Button variant="outline" leftSection={<GitlabIcon />} onClick={() => setGitlabOpen(true)}>
+                      GitLab
+                    </Button>
+                    <Button variant="outline" leftSection={<CoderIcon size={16} />} onClick={() => setCoderOpen(true)}>
+                      Coder
+                    </Button>
+                    {isProjectContext && (
+                      <Button variant="outline" leftSection={<IconBrandSlack size={16} />} onClick={handleConnectSlack}>
+                        Slack
+                      </Button>
+                    )}
+                  </Group>
+                )
+              }
+            />
+          )}
+        </Box>
+      ) : (
+        <ResourceTableShell>
+          <Table highlightOnHover>
+            <Table.Thead style={{ backgroundColor: 'var(--app-bg-deep)' }}>
+              <Table.Tr>
+                <ResourceTh>Name</ResourceTh>
+                <ResourceTh>Provider</ResourceTh>
+                {isProjectContext && <ResourceTh>Scope</ResourceTh>}
+                <ResourceTh>Status</ResourceTh>
+                <ResourceTh>Connected by</ResourceTh>
+                <ResourceTh align="right" w={150}>
+                  Actions
+                </ResourceTh>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {filtered.map((integration) => {
+                const readOnly = isProjectContext && integration.scopeIndicator === 'company';
+                const canLink =
+                  isProjectContext &&
+                  readOnly &&
+                  integration.status === 'active' &&
+                  integration.installationId &&
+                  !alreadyLinkedInstallationIds.has(integration.installationId);
+
+                return (
+                  <Table.Tr key={integration.id}>
+                    <Table.Td>
+                      <Group gap="sm" wrap="nowrap">
+                        <Box
+                          w={30}
+                          h={30}
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            backgroundColor: 'var(--app-bg-deep)',
+                            borderRadius: 'var(--mantine-radius-sm)',
+                            color: 'var(--app-text-secondary)',
+                            flexShrink: 0,
+                          }}
+                        >
+                          <ProviderIcon provider={integration.provider} />
+                        </Box>
+                        <Box style={{ minWidth: 0 }}>
+                          <Text fz={14} fw={500} c="var(--app-text-primary)" truncate>
+                            {integration.name}
+                          </Text>
+                          {integration.provider === 'slack' && integration.slackRequestUrl && (
+                            <Group gap={4} wrap="nowrap">
+                              <Text fz={11} c="dimmed" ff="JetBrains Mono, monospace" truncate maw={180}>
+                                {integration.slackRequestUrl}
+                              </Text>
+                              <CopyButton value={integration.slackRequestUrl}>
+                                {({ copied, copy }) => (
+                                  <Tooltip label={copied ? 'Copied' : 'Copy request URL'}>
+                                    <ActionIcon
+                                      aria-label="Request URL"
+                                      variant="subtle"
+                                      size="xs"
+                                      color="gray"
+                                      onClick={copy}
+                                    >
+                                      {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+                                    </ActionIcon>
+                                  </Tooltip>
+                                )}
+                              </CopyButton>
+                            </Group>
+                          )}
+                          {integration.provider === 'coder' && integration.coderUrl && (
+                            <Text fz={11} c="dimmed" truncate maw={200}>
+                              {integration.coderUrl}
+                            </Text>
+                          )}
+                        </Box>
+                      </Group>
+                    </Table.Td>
+                    <Table.Td>
+                      <Text fz={13} c="dimmed">
+                        {PROVIDER_LABELS[integration.provider] ?? integration.provider}
+                      </Text>
+                    </Table.Td>
+                    {isProjectContext && (
+                      <Table.Td>
+                        <Badge color={SCOPE_COLORS[integration.scopeIndicator] ?? 'gray'} size="sm" variant="light">
+                          {integration.scopeIndicator}
+                        </Badge>
+                      </Table.Td>
+                    )}
+                    <Table.Td>
+                      <StatusBadge state={integration.status} size="sm" />
+                    </Table.Td>
+                    <Table.Td>
+                      <Text fz={13} c="dimmed">
+                        {integration.connectedBy.name} · {formatDate(integration.createdAt)}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Group gap={4} justify="flex-end">
+                        {canExecute && canLink && (
+                          <Tooltip label="Link to project">
+                            <ActionIcon
+                              aria-label="Link to project"
+                              variant="subtle"
+                              size="sm"
+                              onClick={() => handleLinkToProject(integration)}
+                            >
+                              <IconLink size={16} />
+                            </ActionIcon>
+                          </Tooltip>
+                        )}
+                        {integration.githubUrl && !readOnly && (
+                          <Tooltip label="Settings">
+                            <ActionIcon
+                              aria-label="Settings"
+                              variant="subtle"
+                              size="sm"
+                              component="a"
+                              href={integration.githubUrl}
+                              target="_blank"
+                            >
+                              <IconSettings size={16} />
+                            </ActionIcon>
+                          </Tooltip>
+                        )}
+                        {canExecute && !readOnly && (
+                          <Tooltip label="Remove">
+                            <ActionIcon
+                              aria-label="Remove"
+                              variant="subtle"
+                              size="sm"
+                              color="red"
+                              onClick={() => handleDelete(integration)}
+                            >
+                              <IconTrash size={16} />
+                            </ActionIcon>
+                          </Tooltip>
+                        )}
+                      </Group>
+                    </Table.Td>
+                  </Table.Tr>
+                );
+              })}
+            </Table.Tbody>
+          </Table>
+        </ResourceTableShell>
       )}
 
       <Modal
@@ -514,14 +588,12 @@ export const IntegrationsContent = ({ integrations, basePath, title }: Integrati
             onChange={(e) => setCoderUrl(e.currentTarget.value)}
             error={coderUrl.trim() && !isValidHttpUrl(coderUrl) ? 'Must be a valid http or https URL' : undefined}
             autoFocus
-            required
           />
           <PasswordInput
             label="Session Token"
             placeholder="vFVrbTLdls-..."
             value={coderToken}
             onChange={(e) => setCoderToken(e.currentTarget.value)}
-            required
           />
 
           <UnstyledButton onClick={() => setCoderAdvancedOpen((open) => !open)}>
@@ -553,7 +625,6 @@ export const IntegrationsContent = ({ integrations, basePath, title }: Integrati
                 max={1440}
                 value={coderLockTtlMinutes}
                 onChange={(value) => setCoderLockTtlMinutes(value)}
-                required
                 error={typeof coderLockTtlMinutes === 'number' && coderLockTtlMinutes > 0 ? undefined : 'Required'}
               />
             </Stack>

--- a/app/frontend/shared/resources/repositories/AddRepositoryModal.test.tsx
+++ b/app/frontend/shared/resources/repositories/AddRepositoryModal.test.tsx
@@ -99,7 +99,7 @@ describe('AddRepositoryModal', () => {
     expect(router.post).not.toHaveBeenCalled();
   });
 
-  it('Cancel calls onClose', async () => {
+  it('the drawer close button calls onClose', async () => {
     const onClose = vi.fn();
     renderPage(
       <AddRepositoryModal
@@ -111,7 +111,7 @@ describe('AddRepositoryModal', () => {
       { props: { integrations: [] } },
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Close' }));
 
     expect(onClose).toHaveBeenCalled();
   });

--- a/app/frontend/shared/resources/repositories/AddRepositoryModal.tsx
+++ b/app/frontend/shared/resources/repositories/AddRepositoryModal.tsx
@@ -1,22 +1,12 @@
 import { router, usePage } from '@inertiajs/react';
-import {
-  Alert,
-  Button,
-  Group,
-  Loader,
-  Modal,
-  SegmentedControl,
-  Select,
-  Stack,
-  Text,
-  TextInput,
-  Textarea,
-} from '@mantine/core';
+import { Alert, Button, Loader, SegmentedControl, Select, Stack, Text, TextInput, Textarea } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { zod4Resolver as zodResolver } from 'mantine-form-zod-resolver';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import { z } from 'zod';
+
+import { ResourceDrawer } from 'shared/ui/ResourceDrawer';
 
 const schema = z
   .object({
@@ -201,8 +191,17 @@ export const AddRepositoryModal: FC<Props> = ({ opened, onClose, basePath, exist
   };
 
   return (
-    <Modal opened={opened} onClose={handleClose} title="Add Repository" centered>
-      <form onSubmit={form.onSubmit(handleSubmit)}>
+    <ResourceDrawer
+      opened={opened}
+      onClose={handleClose}
+      title="Add Repository"
+      footer={
+        <Button type="submit" form="add-repository-form" fullWidth loading={loading}>
+          Add Repository
+        </Button>
+      }
+    >
+      <form id="add-repository-form" onSubmit={form.onSubmit(handleSubmit)}>
         <Stack gap="md">
           {serverErrors && (
             <Alert icon={<IconAlertCircle size={16} />} color="red" variant="light">
@@ -288,16 +287,8 @@ export const AddRepositoryModal: FC<Props> = ({ opened, onClose, basePath, exist
             minRows={2}
             autosize
           />
-          <Group justify="flex-end" mt="sm">
-            <Button variant="default" onClick={handleClose} disabled={loading}>
-              Cancel
-            </Button>
-            <Button type="submit" loading={loading}>
-              Add Repository
-            </Button>
-          </Group>
         </Stack>
       </form>
-    </Modal>
+    </ResourceDrawer>
   );
 };

--- a/app/frontend/shared/resources/repositories/EditRepositoryModal.test.tsx
+++ b/app/frontend/shared/resources/repositories/EditRepositoryModal.test.tsx
@@ -61,7 +61,7 @@ describe('EditRepositoryModal', () => {
     expect(router.patch).not.toHaveBeenCalled();
   });
 
-  it('clicking Cancel calls onClose without hitting the backend', async () => {
+  it('clicking the drawer close button calls onClose without hitting the backend', async () => {
     const onClose = vi.fn();
     renderPage(
       <EditRepositoryModal
@@ -72,7 +72,7 @@ describe('EditRepositoryModal', () => {
       />,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Close' }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(router.patch).not.toHaveBeenCalled();

--- a/app/frontend/shared/resources/repositories/EditRepositoryModal.tsx
+++ b/app/frontend/shared/resources/repositories/EditRepositoryModal.tsx
@@ -1,9 +1,11 @@
 import { router } from '@inertiajs/react';
-import { Button, Group, Modal, Select, Stack, TextInput, Textarea } from '@mantine/core';
+import { Button, Select, Stack, TextInput, Textarea } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { zod4Resolver as zodResolver } from 'mantine-form-zod-resolver';
 import { useEffect, useState, type FC } from 'react';
 import { z } from 'zod';
+
+import { ResourceDrawer } from 'shared/ui/ResourceDrawer';
 
 const schema = z.object({
   sourceBranch: z.string().min(1, 'Branch is required'),
@@ -70,8 +72,17 @@ export const EditRepositoryModal: FC<Props> = ({ repo, branches = [], basePath, 
   };
 
   return (
-    <Modal opened={!!repo} onClose={onClose} title={`Edit ${repo?.fullName ?? 'Repository'}`} centered>
-      <form onSubmit={form.onSubmit(handleSubmit)}>
+    <ResourceDrawer
+      opened={!!repo}
+      onClose={onClose}
+      title={`Edit ${repo?.fullName ?? 'Repository'}`}
+      footer={
+        <Button type="submit" form="edit-repository-form" fullWidth loading={loading}>
+          Update
+        </Button>
+      }
+    >
+      <form id="edit-repository-form" onSubmit={form.onSubmit(handleSubmit)}>
         <Stack gap="md">
           {/* Branch lists come from the integration's API; public repositories
               have none to list, so the branch stays free text there. */}
@@ -96,16 +107,8 @@ export const EditRepositoryModal: FC<Props> = ({ repo, branches = [], basePath, 
             autosize
           />
           <Textarea label="Description" placeholder="Optional description..." {...form.getInputProps('description')} />
-          <Group justify="flex-end" mt="sm">
-            <Button variant="default" onClick={onClose} disabled={loading}>
-              Cancel
-            </Button>
-            <Button type="submit" loading={loading}>
-              Update
-            </Button>
-          </Group>
         </Stack>
       </form>
-    </Modal>
+    </ResourceDrawer>
   );
 };

--- a/app/frontend/shared/resources/repositories/RepositoriesContent.test.tsx
+++ b/app/frontend/shared/resources/repositories/RepositoriesContent.test.tsx
@@ -32,7 +32,7 @@ describe('RepositoriesContent', () => {
     );
 
     expect(screen.getByText('rails/rails')).toBeInTheDocument();
-    expect(screen.getByText('public read-only')).toBeInTheDocument();
+    expect(screen.getByText('Public (read-only)')).toBeInTheDocument();
   });
 
   it('renders the title and a row per seeded repository', () => {
@@ -52,6 +52,7 @@ describe('RepositoriesContent', () => {
     expect(screen.getByText('acme/frontend')).toBeInTheDocument();
     // branch badge rendered for the row
     expect(screen.getByText('develop')).toBeInTheDocument();
+    expect(screen.getByText('2 repositories')).toBeInTheDocument();
   });
 
   it('shows the empty state when there are no repositories', () => {
@@ -64,7 +65,7 @@ describe('RepositoriesContent', () => {
     expect(screen.getAllByRole('button', { name: /add repository/i }).length).toBeGreaterThanOrEqual(2);
   });
 
-  it('splits repos into project + company sections in a project context', () => {
+  it('filters by scope in a project context', async () => {
     renderPage(
       <RepositoriesContent
         title="Project Repositories"
@@ -76,10 +77,13 @@ describe('RepositoriesContent', () => {
       />,
     );
 
-    expect(screen.getByText('This Project')).toBeInTheDocument();
-    expect(screen.getByText('Company-wide')).toBeInTheDocument();
     expect(screen.getByText('acme/service')).toBeInTheDocument();
     expect(screen.getByText('acme/shared-lib')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Project' }));
+
+    expect(screen.getByText('acme/service')).toBeInTheDocument();
+    expect(screen.queryByText('acme/shared-lib')).not.toBeInTheDocument();
   });
 
   it('opens the Add Repository modal when the header button is clicked', async () => {
@@ -111,13 +115,11 @@ describe('RepositoriesContent', () => {
       />,
     );
 
-    // Open the row menu (the only icon button before the modal opens).
-    await userEvent.click(screen.getByRole('button', { name: '' }));
-    await userEvent.click(await screen.findByRole('menuitem', { name: /remove/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
 
     // Confirm modal from @mantine/modals; click its Remove button.
-    const confirmBtn = await screen.findByRole('button', { name: 'Remove' });
-    await userEvent.click(confirmBtn);
+    const confirmDialog = await screen.findByRole('dialog', { name: /Remove Repository/i });
+    await userEvent.click(within(confirmDialog).getByRole('button', { name: 'Remove' }));
 
     await waitFor(() =>
       expect(router.delete).toHaveBeenCalledWith(

--- a/app/frontend/shared/resources/repositories/RepositoriesContent.tsx
+++ b/app/frontend/shared/resources/repositories/RepositoriesContent.tsx
@@ -1,21 +1,34 @@
 import { router } from '@inertiajs/react';
-import { Badge, Box, Button, Card, Divider, Group, Menu, Stack, Text, ThemeIcon } from '@mantine/core';
+import {
+  ActionIcon,
+  Badge,
+  Box,
+  Button,
+  Group,
+  SegmentedControl,
+  Table,
+  Text,
+  TextInput,
+  Tooltip,
+} from '@mantine/core';
 import { modals } from '@mantine/modals';
 import { notifications } from '@mantine/notifications';
 import {
-  IconDotsVertical,
   IconEdit,
   IconFolder,
   IconGitBranch,
   IconLock,
   IconPlus,
+  IconSearch,
   IconTrash,
   IconWorld,
 } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
 
 import { useProjectPermissions } from 'shared/lib/hooks/useProjectPermissions';
+import { EmptyState } from 'shared/ui/EmptyState';
 import { PageHeader } from 'shared/ui/PageHeader';
+import { ResourceCount, ResourceTableShell, ResourceTh } from 'shared/ui/ResourceTable';
 
 import { AddRepositoryModal } from './AddRepositoryModal';
 import { EditRepositoryModal } from './EditRepositoryModal';
@@ -41,93 +54,43 @@ interface RepositoriesContentProps {
   editBranches?: string[];
 }
 
-const RepoCard = ({
-  repo,
-  readOnly,
-  canExecute,
-  onEdit,
-  onDelete,
-  showScope,
-}: {
-  repo: Repository;
-  readOnly?: boolean;
-  canExecute: boolean;
-  onEdit: (r: Repository) => void;
-  onDelete: (r: Repository) => void;
-  showScope?: boolean;
-}) => (
-  <Card withBorder p="md" radius="md">
-    <Group justify="space-between" wrap="nowrap">
-      <Group gap="md" wrap="nowrap">
-        <ThemeIcon variant="light" size="lg" radius="md" color={repo.isPrivate ? 'yellow' : 'teal'}>
-          {repo.isPrivate ? <IconLock size={18} /> : <IconWorld size={18} />}
-        </ThemeIcon>
-        <Box style={{ minWidth: 0 }}>
-          <Group gap="xs" wrap="nowrap">
-            <Text fw={600} size="sm" truncate>
-              {repo.fullName}
-            </Text>
-            <Badge size="xs" variant="light" leftSection={<IconGitBranch size={10} />}>
-              {repo.sourceBranch}
-            </Badge>
-            {showScope && (
-              <Badge size="xs" variant="light" color={repo.scopeIndicator === 'project' ? 'green' : 'gray'}>
-                {repo.scopeIndicator}
-              </Badge>
-            )}
-            {repo.publicSource && (
-              <Badge size="xs" variant="light" color="blue" title="Cloned without credentials — read-only">
-                public read-only
-              </Badge>
-            )}
-          </Group>
-          <Text size="xs" c="dimmed" truncate>
-            {repo.integration?.name ?? 'No integration'}
-            {repo.description && ` · ${repo.description}`}
-          </Text>
-          {repo.purpose && (
-            <Text size="xs" c="dimmed" fs="italic" mt={2} lineClamp={1}>
-              {repo.purpose}
-            </Text>
-          )}
-        </Box>
-      </Group>
-
-      {!readOnly && canExecute && (
-        <Menu position="bottom-end" withArrow>
-          <Menu.Target>
-            <Button variant="subtle" size="xs" p={4} color="gray">
-              <IconDotsVertical size={16} />
-            </Button>
-          </Menu.Target>
-          <Menu.Dropdown>
-            <Menu.Item leftSection={<IconEdit size={14} />} onClick={() => onEdit(repo)}>
-              Edit
-            </Menu.Item>
-            <Menu.Item color="red" leftSection={<IconTrash size={14} />} onClick={() => onDelete(repo)}>
-              Remove
-            </Menu.Item>
-          </Menu.Dropdown>
-        </Menu>
-      )}
-    </Group>
-  </Card>
-);
+const SCOPE_COLORS: Record<string, string> = {
+  company: 'gray',
+  project: 'green',
+};
 
 export const RepositoriesContent = ({ repositories, basePath, title, editBranches }: RepositoriesContentProps) => {
   const { canExecute } = useProjectPermissions();
+  const [search, setSearch] = useState('');
+  const [scopeFilter, setScopeFilter] = useState('all');
   const [editRepo, setEditRepo] = useState<Repository | null>(null);
   const [addModalOpen, setAddModalOpen] = useState(false);
+
+  const isProjectContext = basePath.includes('projects');
+
+  const filtered = useMemo(() => {
+    let result = repositories;
+
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter((r) => r.fullName.toLowerCase().includes(q));
+    }
+
+    if (scopeFilter !== 'all') {
+      result = result.filter((r) => r.scopeIndicator === scopeFilter);
+    }
+
+    return result;
+  }, [repositories, search, scopeFilter]);
+
+  const hasFilters = !!search || scopeFilter !== 'all';
+
+  const canEdit = (repo: Repository) => !isProjectContext || repo.scopeIndicator === 'project';
 
   const handleEdit = (repo: Repository) => {
     setEditRepo(repo);
     router.reload({ data: { edit_repo_id: repo.id }, only: ['editBranches'] });
   };
-
-  const isProjectContext = basePath.includes('projects');
-
-  const projectRepos = useMemo(() => repositories.filter((r) => r.scopeIndicator === 'project'), [repositories]);
-  const companyRepos = useMemo(() => repositories.filter((r) => r.scopeIndicator === 'company'), [repositories]);
 
   const handleDelete = (repo: Repository) => {
     modals.openConfirmModal({
@@ -150,44 +113,6 @@ export const RepositoriesContent = ({ repositories, basePath, title, editBranche
     });
   };
 
-  const canEdit = (repo: Repository) => !isProjectContext || repo.scopeIndicator === 'project';
-
-  const renderRepoList = (repos: Repository[], readOnly = false) => (
-    <Stack gap="sm">
-      {repos.map((repo) => (
-        <RepoCard
-          key={repo.id}
-          repo={repo}
-          readOnly={readOnly || !canEdit(repo)}
-          canExecute={canExecute}
-          onEdit={handleEdit}
-          onDelete={handleDelete}
-          showScope={!isProjectContext}
-        />
-      ))}
-    </Stack>
-  );
-
-  const renderSection = (label: string, repos: Repository[], readOnly = false) => (
-    <Box>
-      <Group gap="xs" mb="sm">
-        <Text fw={600} size="sm" tt="uppercase" c="dimmed" lts={0.5}>
-          {label}
-        </Text>
-        <Badge size="xs" variant="light" color="gray">
-          {repos.length}
-        </Badge>
-      </Group>
-      {repos.length === 0 ? (
-        <Text c="dimmed" size="sm" mb="md">
-          {readOnly ? 'No company-wide repositories available.' : 'No repositories in this scope.'}
-        </Text>
-      ) : (
-        <Box mb="md">{renderRepoList(repos, readOnly)}</Box>
-      )}
-    </Box>
-  );
-
   return (
     <Box>
       <PageHeader
@@ -202,39 +127,162 @@ export const RepositoriesContent = ({ repositories, basePath, title, editBranche
         }
       />
 
-      {repositories.length === 0 ? (
-        <Card p="xl" withBorder radius="md">
-          <Stack align="center" gap="md" py="lg">
-            <ThemeIcon size={56} radius="xl" variant="light" color="gray">
-              <IconFolder size={28} />
-            </ThemeIcon>
-            <Box ta="center">
-              <Text fw={500} size="lg">
-                No repositories added
-              </Text>
-              <Text size="sm" c="dimmed" mt={4} maw={400}>
-                Add repositories to use as code context in agent sessions. Connect a GitHub or GitLab integration first.
-              </Text>
-            </Box>
-            {canExecute && (
-              <Button variant="light" leftSection={<IconPlus size={16} />} onClick={() => setAddModalOpen(true)}>
-                Add Repository
-              </Button>
-            )}
-          </Stack>
-        </Card>
-      ) : isProjectContext ? (
-        <Stack gap="lg">
-          {renderSection('This Project', projectRepos)}
-          {companyRepos.length > 0 && (
-            <>
-              <Divider />
-              {renderSection('Company-wide', companyRepos, true)}
-            </>
-          )}
-        </Stack>
+      <Group gap="md" mb="lg">
+        <TextInput
+          placeholder="Search repositories..."
+          leftSection={<IconSearch size={16} />}
+          value={search}
+          onChange={(e) => setSearch(e.currentTarget.value)}
+          maw={300}
+        />
+        {isProjectContext && (
+          <SegmentedControl
+            value={scopeFilter}
+            onChange={setScopeFilter}
+            data={[
+              { label: 'All', value: 'all' },
+              { label: 'Project', value: 'project' },
+              { label: 'Company', value: 'company' },
+            ]}
+            size="sm"
+          />
+        )}
+        <ResourceCount>
+          {filtered.length} {filtered.length === 1 ? 'repository' : 'repositories'}
+        </ResourceCount>
+      </Group>
+
+      {filtered.length === 0 ? (
+        <Box
+          style={{
+            border: '1px solid var(--app-border-default)',
+            borderRadius: 'var(--mantine-radius-md)',
+            backgroundColor: 'var(--app-bg-paper)',
+          }}
+        >
+          <EmptyState
+            icon={<IconFolder size={22} />}
+            title={
+              hasFilters
+                ? scopeFilter !== 'all' && !search
+                  ? 'No repositories in this scope'
+                  : 'No repositories match your filters'
+                : 'No repositories added'
+            }
+            description={
+              hasFilters
+                ? undefined
+                : 'Add repositories to use as code context in agent sessions. Connect a GitHub or GitLab integration first.'
+            }
+            action={
+              !hasFilters &&
+              canExecute && (
+                <Button variant="outline" onClick={() => setAddModalOpen(true)}>
+                  Add Repository
+                </Button>
+              )
+            }
+          />
+        </Box>
       ) : (
-        renderRepoList(repositories)
+        <ResourceTableShell>
+          <Table highlightOnHover>
+            <Table.Thead style={{ backgroundColor: 'var(--app-bg-deep)' }}>
+              <Table.Tr>
+                <ResourceTh>Repository</ResourceTh>
+                <ResourceTh>Source</ResourceTh>
+                {isProjectContext && <ResourceTh>Scope</ResourceTh>}
+                <ResourceTh align="right" w={90}>
+                  Actions
+                </ResourceTh>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {filtered.map((repo) => {
+                const readOnly = !canEdit(repo);
+                return (
+                  <Table.Tr key={repo.id}>
+                    <Table.Td>
+                      <Group gap="sm" wrap="nowrap">
+                        <Box
+                          w={36}
+                          h={36}
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            backgroundColor: 'var(--app-bg-deep)',
+                            borderRadius: 'var(--mantine-radius-sm)',
+                            color: repo.isPrivate ? 'var(--app-warning-fg)' : 'var(--app-text-secondary)',
+                            flexShrink: 0,
+                          }}
+                        >
+                          {repo.isPrivate ? <IconLock size={16} /> : <IconWorld size={16} />}
+                        </Box>
+                        <Box style={{ minWidth: 0 }}>
+                          <Group gap={6} wrap="nowrap">
+                            <Text fz={14} fw={500} c="var(--app-text-primary)" truncate>
+                              {repo.fullName}
+                            </Text>
+                            <Badge size="xs" variant="light" leftSection={<IconGitBranch size={10} />}>
+                              {repo.sourceBranch}
+                            </Badge>
+                          </Group>
+                          {repo.purpose && (
+                            <Text fz={12} c="dimmed" truncate maw={340}>
+                              {repo.purpose}
+                            </Text>
+                          )}
+                        </Box>
+                      </Group>
+                    </Table.Td>
+                    <Table.Td>
+                      <Text fz={13} c="dimmed">
+                        {repo.integration?.name ?? (repo.publicSource ? 'Public (read-only)' : 'No integration')}
+                      </Text>
+                    </Table.Td>
+                    {isProjectContext && (
+                      <Table.Td>
+                        <Badge color={SCOPE_COLORS[repo.scopeIndicator] ?? 'gray'} size="sm" variant="light">
+                          {repo.scopeIndicator}
+                        </Badge>
+                      </Table.Td>
+                    )}
+                    <Table.Td>
+                      {canExecute && (
+                        <Group gap={4} justify="flex-end">
+                          <Tooltip label={readOnly ? 'Company-managed' : 'Edit'}>
+                            <ActionIcon
+                              aria-label="Edit"
+                              variant="subtle"
+                              size="sm"
+                              disabled={readOnly}
+                              onClick={() => handleEdit(repo)}
+                            >
+                              <IconEdit size={16} />
+                            </ActionIcon>
+                          </Tooltip>
+                          <Tooltip label={readOnly ? 'Company-managed' : 'Remove'}>
+                            <ActionIcon
+                              aria-label="Remove"
+                              variant="subtle"
+                              size="sm"
+                              color="red"
+                              disabled={readOnly}
+                              onClick={() => handleDelete(repo)}
+                            >
+                              <IconTrash size={16} />
+                            </ActionIcon>
+                          </Tooltip>
+                        </Group>
+                      )}
+                    </Table.Td>
+                  </Table.Tr>
+                );
+              })}
+            </Table.Tbody>
+          </Table>
+        </ResourceTableShell>
       )}
 
       <AddRepositoryModal

--- a/app/frontend/shared/resources/tools/ToolFormModal.test.tsx
+++ b/app/frontend/shared/resources/tools/ToolFormModal.test.tsx
@@ -56,11 +56,11 @@ describe('ToolFormModal', () => {
     expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
   });
 
-  it('clicking Cancel calls onClose', async () => {
+  it('clicking the drawer close button calls onClose', async () => {
     const onClose = vi.fn();
     renderPage(<ToolFormModal opened onClose={onClose} configItemNames={[]} basePath="/projects/1/tools" />);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Close' }));
     expect(onClose).toHaveBeenCalled();
   });
 

--- a/app/frontend/shared/resources/tools/ToolFormModal.tsx
+++ b/app/frontend/shared/resources/tools/ToolFormModal.tsx
@@ -5,7 +5,6 @@ import {
   Box,
   Button,
   Group,
-  Modal,
   MultiSelect,
   SegmentedControl,
   Stack,
@@ -19,6 +18,8 @@ import { IconCode, IconDownload, IconFile, IconPlus, IconTrash, IconUpload } fro
 import { zod4Resolver as zodResolver } from 'mantine-form-zod-resolver';
 import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { z } from 'zod';
+
+import { ResourceDrawer } from 'shared/ui/ResourceDrawer';
 
 import { ToolFileEditor } from './ToolFileEditor';
 
@@ -289,8 +290,17 @@ export const ToolFormModal: FC<ToolFormModalProps> = ({ opened, onClose, editToo
   const visibleFiles = files.filter((f) => !f._destroy);
 
   return (
-    <Modal opened={opened} onClose={onClose} title={isEditMode ? 'Edit Tool' : 'Create Tool'} size="lg" centered>
-      <form onSubmit={form.onSubmit(handleSubmit)}>
+    <ResourceDrawer
+      opened={opened}
+      onClose={onClose}
+      title={isEditMode ? 'Edit Tool' : 'Create Tool'}
+      footer={
+        <Button type="submit" form="tool-form" fullWidth loading={submitting}>
+          {isEditMode ? 'Save' : 'Create'}
+        </Button>
+      }
+    >
+      <form id="tool-form" onSubmit={form.onSubmit(handleSubmit)}>
         <Tabs value={activeTab} onChange={setActiveTab} mb="md">
           <Tabs.List>
             <Tabs.Tab value="basic">Basic Info</Tabs.Tab>
@@ -306,6 +316,7 @@ export const ToolFormModal: FC<ToolFormModalProps> = ({ opened, onClose, editToo
                 label="Name"
                 placeholder="my_tool"
                 description="Unique identifier (lowercase, underscores)"
+                withAsterisk
                 autoFocus
                 disabled={isEditMode}
                 styles={{ input: { fontFamily: '"JetBrains Mono", monospace' } }}
@@ -316,6 +327,7 @@ export const ToolFormModal: FC<ToolFormModalProps> = ({ opened, onClose, editToo
                 label="Display Name"
                 placeholder="My Custom Tool"
                 description="Human-readable name"
+                withAsterisk
               />
 
               <Textarea
@@ -331,6 +343,7 @@ export const ToolFormModal: FC<ToolFormModalProps> = ({ opened, onClose, editToo
                 label="Docker Image"
                 placeholder="python:3.11-slim"
                 description="Docker image to run"
+                withAsterisk
                 styles={{ input: { fontFamily: '"JetBrains Mono", monospace' } }}
               />
 
@@ -564,16 +577,7 @@ export const ToolFormModal: FC<ToolFormModalProps> = ({ opened, onClose, editToo
             </Box>
           </Tabs.Panel>
         </Tabs>
-
-        <Group justify="flex-end" mt="md">
-          <Button variant="default" onClick={onClose} disabled={submitting}>
-            Cancel
-          </Button>
-          <Button type="submit" loading={submitting}>
-            {isEditMode ? 'Save' : 'Create'}
-          </Button>
-        </Group>
       </form>
-    </Modal>
+    </ResourceDrawer>
   );
 };

--- a/app/frontend/shared/resources/tools/ToolsContent.tsx
+++ b/app/frontend/shared/resources/tools/ToolsContent.tsx
@@ -16,6 +16,7 @@ import { useMemo, useState } from 'react';
 import { useProjectPermissions } from 'shared/lib/hooks/useProjectPermissions';
 import { EmptyState } from 'shared/ui/EmptyState';
 import { PageHeader } from 'shared/ui/PageHeader';
+import { ResourceCount, ResourceTableShell, ResourceTh } from 'shared/ui/ResourceTable';
 
 import { DeleteToolModal } from './DeleteToolModal';
 import { ToolFormModal } from './ToolFormModal';
@@ -145,6 +146,9 @@ export function ToolsContent({
           ]}
           size="sm"
         />
+        <ResourceCount>
+          {filtered.length} {filtered.length === 1 ? 'wrapper' : 'wrappers'}
+        </ResourceCount>
       </Group>
 
       {filtered.length === 0 ? (
@@ -174,41 +178,17 @@ export function ToolsContent({
           />
         </Box>
       ) : (
-        <Box
-          style={{
-            border: '1px solid var(--app-border-default)',
-            borderRadius: 'var(--mantine-radius-md)',
-            overflow: 'hidden',
-          }}
-        >
+        <ResourceTableShell>
           <Table highlightOnHover>
             <Table.Thead style={{ backgroundColor: 'var(--app-bg-deep)' }}>
               <Table.Tr>
-                <Table.Th>
-                  <Text fz={12} fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: 0.5 }}>
-                    Tool
-                  </Text>
-                </Table.Th>
-                <Table.Th>
-                  <Text fz={12} fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: 0.5 }}>
-                    Scope
-                  </Text>
-                </Table.Th>
-                <Table.Th>
-                  <Text fz={12} fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: 0.5 }}>
-                    Docker Image
-                  </Text>
-                </Table.Th>
-                <Table.Th>
-                  <Text fz={12} fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: 0.5 }}>
-                    Files
-                  </Text>
-                </Table.Th>
-                <Table.Th w={100}>
-                  <Text fz={12} fw={600} c="dimmed" tt="uppercase" ta="right" style={{ letterSpacing: 0.5 }}>
-                    Actions
-                  </Text>
-                </Table.Th>
+                <ResourceTh>Tool</ResourceTh>
+                <ResourceTh>Scope</ResourceTh>
+                <ResourceTh>Docker Image</ResourceTh>
+                <ResourceTh>Files</ResourceTh>
+                <ResourceTh align="right" w={100}>
+                  Actions
+                </ResourceTh>
               </Table.Tr>
             </Table.Thead>
             <Table.Tbody>
@@ -287,7 +267,7 @@ export function ToolsContent({
               })}
             </Table.Tbody>
           </Table>
-        </Box>
+        </ResourceTableShell>
       )}
 
       <ToolFormModal

--- a/app/frontend/shared/ui/ResourceDrawer.tsx
+++ b/app/frontend/shared/ui/ResourceDrawer.tsx
@@ -1,0 +1,60 @@
+import { ActionIcon, Box, Drawer, Text } from '@mantine/core';
+import { IconX } from '@tabler/icons-react';
+import type { ReactNode } from 'react';
+
+interface ResourceDrawerProps {
+  opened: boolean;
+  onClose: () => void;
+  title: ReactNode;
+  children: ReactNode;
+  /** Typically a single full-width primary button — no Cancel. Close is the X in the header. */
+  footer?: ReactNode;
+}
+
+/**
+ * The one create/edit side panel in the app: 460px, right-slide, drop shadow,
+ * plain header (title + close, no accent icon tile), single full-width
+ * primary footer action. Matches the Sessions & Runs side panels.
+ */
+export function ResourceDrawer({ opened, onClose, title, children, footer }: ResourceDrawerProps) {
+  return (
+    <Drawer
+      opened={opened}
+      onClose={onClose}
+      position="right"
+      size={460}
+      withCloseButton={false}
+      padding={0}
+      styles={{
+        body: { padding: 0, height: '100%', display: 'flex', flexDirection: 'column' },
+        content: { display: 'flex', flexDirection: 'column' },
+      }}
+    >
+      <Box
+        style={{
+          padding: '18px 24px',
+          borderBottom: '1px solid var(--app-border-default)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          flexShrink: 0,
+        }}
+      >
+        <Text component="h2" fz={16} fw={600} c="var(--app-text-primary)" m={0}>
+          {title}
+        </Text>
+        <ActionIcon aria-label="Close" variant="subtle" color="gray" onClick={onClose}>
+          <IconX size={16} />
+        </ActionIcon>
+      </Box>
+
+      <Box style={{ flex: 1, overflowY: 'auto', padding: '22px 24px 24px' }}>{children}</Box>
+
+      {footer && (
+        <Box style={{ padding: '16px 24px', borderTop: '1px solid var(--app-border-default)', flexShrink: 0 }}>
+          {footer}
+        </Box>
+      )}
+    </Drawer>
+  );
+}

--- a/app/frontend/shared/ui/ResourceTable.tsx
+++ b/app/frontend/shared/ui/ResourceTable.tsx
@@ -1,0 +1,53 @@
+import { Table, Text } from '@mantine/core';
+import type { ReactNode } from 'react';
+
+interface ResourceTableShellProps {
+  children: ReactNode;
+  /** Ensures the table never collapses columns below legibility on narrow viewports. */
+  minWidth?: number;
+}
+
+/**
+ * The one resource list table shell in the app: bordered, rounded, dark
+ * header row, horizontal scroll below `minWidth` instead of squeezing
+ * columns. Wraps a plain `<Table>` — pass columns/rows as children.
+ */
+export function ResourceTableShell({ children, minWidth = 720 }: ResourceTableShellProps) {
+  return (
+    <Table.ScrollContainer
+      minWidth={minWidth}
+      style={{
+        border: '1px solid var(--app-border-default)',
+        borderRadius: 'var(--mantine-radius-md)',
+      }}
+    >
+      {children}
+    </Table.ScrollContainer>
+  );
+}
+
+interface ResourceThProps {
+  children: ReactNode;
+  align?: 'left' | 'right';
+  w?: number;
+}
+
+/** The one table header cell label style in the app. */
+export function ResourceTh({ children, align = 'left', w }: ResourceThProps) {
+  return (
+    <Table.Th w={w}>
+      <Text fz={12} fw={600} c="dimmed" tt="uppercase" ta={align} style={{ letterSpacing: 0.5 }}>
+        {children}
+      </Text>
+    </Table.Th>
+  );
+}
+
+/** Row/table total, right-aligned in the toolbar. Sans — never mono, per design spec. */
+export function ResourceCount({ children }: { children: ReactNode }) {
+  return (
+    <Text fz={13} c="dimmed" ml="auto" style={{ whiteSpace: 'nowrap' }}>
+      {children}
+    </Text>
+  );
+}


### PR DESCRIPTION
## Summary
Implements the design spec in #456: replaces the four Resources pages' inconsistent layouts (Agents/Wrappers already tables, Repositories/Integrations were card grids grouped into "This Project" / "Company-wide" sections) with one shared table shell (`ResourceTableShell`/`ResourceTh`), one shared empty state, one shared 460px right-slide create/edit drawer (`ResourceDrawer`), and a consistent search + filter + count toolbar across all four pages.

- **Agents / Wrappers**: kept their real data columns (no fabricated Status/session-count fields), applied the new table visual language, added a count, converted the create/edit form to the drawer, added required-field asterisks, moved the agent icon picker to lead the Name row.
- **Repositories**: flattened from Project/Company-wide sectioned cards into one table with search + a Scope segmented filter (All/Project/Company), matching the Integrations treatment for consistency.
- **Integrations**: flattened into one table with the same Scope filter (per spec item 5), added an inline "No integrations in this scope." row, added the Connect button's chevron-flip, kept the GitLab/Coder connect modals and delete confirmations as-is (out of the create-drawer scope).
- Fixed a pre-existing accessibility bug where Agents' Duplicate/Edit/Delete row actions all shared the aria-label "Duplicate".
- Seeded dev data (agents, wrappers, repositories, integrations) for the Demo Alpha project so the tables aren't empty locally.

Design tokens (`--app-*` CSS variables in `mantineTheme.ts`) already matched the reference HTML exactly in both dark and light mode, so no palette/spacing changes were needed — only table/empty-state/drawer structure.

## Test plan
- [x] `vitest run` on all touched resource files: 155/155 passing
- [x] `tsc --noEmit`: clean
- [x] `eslint` on touched files: clean
- [x] `rubocop`: clean (no Ruby files touched)
- [x] `brakeman`: 0 warnings (no Ruby files touched)
- [ ] `bin/rails test` (full backend suite) — **could not get a clean run**: the shared dev Postgres was being hit by a concurrent process (parallel test-DB corruption: "database not found aixle_test_N", duplicate-key errors recreating schemas) plus 3 pre-existing pending migrations already in the repo unrelated to this change. This PR touches zero backend Ruby files, so it shouldn't be affected — recommend CI re-verifies on a clean runner.
- [x] Manually verified all 4 redesigned pages in the browser (Agents, Wrappers, Repositories, Integrations) against seeded data — tables, search, filters, counts, and empty states all render correctly in both project and company contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)