### PR TITLE
feat(personal-mcp): add trigger, authoring and diagnostic tools

### DIFF
--- a/app/frontend/pages/Docs/data/pages/mcp.md
+++ b/app/frontend/pages/Docs/data/pages/mcp.md
@@ -50,10 +50,17 @@ This server is **session-less** and grants **exactly your own access
 level** — every action runs through the same permission checks as the UI,
 so you can only do in a project what you could do by hand. It exposes the
 things you do in the app: list your companies and projects, manage board
-tasks and columns, build and run workflows (steps, sub-steps, triggers,
-runs), manage agents, custom tools, skills, MCP servers, config items and
-repositories, and update project settings. Two built-in prompts,
+tasks, columns and gates, build and run workflows (steps, sub-steps,
+triggers, runs), manage agents, custom tools, skills, MCP servers, config
+items and repositories, and update project settings. Two built-in prompts,
 `build_workflow` and `author_step`, guide multi-step construction.
+
+A workflow built this way can be wired up end to end: `create_workflow_trigger`
+attaches a board column, a Slack message, a cron schedule or an inbound
+webhook, so the workflow launches on its own rather than only on a button.
+When a run misbehaves, `get_step_run` returns that step's error, retry
+history and container-session diagnostics — the same detail the run page
+shows.
 
 The token is shown once — regenerate or disable it any time from your
 profile. Regenerating immediately invalidates the old token.

--- a/app/services/personal_tools/archive_board_task.rb
+++ b/app/services/personal_tools/archive_board_task.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class ArchiveBoardTask < Base
+    tool do
+      display_name "Archive Board Task"
+      description "Archive a board task, or unarchive it by passing archived=false. " \
+                  "The resulting state is reported as `archived` by get_board_task."
+      audience :user
+      tags :board
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :task_id, type: :integer, description: "Board task id.", required: true
+      param :archived, type: :boolean,
+            description: "true archives (the default); false unarchives.", default: true
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project.board, :update?, policy: Web::Company::Projects::Board::TasksPolicy, project: project)
+      task = project.board&.board_tasks&.find_by(id: params[:task_id])
+      return error("Task not found on this project's board") unless task
+
+      # Through TaskService, so the board activity feed records the change the
+      # same way the UI's archive action does.
+      archive? ? TaskService.archive(task: task, actor: user) : TaskService.unarchive(task: task, actor: user)
+      return error("Failed to update task: #{task.errors.full_messages.to_sentence}") if task.errors.any?
+
+      success(id: task.id, title: task.title, archived: task.archived?, archived_at: task.archived_at)
+    end
+
+    private
+
+    # Omitting the param archives; only an explicit false unarchives.
+    def archive?
+      params[:archived].nil? || ActiveModel::Type::Boolean.new.cast(params[:archived]) != false
+    end
+  end
+end

--- a/app/services/personal_tools/create_board_column.rb
+++ b/app/services/personal_tools/create_board_column.rb
@@ -4,13 +4,15 @@ module PersonalTools
   class CreateBoardColumn < Base
     tool do
       display_name "Create Board Column"
-      description "Add a column to a project's board. Requires project-admin (owner)."
+      description "Add a column to a project's board. Requires project-admin (owner). " \
+                  "A given position inserts there, pushing the columns at and after it one " \
+                  "place right; omitting it appends."
       audience :user
       tags :board
       param :project_id, type: :integer, description: "Project id.", required: true
       param :name, type: :string, description: "Column name.", required: true
       param :purpose, type: :string, description: "What the column represents."
-      param :position, type: :integer, description: "Position; appended if omitted."
+      param :position, type: :integer, description: "Insert position; appended if omitted."
     end
 
     def execute
@@ -19,11 +21,37 @@ module PersonalTools
       board = project.board
       return error("This project has no board") unless board
 
-      position = params[:position] || (board.board_columns.maximum(:position).to_i + 1)
-      column = board.board_columns.create!(name: params[:name], purpose: params[:purpose], position: position)
+      column = ActiveRecord::Base.transaction { insert_column(board) }
       success(id: column.id, name: column.name, position: column.position)
     rescue ActiveRecord::RecordInvalid => e
       error("Failed to create column: #{e.message}")
+    end
+
+    private
+
+    def insert_column(board)
+      position = params[:position]&.to_i
+      if position.nil?
+        position = board.board_columns.maximum(:position).to_i + 1
+      else
+        shift_right_from(board, position)
+      end
+
+      board.board_columns.create!(name: params[:name], purpose: params[:purpose], position: position)
+    end
+
+    # Both the model's uniqueness validation and the (board_id, position)
+    # unique index reject a collision, so the shift walks the tail backwards:
+    # the highest position moves first, into a slot nothing occupies, and every
+    # later step's target has already been vacated. No intermediate duplicate,
+    # hence no need for the negative-position two-phase pass
+    # reorder_board_columns does (that one permutes ids, not a single shift).
+    # `reorder` because the association carries a default `order(:position)`
+    # that a plain `order` would only append to — leaving the walk ascending.
+    def shift_right_from(board, position)
+      board.board_columns.where(position: position..).reorder(position: :desc).each do |column|
+        column.update_column(:position, column.position + 1)
+      end
     end
   end
 end

--- a/app/services/personal_tools/create_workflow_step.rb
+++ b/app/services/personal_tools/create_workflow_step.rb
@@ -4,7 +4,7 @@ module PersonalTools
   class CreateWorkflowStep < Base
     tool do
       display_name "Create Workflow Step"
-      description "Add a step to a workflow. Steps run in position order unless dependencies say otherwise."
+      description "Add a step to a workflow, wiring included. Steps run in position order unless dependencies say otherwise."
       audience :user
       tags :workflows
       param :project_id, type: :integer, description: "Project id.", required: true
@@ -13,7 +13,27 @@ module PersonalTools
       param :instructions, type: :string, description: "Task-specific instructions (markdown)."
       param :agent_id, type: :integer, description: "Agent id to run this step."
       param :position, type: :integer, description: "0-based position; auto-assigned if omitted."
+      param :tool_ids, type: :array,
+            description: "Tool ids available in this step. Replaces the whole list — read the current value " \
+                         "with get_workflow_step first.",
+            items: { type: "integer" }
+      param :skill_ids, type: :array,
+            description: "Skill ids injected into context. Replaces the whole list — read the current value " \
+                         "with get_workflow_step first.",
+            items: { type: "integer" }
+      param :mcp_server_ids, type: :array,
+            description: "MCP server ids. Replaces the whole list — read the current value with " \
+                         "get_workflow_step first.",
+            items: { type: "integer" }
+      param :depends_on_step_ids, type: :array,
+            description: "Step ids this step depends on; they must already exist. Replaces the whole list — " \
+                         "read the current value with get_workflow_step first.",
+            items: { type: "integer" }
+      param :bmad_enabled, type: :boolean, description: "Run this step with the BMAD method enabled."
+      param :allow_non_interactive, type: :boolean, description: "Allow this step to run without a human in the loop."
     end
+
+    OPTIONAL = %i[tool_ids skill_ids mcp_server_ids depends_on_step_ids bmad_enabled allow_non_interactive].freeze
 
     def execute
       project = find_project!
@@ -23,12 +43,21 @@ module PersonalTools
 
       position = params[:position] || (workflow.steps.maximum(:position).to_i + 1)
       step = workflow.steps.create!(
-        name: params[:name], position: position,
-        instructions: params[:instructions], agent_id: params[:agent_id]
+        { name: params[:name], position: position,
+          instructions: params[:instructions], agent_id: params[:agent_id] }.merge(wiring)
       )
-      success(id: step.id, workflow_id: workflow.id, name: step.name, position: step.position)
+      success(id: step.id, workflow_id: workflow.id, name: step.name, position: step.position,
+              tool_ids: step.tool_ids, skill_ids: step.skill_ids, mcp_server_ids: step.mcp_server_ids,
+              depends_on_step_ids: step.depends_on_step_ids, bmad_enabled: step.bmad_enabled,
+              allow_non_interactive: step.allow_non_interactive)
     rescue ActiveRecord::RecordInvalid => e
       error("Failed to create step: #{e.message}")
+    end
+
+    private
+
+    def wiring
+      OPTIONAL.each_with_object({}) { |k, h| h[k] = params[k] if params.key?(k) }
     end
   end
 end

--- a/app/services/personal_tools/create_workflow_trigger.rb
+++ b/app/services/personal_tools/create_workflow_trigger.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class CreateWorkflowTrigger < Base
+    include WorkflowTriggerSupport
+
+    # A column trigger binds to a board column, which cannot exist without a
+    # board — reported as a tool error, not a lookup failure.
+    BoardMissingError = Class.new(StandardError)
+
+    tool do
+      display_name "Create Workflow Trigger"
+      description "Connect a trigger to a workflow so it launches on its own: a card entering a " \
+                  "board column (kind=column), a Slack message (slack), a cron schedule (schedule), " \
+                  "an inbound webhook (webhook), or a custom platform event (event). " \
+                  "IMPORTANT: the off-board kinds (slack, schedule, webhook, event) fire unattended, " \
+                  "so EVERY step of the workflow must have auto-run (allow_non_interactive) enabled — " \
+                  "otherwise this call is rejected and the error names the steps still waiting on a " \
+                  "human. Column triggers are exempt: their manual mode puts a person on the button. " \
+                  "kind=webhook also provisions an inbound endpoint and returns webhook_url and " \
+                  "webhook_secret; the secret is shown only in this response."
+      audience :user
+      tags :workflows
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :workflow_id, type: :integer, description: "Workflow id.", required: true
+      param :kind, type: :string, enum: WorkflowTriggerSupport::KINDS, required: true,
+                   description: "What launches the workflow."
+      param :board_column_id, type: :integer,
+                              description: "Board column whose incoming cards fire the workflow. Required for kind=column."
+      param :event_type, type: :string,
+                         description: "Platform event name for kind=event (e.g. 'github.push'). Ignored for the " \
+                                      "other kinds, which set their own event type."
+      param :name, type: :string, description: "Human-readable label for this trigger."
+      param :trigger_mode, type: :string, enum: WorkflowTriggerSupport::TRIGGER_MODES,
+                           description: "auto starts the run immediately; manual only offers it. Defaults to auto."
+      param :enabled, type: :boolean, description: "Whether the trigger fires. Defaults to true; column triggers are always on."
+      param :cooldown_seconds, type: :integer, description: "Minimum gap between two firings. Defaults to 5 for column triggers, 0 otherwise."
+      param :subject_policy, type: :string, enum: WorkflowTriggerSupport::SUBJECT_POLICIES,
+                             description: "Which board task the run is about: none, existing_task, or create_task " \
+                                          "(create_task also needs subject_column_id)."
+      param :subject_column_id, type: :integer, description: "Board column the new card lands in when subject_policy is create_task."
+      param :subject_title_template, type: :string, description: "Title template for the card created by subject_policy=create_task."
+      param :filter_predicate, type: :object,
+                               description: "Only fire when the event data contains these key/value pairs, " \
+                                            "e.g. {\"channel\": \"C123\"}. Empty means every event of this type."
+      param :schedule_config, type: :object,
+                              description: "Required for kind=schedule: {\"cron\": \"0 9 * * 1-5\", \"timezone\": " \
+                                           "\"Europe/Berlin\"}. ALWAYS pass timezone explicitly — an empty timezone " \
+                                           "makes Temporal schedule in UTC, which drifts by an hour under DST."
+      param :verification_strategy, type: :string, enum: WorkflowTriggerSupport::VERIFICATION_STRATEGIES,
+                                    description: "How the inbound webhook is authenticated (kind=webhook). Defaults to none."
+      param :secret, type: :string, description: "Shared secret for the webhook's verification strategy (kind=webhook)."
+    end
+
+    def execute
+      kind = params[:kind].to_s
+      return error("Unsupported trigger kind: #{kind}") unless WorkflowTriggerSupport::KINDS.include?(kind)
+
+      project = find_project!
+      authorize!(project, :update?, policy: Web::Company::Projects::WorkflowsPolicy, project: project)
+      workflow = find_workflow!(project)
+
+      success(build_trigger(project, workflow, kind))
+    rescue BoardMissingError
+      error("This project has no board. Create a board before adding a column trigger.")
+    rescue ActiveRecord::RecordInvalid => e
+      error(e.record.errors.full_messages.join(", "))
+    rescue Temporalio::Error => e
+      # Schedule triggers reconcile onto Temporal synchronously on save: the
+      # binding IS persisted and only the scheduling failed. Re-saving retries,
+      # and the worker-boot sync re-reconciles.
+      Rails.logger.error("[personal-mcp] Temporal scheduling failed: #{e.message}")
+      error("Trigger saved, but scheduling it failed — re-save to retry. (#{e.message})")
+    end
+
+    private
+
+    def build_trigger(project, workflow, kind)
+      case kind
+      when "column" then create_column_trigger(project, workflow)
+      when "webhook" then create_webhook_trigger(project, workflow)
+      else create_event_trigger(project, workflow, kind)
+      end
+    end
+
+    def create_column_trigger(project, workflow)
+      board = project.board
+      raise BoardMissingError unless board
+
+      column = board.board_columns.find_by(id: params[:board_column_id])
+      raise NotFoundError, "Board column #{params[:board_column_id]} not found on this project's board" unless column
+
+      serialize_column(ColumnWorkflowBinding.create!(
+                         board_column: column,
+                         workflow: workflow,
+                         trigger_mode: params[:trigger_mode].presence || "auto",
+                         cooldown_seconds: params[:cooldown_seconds].presence || 5
+                       ))
+    end
+
+    def create_event_trigger(project, workflow, kind)
+      event_type =
+        case kind
+        when "slack" then "slack.message"
+        when "schedule" then "schedule.fired"
+        else params[:event_type].to_s.presence || "webhook.received"
+        end
+
+      serialize_binding(create_binding!(project, workflow, event_type))
+    end
+
+    def create_webhook_trigger(project, workflow)
+      token = SecureRandom.hex(6)
+      event_type = "webhook.#{token}"
+
+      # One transaction so a rejected binding (the auto-run rule rejects most
+      # first attempts) doesn't leave an orphan endpoint behind on every retry.
+      endpoint, trigger = ActiveRecord::Base.transaction do
+        created = WebhookEndpoint.create!(
+          slug: "wh-#{token}",
+          provider: :generic,
+          verification_strategy: params[:verification_strategy].presence || "none",
+          secret: params[:secret].presence,
+          config: { "event_type" => event_type },
+          project: project,
+          company: project.company,
+          created_by: user
+        )
+        [ created, create_binding!(project, workflow, event_type) ]
+      end
+
+      serialize_binding(trigger).merge(
+        webhook_url: webhook_url(endpoint.slug),
+        webhook_secret: endpoint.secret,
+        verification_strategy: endpoint.verification_strategy
+      )
+    end
+
+    def create_binding!(project, workflow, event_type)
+      workflow.trigger_bindings.create!(
+        trigger_binding_attrs.merge(project: project, created_by: user, event_type: event_type)
+      )
+    end
+
+    def webhook_url(slug)
+      "https://#{Settings.domain}/webhooks/in/#{slug}"
+    end
+  end
+end

--- a/app/services/personal_tools/delete_gate.rb
+++ b/app/services/personal_tools/delete_gate.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class DeleteGate < Base
+    tool do
+      display_name "Delete Gate"
+      description "Delete a gate from a board task — how to unstick a task blocked on a CI gate " \
+                  "whose resolving webhook never arrived (see list_gates for the ids)."
+      audience :user
+      tags :board
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :gate_id, type: :integer, description: "Gate id, from list_gates.", required: true
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project.board, :update?, policy: Web::Company::Projects::Board::TasksPolicy, project: project)
+      gate = find_gate(project)
+      return error("Gate not found on this project's board") unless gate
+
+      attributes = { deleted_gate_id: gate.id, board_task_id: gate.board_task_id, gate_type: gate.gate_type }
+      gate.destroy
+      success(attributes)
+    end
+
+    private
+
+    # Scoped through this project's own board tasks — never Gate.find, which
+    # would hand any company's gate over by id alone.
+    def find_gate(project)
+      Gate.where(board_task_id: project.board&.board_tasks&.select(:id)).find_by(id: params[:gate_id])
+    end
+  end
+end

--- a/app/services/personal_tools/delete_workflow_trigger.rb
+++ b/app/services/personal_tools/delete_workflow_trigger.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class DeleteWorkflowTrigger < Base
+    include WorkflowTriggerSupport
+
+    tool do
+      display_name "Delete Workflow Trigger"
+      description "Remove a trigger from a workflow — the workflow itself is untouched. Pass its " \
+                  "kind together with trigger_id: column triggers and event triggers are separate " \
+                  "records whose ids can collide. Deleting a schedule trigger also removes its " \
+                  "Temporal schedule."
+      audience :user
+      tags :workflows
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :workflow_id, type: :integer, description: "Workflow id.", required: true
+      param :trigger_id, type: :integer, description: "Trigger id (from list_workflow_triggers).", required: true
+      param :kind, type: :string, enum: WorkflowTriggerSupport::KINDS, required: true,
+                   description: "The trigger's kind, as reported by list_workflow_triggers."
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project, :update?, policy: Web::Company::Projects::WorkflowsPolicy, project: project)
+      workflow = find_workflow!(project)
+      kind = params[:kind].to_s
+
+      trigger =
+        if kind == "column"
+          find_column_trigger!(project, workflow, params[:trigger_id])
+        else
+          find_event_trigger!(workflow, params[:trigger_id])
+        end
+
+      trigger.destroy!
+      success(deleted_trigger_id: trigger.id, kind: kind, workflow_id: workflow.id)
+    end
+  end
+end

--- a/app/services/personal_tools/duplicate_workflow.rb
+++ b/app/services/personal_tools/duplicate_workflow.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class DuplicateWorkflow < Base
+    tool do
+      display_name "Duplicate Workflow"
+      description "Copy a workflow — steps, sub-steps and their wiring — into the same or another project. " \
+                  "Returns the new workflow plus a needs_setup list: secrets, assets, repositories and " \
+                  "integrations are never copied and must be set up manually in the target project."
+      audience :user
+      tags :workflows
+      param :project_id, type: :integer, description: "Project id the source workflow lives in.", required: true
+      param :workflow_id, type: :integer, description: "Workflow id to copy.", required: true
+      param :name, type: :string,
+            description: "Name for the copy; defaults to the source name with a numeric suffix."
+      param :target_project_id, type: :integer,
+            description: "Project to copy into; defaults to the source project."
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project, :duplicate?, policy: Web::Company::Projects::WorkflowsPolicy, project: project)
+      workflow = find_workflow!(project)
+
+      target = target_project(project)
+      # Copying into another project writes there, so it needs write access there too.
+      authorize!(target, :duplicate?, policy: Web::Company::Projects::WorkflowsPolicy, project: target) unless target == project
+
+      duplicator = WorkflowDuplicator.new(workflow, target_scope: target, name: params[:name].presence)
+      copy = duplicator.duplicate!
+
+      success(id: copy.id, name: copy.name, project_id: target.id,
+              source_workflow_id: workflow.id, steps_count: copy.steps.not_deleted.count,
+              needs_setup: duplicator.summary&.dig(:needs_setup) || [])
+    rescue ActiveRecord::RecordInvalid => e
+      error("Failed to duplicate workflow: #{e.message}")
+    end
+
+    private
+
+    def target_project(source)
+      id = params[:target_project_id]
+      return source if id.blank? || id.to_i == source.id
+
+      find_project!(id)
+    end
+  end
+end

--- a/app/services/personal_tools/get_agent.rb
+++ b/app/services/personal_tools/get_agent.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  # `list_agents` answers with id/name/title only, which is enough to attach an
+  # agent to a step and nothing like enough to judge whether it is the right
+  # one — or, for an agent re-reading its own configuration, to know what it was
+  # told to be. Agents carry no `description` column: the text lives in
+  # persona / principles / communication_style, so all three are returned in full.
+  class GetAgent < Base
+    tool do
+      display_name "Get Agent"
+      description "Return one project agent in full: persona, principles, communication style and icon."
+      audience :user
+      tags :resources
+      read_only
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :agent_id, type: :integer, description: "Agent id (see list_agents).", required: true
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project, :index?, policy: Web::Company::Projects::AgentsPolicy, project: project)
+
+      agent = Agent.visible_for_project(project).find_by(id: params[:agent_id])
+      return error("Agent not found in this project") unless agent
+
+      success(id: agent.id, name: agent.name, title: agent.title, icon: agent.icon,
+              persona: agent.persona, principles: agent.principles,
+              communication_style: agent.communication_style,
+              source: agent.source.to_s, scope: agent.scope_type)
+    end
+  end
+end

--- a/app/services/personal_tools/get_skill.rb
+++ b/app/services/personal_tools/get_skill.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  # `list_skills` truncates description to 200 characters and never carries
+  # content, so "attach this skill or not" is decided from one line. This reads
+  # the whole thing — including the SKILL.md body an agent would actually run on.
+  class GetSkill < Base
+    tool do
+      display_name "Get Skill"
+      description "Return one project skill in full, including its complete SKILL.md content. " \
+                  "Skill content can be thousands of tokens — narrow the choice with list_skills " \
+                  "first and fetch this only for the skill you are actually deciding on."
+      audience :user
+      tags :resources
+      read_only
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :skill_id, type: :integer, description: "Skill id (see list_skills).", required: true
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project, :index?, policy: Web::Company::Projects::SkillsPolicy, project: project)
+
+      skill = ::Skill.visible_for_project(project).find_by(id: params[:skill_id])
+      return error("Skill not found in this project") unless skill
+
+      success(id: skill.id, name: skill.name, title: skill.title,
+              description: skill.description, content: skill.content,
+              package: skill.package, source: skill.source, source_url: skill.source_url,
+              origin: skill.origin.to_s)
+    end
+  end
+end

--- a/app/services/personal_tools/get_step_run.rb
+++ b/app/services/personal_tools/get_step_run.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class GetStepRun < Base
+    tool do
+      display_name "Get Step Run"
+      description "Return one step run in full: state, timings, retry count, error " \
+                  "category/message/history, skip reason and note, plus its terminal session's " \
+                  "state, error and context metadata (where the BMAD install status lands). " \
+                  "This is the tool for diagnosing a step that failed instead of just seeing " \
+                  "that it did — get_workflow_run only reports states."
+      audience :user
+      tags :workflows
+      read_only
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :step_run_id, type: :integer, description: "Step run id, from get_workflow_run.", required: true
+    end
+
+    # Diagnostics, not a log stream: a step's error text can carry a whole
+    # container tail, and error_history grows one entry per retry.
+    TEXT_LIMIT = 4_000
+    HISTORY_LIMIT = 10
+
+    def execute
+      project = find_project!
+      authorize!(project, :show?, policy: Web::Company::Projects::WorkflowRunsPolicy, project: project)
+      step_run = find_step_run(project)
+      return error("Step run not found in this project") unless step_run
+
+      success(step_run_payload(step_run).merge(terminal_session: session_payload(step_run.terminal_session)))
+    end
+
+    private
+
+    # Scoped through the project's own workflow runs — never a global
+    # StepRun.find, which would reach another company's run by id.
+    def find_step_run(project)
+      StepRun.where(workflow_run_id: WorkflowRun.where(project: project).select(:id))
+             .includes(:step, :terminal_session)
+             .find_by(id: params[:step_run_id])
+    end
+
+    def step_run_payload(step_run)
+      history = Array(step_run.error_history)
+      { id: step_run.id, workflow_run_id: step_run.workflow_run_id,
+        step_id: step_run.step_id, step: step_run.step&.name, step_position: step_run.step&.position,
+        state: step_run.state, started_at: step_run.started_at, completed_at: step_run.completed_at,
+        retry_count: step_run.retry_count,
+        error_category: step_run.error_category,
+        error_message: truncate(step_run.error_message),
+        error_history: history.last(HISTORY_LIMIT),
+        error_history_omitted: [ history.size - HISTORY_LIMIT, 0 ].max,
+        skip_reason: step_run.skip_reason,
+        step_note: truncate(step_run.step_note) }
+    end
+
+    # The container's own side of the failure: a step run that dies in seconds
+    # usually failed before it ran anything, and the reason sits here —
+    # context_metadata carries bmad_install_status / bmad_install_error.
+    def session_payload(session)
+      return nil unless session
+
+      { id: session.id, state: session.state, session_type: session.session_type,
+        agent_type: session.agent_type, started_at: session.started_at, finished_at: session.finished_at,
+        error_message: truncate(session.error_message), context_metadata: session.context_metadata }
+    end
+
+    def truncate(text)
+      return text if text.blank? || text.length <= TEXT_LIMIT
+
+      "#{text[0, TEXT_LIMIT]}... [truncated, #{text.length} chars total]"
+    end
+  end
+end

--- a/app/services/personal_tools/get_workflow.rb
+++ b/app/services/personal_tools/get_workflow.rb
@@ -4,7 +4,9 @@ module PersonalTools
   class GetWorkflow < Base
     tool do
       display_name "Get Workflow"
-      description "Return a workflow's full definition: steps, sub-steps, agents, dependencies."
+      description "Return a workflow's full definition: base resources, steps, sub-steps, agents, " \
+                  "dependencies. Step instructions are truncated here (instructions_truncated: true) — " \
+                  "use get_workflow_step to read a step's complete instructions before editing it."
       audience :user
       tags :workflows
       read_only
@@ -12,25 +14,40 @@ module PersonalTools
       param :workflow_id, type: :integer, description: "Workflow id.", required: true
     end
 
+    INSTRUCTIONS_LIMIT = 500
+
     def execute
       project = find_project!
       authorize!(project, :show?, policy: Web::Company::Projects::WorkflowsPolicy, project: project)
       workflow = Workflow.visible_for_project(project).find_by(id: params[:workflow_id])
       return error("Workflow not found in this project") unless workflow
 
-      steps = workflow.steps.not_deleted.includes(:agent).order(:position).map do |step|
-        { id: step.id, name: step.name, position: step.position,
-          instructions: step.instructions&.truncate(500),
-          agent: step.agent && { id: step.agent.id, title: step.agent.title },
-          tool_ids: step.tool_ids, skill_ids: step.skill_ids, mcp_server_ids: step.mcp_server_ids,
-          depends_on_step_ids: step.depends_on_step_ids,
-          sub_steps: step.sub_steps.active.order(:position).map { |ss|
-            { id: ss.id, name: ss.name, position: ss.position, required: ss.required,
-              instructions: ss.instructions&.truncate(500) }
-          } }
-      end
+      steps = workflow.steps.not_deleted.includes(:agent).order(:position).map { |step| step_view(step) }
       success(id: workflow.id, name: workflow.name, description: workflow.description,
+              published_at: workflow.published_at,
+              base_tool_ids: workflow.base_tool_ids, base_skill_ids: workflow.base_skill_ids,
+              base_mcp_server_ids: workflow.base_mcp_server_ids,
               steps_count: steps.size, steps: steps)
     end
+
+    private
+
+    def step_view(step)
+      { id: step.id, name: step.name, position: step.position,
+        instructions: truncate(step.instructions),
+        instructions_truncated: truncated?(step.instructions),
+        agent: step.agent && { id: step.agent.id, title: step.agent.title },
+        tool_ids: step.tool_ids, skill_ids: step.skill_ids, mcp_server_ids: step.mcp_server_ids,
+        depends_on_step_ids: step.depends_on_step_ids,
+        sub_steps: step.sub_steps.active.order(:position).map { |ss|
+          { id: ss.id, name: ss.name, position: ss.position, required: ss.required,
+            instructions: truncate(ss.instructions),
+            instructions_truncated: truncated?(ss.instructions) }
+        } }
+    end
+
+    def truncate(text) = text&.truncate(INSTRUCTIONS_LIMIT)
+
+    def truncated?(text) = text.present? && text.length > INSTRUCTIONS_LIMIT
   end
 end

--- a/app/services/personal_tools/get_workflow_step.rb
+++ b/app/services/personal_tools/get_workflow_step.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class GetWorkflowStep < Base
+    tool do
+      display_name "Get Workflow Step"
+      description "Return one workflow step in full: the complete, untruncated instructions plus every " \
+                  "wiring field (agent, tools, skills, MCP servers, dependencies, BMAD, retries, assets) " \
+                  "and its sub-steps. Use this before editing a step — get_workflow truncates instructions."
+      audience :user
+      tags :workflows
+      read_only
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :workflow_id, type: :integer, description: "Workflow id.", required: true
+      param :step_id, type: :integer, description: "Step id.", required: true
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project, :show?, policy: Web::Company::Projects::WorkflowsPolicy, project: project)
+      workflow = find_workflow!(project)
+      step = find_step!(workflow)
+
+      success(id: step.id, workflow_id: workflow.id, name: step.name, position: step.position,
+              instructions: step.instructions,
+              agent: step.agent && { id: step.agent.id, title: step.agent.title },
+              tool_ids: step.tool_ids, skill_ids: step.skill_ids, mcp_server_ids: step.mcp_server_ids,
+              depends_on_step_ids: step.depends_on_step_ids,
+              bmad_enabled: step.bmad_enabled, allow_non_interactive: step.allow_non_interactive,
+              max_retries: step.max_retries, on_failure: step.on_failure.to_s,
+              skip_policy: step.skip_policy.to_s, preferred_model: step.preferred_model,
+              required_agent_runtime: step.required_agent_runtime,
+              mount_repositories: step.mount_repositories,
+              input_asset_specs: step.input_asset_specs, output_asset_specs: step.output_asset_specs,
+              asset_ids: step.asset_ids,
+              sub_steps: sub_steps(step))
+    end
+
+    private
+
+    def sub_steps(step)
+      step.sub_steps.active.order(:position).map do |ss|
+        { id: ss.id, name: ss.name, position: ss.position, required: ss.required,
+          instructions: ss.instructions }
+      end
+    end
+  end
+end

--- a/app/services/personal_tools/list_gates.rb
+++ b/app/services/personal_tools/list_gates.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class ListGates < Base
+    tool do
+      display_name "List Gates"
+      description "List the gates on a board task — what a task reported as `pending_gates` " \
+                  "actually is. Gates are CI gates (GitHub checks/workflow, GitLab pipeline) " \
+                  "created and resolved by incoming CI webhooks, so there is deliberately no " \
+                  "tool to create or resolve one by hand; use delete_gate to clear a gate whose " \
+                  "webhook never arrived."
+      audience :user
+      tags :board
+      read_only
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :task_id, type: :integer, description: "Board task id.", required: true
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project.board, :show?, policy: Web::Company::Projects::Board::TasksPolicy, project: project)
+      task = project.board&.board_tasks&.find_by(id: params[:task_id])
+      return error("Task not found on this project's board") unless task
+
+      rows = task.gates.includes(:creator).order(:created_at).map do |gate|
+        { id: gate.id, gate_type: gate.gate_type, status: gate.status, metadata: gate.metadata,
+          creator: gate.creator&.name, creator_id: gate.creator_id,
+          created_at: gate.created_at, resolved_at: gate.resolved_at }
+      end
+      success(task_id: task.id, gates: rows)
+    end
+  end
+end

--- a/app/services/personal_tools/list_project_tools.rb
+++ b/app/services/personal_tools/list_project_tools.rb
@@ -1,10 +1,24 @@
 # frozen_string_literal: true
 
 module PersonalTools
+  # The catalog a workflow author picks a step's `tool_ids` from.
+  #
+  # Deliberately NOT chained with `.ui_visible`: that scope means "custom tools
+  # the UI lets you manage" (`db_source`), which is mutually exclusive with the
+  # platform half of `visible_for_project` — chaining the two stripped every
+  # platform tool back out and answered `[]` for any project without custom
+  # tools. `visible_for_project` is the same set the UI pickers offer, so it is
+  # what an MCP client should see too.
   class ListProjectTools < Base
+    # High enough that a real project is never clipped; when it is, the payload
+    # says so instead of pretending the list is complete.
+    LIMIT = 200
+
     tool do
       display_name "List Project Tools"
-      description "List the tools available in a project (custom tools and attachable platform tools)."
+      description "List the tools available in a project — attachable platform tools plus the " \
+                  "project's own custom tools — with description, tags and integration " \
+                  "requirement, so a step's tool_ids can be chosen rather than guessed."
       audience :user
       tags :resources
       read_only
@@ -15,10 +29,31 @@ module PersonalTools
       project = find_project!
       authorize!(project, :index?, policy: Web::Company::Projects::ToolsPolicy, project: project)
 
-      rows = Tool.visible_for_project(project).ui_visible.limit(100).map do |t|
-        { id: t.id, name: t.name, display_name: t.display_name, source: t.source, enabled: t.enabled }
-      end
-      success(project_id: project.id, tools: rows)
+      # One row past the cap: enough to tell "exactly full" from "clipped".
+      found = Tool.visible_for_project(project).order(:source, :name).limit(LIMIT + 1).to_a
+      truncated = found.size > LIMIT
+      rows = found.first(LIMIT).map { |t| serialize(t) }
+
+      payload = { project_id: project.id, tools_count: rows.size, tools: rows, truncated: truncated }
+      payload[:note] = "Listing capped at #{LIMIT} tools; more are available." if truncated
+      success(payload)
+    end
+
+    private
+
+    # Registry-first, like the session MCP server: for a platform tool the
+    # in-code definition is authoritative, so a shadow row that has not been
+    # reconciled since the last deploy can never serve stale metadata.
+    def serialize(tool)
+      defn = tool.definition
+      { id: tool.id,
+        name: tool.name,
+        display_name: defn&.display_name.presence || tool.display_name,
+        description: (defn&.description.presence || tool.description)&.truncate(200),
+        source: tool.source,
+        tags: (defn&.tags || tool.tags).map(&:to_s),
+        requires_integration: (defn&.requires_integration || tool.requires_integration)&.to_s,
+        enabled: tool.enabled }
     end
   end
 end

--- a/app/services/personal_tools/list_workflow_triggers.rb
+++ b/app/services/personal_tools/list_workflow_triggers.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class ListWorkflowTriggers < Base
+    include WorkflowTriggerSupport
+
+    tool do
+      display_name "List Workflow Triggers"
+      description "List everything that can launch a workflow: board-column bindings plus " \
+                  "Slack / schedule / webhook / custom-event triggers. Pass the returned id " \
+                  "together with its kind to update_workflow_trigger or delete_workflow_trigger — " \
+                  "the two kinds are separate records and their ids can collide."
+      audience :user
+      tags :workflows
+      read_only
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :workflow_id, type: :integer, description: "Workflow id.", required: true
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project, :show?, policy: Web::Company::Projects::WorkflowsPolicy, project: project)
+      workflow = find_workflow!(project)
+
+      triggers = column_bindings(project, workflow).map { |t| serialize_column(t) } +
+                 workflow.trigger_bindings.order(:created_at).map { |t| serialize_binding(t) }
+      success(project_id: project.id, workflow_id: workflow.id, triggers: triggers)
+    end
+  end
+end

--- a/app/services/personal_tools/update_workflow.rb
+++ b/app/services/personal_tools/update_workflow.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class UpdateWorkflow < Base
+    tool do
+      display_name "Update Workflow"
+      description "Update a workflow's name, description and base resources (tools/skills/MCP servers " \
+                  "granted to every step). Read the current values with get_workflow first."
+      audience :user
+      tags :workflows
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :workflow_id, type: :integer, description: "Workflow id.", required: true
+      param :name, type: :string, description: "Updated workflow name."
+      param :description, type: :string, description: "Updated workflow description."
+      param :base_tool_ids, type: :array,
+            description: "Tool ids granted to every step of this workflow. Replaces the whole list — " \
+                         "read the current value with get_workflow first.",
+            items: { type: "integer" }
+      param :base_skill_ids, type: :array,
+            description: "Skill ids injected into every step of this workflow. Replaces the whole list — " \
+                         "read the current value with get_workflow first.",
+            items: { type: "integer" }
+      param :base_mcp_server_ids, type: :array,
+            description: "MCP server ids available to every step of this workflow. Replaces the whole list — " \
+                         "read the current value with get_workflow first.",
+            items: { type: "integer" }
+    end
+
+    ATTRS = %i[name description].freeze
+    # Base resources are not columns — they live in workflow.config, behind the
+    # model's base_* readers and merge_config! writer.
+    CONFIG_ATTRS = %i[base_tool_ids base_skill_ids base_mcp_server_ids].freeze
+
+    def execute
+      project = find_project!
+      authorize!(project, :update?, policy: Web::Company::Projects::WorkflowsPolicy, project: project)
+      workflow = find_workflow!(project)
+
+      attrs = ATTRS.each_with_object({}) { |k, h| h[k] = params[k] if params.key?(k) }
+      config = CONFIG_ATTRS.each_with_object({}) { |k, h| h[k] = Array(params[k]).map(&:to_i) if params.key?(k) }
+      return error("No fields to update") if attrs.empty? && config.empty?
+
+      ActiveRecord::Base.transaction do
+        workflow.update!(attrs) if attrs.any?
+        workflow.merge_config!(config) if config.any?
+      end
+
+      success(id: workflow.id, name: workflow.name, description: workflow.description,
+              base_tool_ids: workflow.base_tool_ids, base_skill_ids: workflow.base_skill_ids,
+              base_mcp_server_ids: workflow.base_mcp_server_ids,
+              updated_fields: (attrs.keys + config.keys).map(&:to_s))
+    rescue ActiveRecord::RecordInvalid => e
+      error("Failed to update workflow: #{e.message}")
+    end
+  end
+end

--- a/app/services/personal_tools/update_workflow_step.rb
+++ b/app/services/personal_tools/update_workflow_step.rb
@@ -4,7 +4,8 @@ module PersonalTools
   class UpdateWorkflowStep < Base
     tool do
       display_name "Update Workflow Step"
-      description "Update a workflow step's fields (name, instructions, agent, tools, skills, deps)."
+      description "Update a workflow step's fields (name, instructions, agent, tools, skills, deps, BMAD). " \
+                  "Read the step with get_workflow_step first — every id list here replaces the current one."
       audience :user
       tags :workflows
       param :project_id, type: :integer, description: "Project id.", required: true
@@ -13,13 +14,30 @@ module PersonalTools
       param :name, type: :string, description: "Updated name."
       param :instructions, type: :string, description: "Updated instructions (markdown)."
       param :agent_id, type: :integer, description: "Agent id to run this step."
-      param :tool_ids, type: :array, description: "Tool ids available in this step.", items: { type: "integer" }
-      param :skill_ids, type: :array, description: "Skill ids injected into context.", items: { type: "integer" }
-      param :mcp_server_ids, type: :array, description: "MCP server ids.", items: { type: "integer" }
-      param :depends_on_step_ids, type: :array, description: "Step ids this step depends on.", items: { type: "integer" }
+      param :tool_ids, type: :array,
+            description: "Tool ids available in this step. Replaces the whole list — read the current value " \
+                         "with get_workflow_step first.",
+            items: { type: "integer" }
+      param :skill_ids, type: :array,
+            description: "Skill ids injected into context. Replaces the whole list — read the current value " \
+                         "with get_workflow_step first.",
+            items: { type: "integer" }
+      param :mcp_server_ids, type: :array,
+            description: "MCP server ids. Replaces the whole list — read the current value with " \
+                         "get_workflow_step first.",
+            items: { type: "integer" }
+      param :depends_on_step_ids, type: :array,
+            description: "Step ids this step depends on. Replaces the whole list — read the current value " \
+                         "with get_workflow_step first.",
+            items: { type: "integer" }
+      param :bmad_enabled, type: :boolean, description: "Run this step with the BMAD method enabled."
+      param :allow_non_interactive, type: :boolean, description: "Allow this step to run without a human in the loop."
     end
 
-    UPDATABLE = %i[name instructions agent_id tool_ids skill_ids mcp_server_ids depends_on_step_ids].freeze
+    UPDATABLE = %i[
+      name instructions agent_id tool_ids skill_ids mcp_server_ids depends_on_step_ids
+      bmad_enabled allow_non_interactive
+    ].freeze
 
     def execute
       project = find_project!

--- a/app/services/personal_tools/update_workflow_trigger.rb
+++ b/app/services/personal_tools/update_workflow_trigger.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class UpdateWorkflowTrigger < Base
+    include WorkflowTriggerSupport
+
+    tool do
+      display_name "Update Workflow Trigger"
+      description "Edit an existing workflow trigger. Pass its kind together with trigger_id — " \
+                  "column triggers and event triggers are separate records whose ids can collide. " \
+                  "Only the fields you pass are changed. Column triggers accept trigger_mode and " \
+                  "cooldown_seconds only; everything else applies to the off-board kinds. Enabling " \
+                  "an off-board trigger requires auto-run (allow_non_interactive) on every step."
+      audience :user
+      tags :workflows
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :workflow_id, type: :integer, description: "Workflow id.", required: true
+      param :trigger_id, type: :integer, description: "Trigger id (from list_workflow_triggers).", required: true
+      param :kind, type: :string, enum: WorkflowTriggerSupport::KINDS, required: true,
+                   description: "The trigger's kind, as reported by list_workflow_triggers."
+      param :name, type: :string, description: "Human-readable label for this trigger."
+      param :trigger_mode, type: :string, enum: WorkflowTriggerSupport::TRIGGER_MODES,
+                           description: "auto starts the run immediately; manual only offers it."
+      param :enabled, type: :boolean, description: "Whether the trigger fires."
+      param :cooldown_seconds, type: :integer, description: "Minimum gap between two firings."
+      param :subject_policy, type: :string, enum: WorkflowTriggerSupport::SUBJECT_POLICIES,
+                             description: "Which board task the run is about: none, existing_task, or create_task " \
+                                          "(create_task also needs subject_column_id)."
+      param :subject_column_id, type: :integer, description: "Board column the new card lands in when subject_policy is create_task."
+      param :subject_title_template, type: :string, description: "Title template for the card created by subject_policy=create_task."
+      param :filter_predicate, type: :object,
+                               description: "Replaces the whole predicate: only fire when the event data contains " \
+                                            "these key/value pairs. Pass {} to clear it."
+      param :schedule_config, type: :object,
+                              description: "Replaces the whole schedule: {\"cron\": \"0 9 * * 1-5\", \"timezone\": " \
+                                           "\"Europe/Berlin\"}. ALWAYS pass timezone explicitly — an empty timezone " \
+                                           "makes Temporal schedule in UTC, which drifts by an hour under DST."
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project, :update?, policy: Web::Company::Projects::WorkflowsPolicy, project: project)
+      workflow = find_workflow!(project)
+
+      params[:kind].to_s == "column" ? update_column(project, workflow) : update_binding(workflow)
+    rescue ActiveRecord::RecordInvalid => e
+      error(e.record.errors.full_messages.join(", "))
+    rescue Temporalio::Error => e
+      # Schedule triggers reconcile onto Temporal synchronously on save: the
+      # binding IS updated and only the scheduling failed. Re-saving retries,
+      # and the worker-boot sync re-reconciles.
+      Rails.logger.error("[personal-mcp] Temporal scheduling failed: #{e.message}")
+      error("Trigger saved, but scheduling it failed — re-save to retry. (#{e.message})")
+    end
+
+    private
+
+    def update_column(project, workflow)
+      trigger = find_column_trigger!(project, workflow, params[:trigger_id])
+      attrs = column_binding_attrs
+      return error("No fields to update — a column trigger accepts trigger_mode and cooldown_seconds") if attrs.empty?
+
+      trigger.update!(attrs)
+      success(serialize_column(trigger))
+    end
+
+    def update_binding(workflow)
+      trigger = find_event_trigger!(workflow, params[:trigger_id])
+      attrs = trigger_binding_attrs
+      return error("No fields to update") if attrs.empty?
+
+      trigger.update!(attrs)
+      success(serialize_binding(trigger))
+    end
+  end
+end

--- a/app/services/personal_tools/workflow_trigger_support.rb
+++ b/app/services/personal_tools/workflow_trigger_support.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  # Shared lookup and serialization for the workflow-trigger tools, mirroring
+  # Api::V1::Projects::Workflows::TriggersController — one surface over two
+  # record kinds:
+  #   column                             → ColumnWorkflowBinding (card enters a board column)
+  #   slack / schedule / webhook / event → TriggerBinding
+  # The UI and the personal MCP must describe the same trigger the same way, so
+  # the field sets below stay in step with the controller's serializers.
+  module WorkflowTriggerSupport
+    KINDS = %w[column slack schedule webhook event].freeze
+    TRIGGER_MODES = %w[auto manual].freeze
+    SUBJECT_POLICIES = %w[none existing_task create_task].freeze
+    VERIFICATION_STRATEGIES = %w[none slack_v0 hmac_sha256 shared_token].freeze
+
+    # Mutable fields, mirroring the controller's permit lists.
+    BINDING_FIELDS = %i[name trigger_mode enabled cooldown_seconds
+                        subject_policy subject_column_id subject_title_template].freeze
+    COLUMN_FIELDS = %i[trigger_mode cooldown_seconds].freeze
+    SCHEDULE_KEYS = %w[cron timezone].freeze
+
+    private
+
+    # Column bindings reached only through this project's board — never a
+    # global ColumnWorkflowBinding lookup by id.
+    def column_bindings(project, workflow)
+      ColumnWorkflowBinding
+        .joins(board_column: :board)
+        .where(boards: { project_id: project.id }, workflow_id: workflow.id)
+    end
+
+    def find_column_trigger!(project, workflow, id)
+      trigger = column_bindings(project, workflow).find_by(id: id)
+      raise Base::NotFoundError, "Column trigger #{id} not found on workflow #{workflow.id}" unless trigger
+
+      trigger
+    end
+
+    def find_event_trigger!(workflow, id)
+      trigger = workflow.trigger_bindings.find_by(id: id)
+      raise Base::NotFoundError, "Trigger #{id} not found on workflow #{workflow.id}" unless trigger
+
+      trigger
+    end
+
+    # Only the keys the caller actually sent: an update must not blank a field
+    # that was simply omitted.
+    def trigger_binding_attrs
+      attrs = BINDING_FIELDS.each_with_object({}) { |key, acc| acc[key] = params[key] if params.key?(key) }
+      attrs[:filter_predicate] = object_param(:filter_predicate) if params.key?(:filter_predicate)
+      attrs[:schedule_config] = object_param(:schedule_config).slice(*SCHEDULE_KEYS) if params.key?(:schedule_config)
+      attrs
+    end
+
+    def column_binding_attrs
+      COLUMN_FIELDS.each_with_object({}) { |key, acc| acc[key] = params[key] if params.key?(key) }
+    end
+
+    def object_param(key)
+      value = params[key]
+      value.is_a?(Hash) ? value.to_h : {}
+    end
+
+    def serialize_column(trigger)
+      {
+        id: trigger.id,
+        kind: "column",
+        event_type: "board.column_changed",
+        board_column_id: trigger.board_column_id,
+        column_name: trigger.board_column.name,
+        trigger_mode: trigger.trigger_mode,
+        cooldown_seconds: trigger.cooldown_seconds,
+        enabled: true
+      }
+    end
+
+    def serialize_binding(trigger)
+      {
+        id: trigger.id,
+        kind: binding_kind(trigger.event_type),
+        event_type: trigger.event_type,
+        name: trigger.name,
+        filter_predicate: trigger.filter_predicate,
+        trigger_mode: trigger.trigger_mode,
+        subject_policy: trigger.subject_policy,
+        subject_column_id: trigger.subject_column_id,
+        subject_title_template: trigger.subject_title_template,
+        schedule_config: trigger.schedule_config,
+        cooldown_seconds: trigger.cooldown_seconds,
+        enabled: trigger.enabled
+      }
+    end
+
+    def binding_kind(event_type)
+      case event_type
+      when "slack.message" then "slack"
+      when "schedule.fired" then "schedule"
+      when /\Awebhook\./ then "webhook"
+      else "event"
+      end
+    end
+  end
+end

--- a/app/services/tools/personal_mcp_request_handler.rb
+++ b/app/services/tools/personal_mcp_request_handler.rb
@@ -125,21 +125,51 @@ module Tools
 
         1. `list_projects` — pick the project; every workflow tool takes its `project_id`.
         2. `list_workflows` / `get_workflow` — see what already exists before adding.
+           `get_workflow` also reports the workflow's base resources (tools, skills
+           and MCP servers every step gets) — read them before wiring per-step ones.
         3. `create_workflow` — name + description. Returns the `workflow_id`.
-        4. For each step: `list_agents` to choose an agent, then `create_workflow_step`
-           (name, instructions, agent_id, position). Set `depends_on_step_ids`
-           later with `update_workflow_step` once the steps it needs exist.
-        5. `create_sub_step` — break a step into a checklist when it has several
+           `update_workflow` renames it and sets the base resources.
+           `duplicate_workflow` copies an existing one, into this project or another.
+        4. Inspect what you can wire in: `list_project_tools`, `list_skills`,
+           `list_mcp_servers`, `list_agents`. `get_agent` and `get_skill` return the
+           full persona / skill content when the list entry isn't enough to decide.
+        5. For each step: `create_workflow_step` takes the wiring in one call —
+           name, instructions, agent_id, position, plus `tool_ids`, `skill_ids`,
+           `mcp_server_ids`, `depends_on_step_ids`, `bmad_enabled` and
+           `allow_non_interactive`. Dependencies must already exist, so create
+           the steps they point at first (or set them later with
+           `update_workflow_step`).
+        6. `create_sub_step` — break a step into a checklist when it has several
            distinct deliverables. See the `author_step` prompt for how to write
            a good step.
-        6. `reorder_workflow_steps` — fix execution order by passing step ids.
-        7. `trigger_workflow` — start a run (interactive or non_interactive).
-           Track it with `list_workflow_runs` / `get_workflow_run`; stop one with
-           `cancel_workflow_run`.
+        7. `reorder_workflow_steps` — fix execution order by passing step ids.
+        8. Connect a trigger, or the workflow only ever starts by hand:
+           `create_workflow_trigger` with a `kind` —
+           `column` (a card entering a board column), `slack` (an inbound message),
+           `schedule` (cron), `webhook` (an inbound HTTP call, which also returns the
+           endpoint URL and secret), or `event` (a custom platform event).
+           `list_workflow_triggers` / `update_workflow_trigger` /
+           `delete_workflow_trigger` manage them.
+        9. `trigger_workflow` — start a run by hand (interactive or non_interactive).
+           Track it with `list_workflow_runs` / `get_workflow_run`; read a single
+           step run's error, retries and session diagnostics with `get_step_run`;
+           stop a run with `cancel_workflow_run`.
 
         Rules:
         - Ask the user before destructive actions (`delete_workflow`,
-          `delete_workflow_step`).
+          `delete_workflow_step`, `delete_workflow_trigger`).
+        - `get_workflow` truncates step instructions. Read a step with
+          `get_workflow_step` before editing it, or you will overwrite text you
+          never saw. The same applies to every id list (`tool_ids`, `skill_ids`,
+          `mcp_server_ids`, `depends_on_step_ids`, and the workflow's `base_*`
+          lists): an update REPLACES the list, so read the current value first.
+        - The off-board trigger kinds (slack, schedule, webhook, event) fire with
+          nobody watching, so every step must have `allow_non_interactive` set.
+          A trigger whose workflow still has a human-gated step is rejected on
+          save, and the error names the steps.
+        - A `schedule` trigger needs a cron expression AND an explicit timezone —
+          leave the timezone out and Temporal schedules in UTC, which drifts by an
+          hour under daylight saving.
         - Everything is scoped to what your account can access — a tool that
           returns "not allowed" means your role can't do that in this project.
 
@@ -169,20 +199,29 @@ module Tools
           to later steps that depend on them.
 
         Wiring:
-        - `agent_id` (from `list_agents`) picks who runs the step.
+        - `agent_id` (from `list_agents`) picks who runs the step. `get_agent`
+          returns that agent's full persona when the title isn't enough.
         - `tool_ids` / `skill_ids` / `mcp_server_ids` grant capabilities — attach
           only what the step needs (list them with list_project_tools / list_skills /
-          list_mcp_servers).
+          list_mcp_servers, and read a skill's content with `get_skill` before
+          deciding). Check the workflow's `base_*` lists in `get_workflow` first:
+          those already apply to every step, so don't re-attach them here.
         - `depends_on_step_ids` builds the DAG: a step runs after every step it
           depends on. A step can't be deleted while others depend on it.
+        - `allow_non_interactive` lets the step run unattended. Every step needs it
+          before a slack / schedule / webhook trigger can be attached to the
+          workflow.
+        - Each of those id lists is REPLACED wholesale by an update — read the
+          current value with `get_workflow_step` before changing one.
 
         Sub-steps:
         - One `create_sub_step` per distinct, checkable deliverable.
         - `required: false` for optional work.
         - The running agent marks them off, giving progress visibility.
 
-        Prefer `get_workflow` to inspect the current shape before editing, and
-        make one focused change per tool call.
+        Prefer `get_workflow` to inspect the current shape and `get_workflow_step`
+        to read a step in full before editing, and make one focused change per
+        tool call.
       GUIDE
     end
   end

--- a/references/aixle-system-reference.md
+++ b/references/aixle-system-reference.md
@@ -41,7 +41,7 @@ Company
     │   │   ├── TaskComments (threaded, with tags)
     │   │   ├── TaskAssets (file attachments)
     │   │   ├── ColumnTransitions (movement history)
-    │   │   ├── TaskWaits (external blockers: CI/CD)
+    │   │   ├── Gates (external blockers: CI/CD)
     │   │   └── WorkflowRuns (triggered by column bindings)
     │   ├── BoardActivities (immutable event log)
     │   └── BoardViewPresets (saved filters)
@@ -106,7 +106,7 @@ Each Project has exactly ONE Board. A Board contains ordered **BoardColumns** (s
 | parent_task_id | Epic-story nesting (1 level max) |
 | assignee_id | Assigned user |
 
-Tasks have: **TaskComments** (with tags like `tech_design`, `code_review`, `qa_report`), **TaskAssets** (file attachments), **ColumnTransitions** (movement history with actor_type: human/agent/auto_trigger), **TaskWaits** (external process blockers for GitHub/GitLab CI).
+Tasks have: **TaskComments** (with tags like `tech_design`, `code_review`, `qa_report`), **TaskAssets** (file attachments), **ColumnTransitions** (movement history with actor_type: human/agent/auto_trigger), **Gates** (external process blockers for GitHub/GitLab CI).
 
 ### BoardActivity
 
@@ -179,9 +179,12 @@ Steps execute based on `depends_on_step_ids` (DAG). Steps with no dependencies c
 
 ---
 
-## 6. Automation: Column → Workflow Binding
+## 6. Automation: Triggers
 
-### ColumnWorkflowBinding
+A workflow never starts by itself — something has to launch it. There are two
+trigger records, and every launch path goes through one of them.
+
+### ColumnWorkflowBinding (board columns)
 
 Connects a BoardColumn to a Workflow. When a task enters the column, the workflow triggers.
 
@@ -192,12 +195,49 @@ Connects a BoardColumn to a Workflow. When a task enters the column, the workflo
 | trigger_mode | **manual** (button in UI) or **auto** (triggers on task entry) |
 | cooldown_seconds | Minimum gap between auto-triggers (default: 5) |
 
+### TriggerBinding (everything else)
+
+The general "events matching X launch workflow Y" rule: Slack messages, inbound
+webhooks, cron schedules, and custom events. A TriggerEvent is matched against
+bindings by (project, event_type, enabled), then by JSONB containment of
+`filter_predicate` in the event data.
+
+| Field | Description |
+|-------|-------------|
+| event_type | `slack.message`, `webhook.<token>`, `schedule.fired`, or a custom event name |
+| workflow_id | Workflow to launch (must be visible from the binding's project) |
+| filter_predicate | JSONB conditions the event data must satisfy; empty ⇒ every event of this type. Supports equality, `{"op","value"}` operators, and dot-paths |
+| schedule_config | `schedule.fired` only: `{"cron": "...", "timezone": "..."}` |
+| subject_policy | `none` / `existing_task` / `create_task` — what board task the run is about |
+| subject_column_id | Required when `subject_policy` is `create_task`: where the new card lands |
+| subject_title_template | Title for the card a `create_task` policy creates |
+| trigger_mode | `auto` or `manual` |
+| cooldown_seconds | Minimum gap between launches — without it a busy Slack thread starts a run per message |
+| enabled | Off switch that keeps the binding |
+
+Rules that reject a binding at save time:
+
+- **`schedule.fired` requires a non-empty `cron`.** Always set `timezone`
+  explicitly too: an empty timezone makes Temporal schedule in UTC, so anything
+  tied to local working hours drifts by an hour across DST.
+- **`create_task` requires `subject_column_id`.** If the agent should create the
+  card itself, use `subject_policy: none` — otherwise the platform creates one
+  first, in the column named here.
+- **Off-board triggers (slack / webhook / schedule) require every step of the
+  workflow to allow non-interactive runs.** They fire unattended, and a step that
+  needs a human is silently skipped at fire time. Set `allow_non_interactive` on
+  each step before wiring the trigger.
+
+Schedule bindings are reconciled onto a Temporal Schedule synchronously on save
+(`ScheduleReconciler`), so a scheduling failure surfaces on the save instead of
+disappearing into a background job. Worker boot re-reconciles as the backstop.
+
 ### Automation Flow
 
 ```
 Task moves to column
   → Has binding? → Auto mode?
-    → No pending TaskWaits? → No active WorkflowRun?
+    → No pending Gates? → No active WorkflowRun?
       → START non_interactive WorkflowRun
         → Agent reads task context → Produces artifacts → Can move task to next column
 ```

--- a/test/integration/personal_mcp_board_test.rb
+++ b/test/integration/personal_mcp_board_test.rb
@@ -32,6 +32,15 @@ class PersonalMCPBoardTest < ActionDispatch::IntegrationTest
 
   def tool_error?(body) = body.dig("result", "isError")
 
+  # A task on a board in a company @user has nothing to do with.
+  def foreign_task
+    owner = create(:user, :with_company)
+    project = create(:project, company: owner.companies.first, owner: owner)
+    board = create(:board, project: project)
+    column = create(:board_column, board: board, name: "To Do", position: 1)
+    create(:board_task, board: board, board_column: column, title: "Not yours", assignee: owner)
+  end
+
   test "list_board_columns returns the project's columns" do
     cols = payload(call_tool("list_board_columns", { project_id: @project.id }))["columns"]
     assert_equal %w[To\ Do Done], cols.map { |c| c["name"] }
@@ -130,6 +139,35 @@ class PersonalMCPBoardTest < ActionDispatch::IntegrationTest
     assert_equal member.id, @task.reload.assignee_id
   end
 
+  test "archive_board_task round-trips and the state shows in get_board_task" do
+    archived = call_tool("archive_board_task", { project_id: @project.id, task_id: @task.id })
+    assert_not tool_error?(archived)
+    assert payload(archived)["archived"]
+    assert @task.reload.archived_at.present?
+
+    detail = payload(call_tool("get_board_task", { project_id: @project.id, task_id: @task.id }))
+    assert detail["archived"]
+
+    restored = call_tool("archive_board_task", { project_id: @project.id, task_id: @task.id, archived: false })
+    assert_not tool_error?(restored)
+    assert_equal false, payload(restored)["archived"] # rubocop:disable Minitest/RefuteFalse
+    assert_nil @task.reload.archived_at
+
+    back = payload(call_tool("get_board_task", { project_id: @project.id, task_id: @task.id }))
+    assert_equal false, back["archived"] # rubocop:disable Minitest/RefuteFalse
+  end
+
+  test "archive_board_task requires write access" do
+    viewer = create(:user, :viewer, company: @company)
+    @project.add_collaborator(viewer)
+    vtoken = viewer.regenerate_mcp_token!
+
+    body = call_tool("archive_board_task", { project_id: @project.id, task_id: @task.id }, token: vtoken)
+    assert tool_error?(body)
+    assert_match(/not allowed/i, body.dig("result", "content").first["text"])
+    assert_nil @task.reload.archived_at
+  end
+
   test "list_project_members returns assignable users with roles" do
     member = create(:user, company: @company)
     @project.add_collaborator(member)
@@ -179,6 +217,24 @@ class PersonalMCPBoardTest < ActionDispatch::IntegrationTest
     assert_not BoardColumn.exists?(cid)
   end
 
+  test "create_board_column inserts at an occupied position instead of failing" do
+    inserted = call_tool("create_board_column", { project_id: @project.id, name: "Review", position: 2 })
+    assert_not tool_error?(inserted)
+    assert_equal 2, payload(inserted)["position"]
+    assert_equal [ [ "To Do", 1 ], [ "Review", 2 ], [ "Done", 3 ] ],
+                 @board.board_columns.order(:position).pluck(:name, :position)
+
+    # Inserting at the head shifts every existing column, exercising the
+    # multi-row walk against the (board_id, position) unique index.
+    head = call_tool("create_board_column", { project_id: @project.id, name: "Backlog", position: 1 })
+    assert_not tool_error?(head)
+    assert_equal [ [ "Backlog", 1 ], [ "To Do", 2 ], [ "Review", 3 ], [ "Done", 4 ] ],
+                 @board.board_columns.order(:position).pluck(:name, :position)
+
+    appended = call_tool("create_board_column", { project_id: @project.id, name: "Archive" })
+    assert_equal 5, payload(appended)["position"]
+  end
+
   test "delete_board_column is rejected when the column has tasks" do
     body = call_tool("delete_board_column", { project_id: @project.id, column_id: @todo.id })
     assert tool_error?(body)
@@ -193,6 +249,45 @@ class PersonalMCPBoardTest < ActionDispatch::IntegrationTest
     body = call_tool("create_board_column", { project_id: @project.id, name: "X" }, token: mtoken)
     assert tool_error?(body)
     assert_match(/not allowed/i, body.dig("result", "content").map { |c| c["text"] }.join(" "))
+  end
+
+  test "list_gates exposes a task's gates and delete_gate clears one" do
+    gate = @task.gates.create!(gate_type: "github_checks_completed", creator: @user,
+                               metadata: { "repo_full_name" => "acme/app", "pr_number" => 7 })
+
+    gates = payload(call_tool("list_gates", { project_id: @project.id, task_id: @task.id }))["gates"]
+    assert_equal [ gate.id ], gates.map { |g| g["id"] }
+    assert_equal "github_checks_completed", gates.first["gate_type"]
+    assert_equal "pending", gates.first["status"]
+    assert_equal 7, gates.first["metadata"]["pr_number"]
+    assert_equal @user.name, gates.first["creator"]
+
+    detail = payload(call_tool("get_board_task", { project_id: @project.id, task_id: @task.id }))
+    assert_equal [ gate.id ], detail["pending_gates"].map { |g| g["id"] }
+
+    deleted = call_tool("delete_gate", { project_id: @project.id, gate_id: gate.id })
+    assert_not tool_error?(deleted)
+    assert_equal gate.id, payload(deleted)["deleted_gate_id"]
+    assert_not Gate.exists?(gate.id)
+    assert_empty payload(call_tool("list_gates", { project_id: @project.id, task_id: @task.id }))["gates"]
+  end
+
+  test "gate tools cannot reach another company's board" do
+    other_task = foreign_task
+    other_gate = other_task.gates.create!(gate_type: "github_workflow_completed", creator: other_task.assignee)
+
+    stolen = call_tool("delete_gate", { project_id: @project.id, gate_id: other_gate.id })
+    assert tool_error?(stolen)
+    assert_match(/not found/i, stolen.dig("result", "content").map { |c| c["text"] }.join(" "))
+    assert Gate.exists?(other_gate.id)
+
+    listed = call_tool("list_gates", { project_id: other_task.board.project.id, task_id: other_task.id })
+    assert tool_error?(listed)
+
+    archived = call_tool("archive_board_task",
+                         { project_id: other_task.board.project.id, task_id: other_task.id })
+    assert tool_error?(archived)
+    assert_nil other_task.reload.archived_at
   end
 
   test "unknown / inaccessible project is not found" do

--- a/test/integration/personal_mcp_resources_test.rb
+++ b/test/integration/personal_mcp_resources_test.rb
@@ -22,6 +22,7 @@ class PersonalMCPResourcesTest < ActionDispatch::IntegrationTest
 
   def payload(body) = JSON.parse(body.dig("result", "content").first["text"])
   def error?(body) = body.dig("result", "isError")
+  def text(body) = body.dig("result", "content").map { |c| c["text"] }.join(" ")
 
   test "list_integrations returns project-visible integrations with status" do
     create(:integration, company: @company, project: @project, provider: :slack,
@@ -40,12 +41,88 @@ class PersonalMCPResourcesTest < ActionDispatch::IntegrationTest
     refute_includes data.keys, "credentials"
   end
 
-  test "list_project_tools lists visible tools" do
+  # The regression: chaining `.ui_visible` onto `visible_for_project` left only
+  # project-scoped custom tools, so a project without any answered `[]`.
+  test "list_project_tools lists attachable platform tools for a project with no custom tools" do
     Tools::Reconciler.run!
-    create(:tool, scope: @project, name: "my_linter", docker_image: "l:1")
 
-    names = payload(call_tool("list_project_tools", { project_id: @project.id }))["tools"].map { |t| t["name"] }
-    assert_includes names, "my_linter"
+    data = payload(call_tool("list_project_tools", { project_id: @project.id }))
+    platform = data["tools"].select { |t| t["source"] == "code" }
+    names = platform.map { |t| t["name"] }
+
+    assert_not_empty platform
+    assert_includes names, "board_create_task"
+    assert_equal data["tools"].size, data["tools_count"]
+    # Builder meta_* tools are not attachable and stay out of the picker set.
+    assert_not_includes names, "meta_list_tools"
+
+    row = platform.find { |t| t["name"] == "board_create_task" }
+    assert_equal "Board Create Task", row["display_name"]
+    assert_match(/board task/i, row["description"])
+    assert_includes row["tags"], "board"
+    assert row["enabled"]
+  end
+
+  test "list_project_tools lists custom tools with their metadata" do
+    Tools::Reconciler.run!
+    create(:tool, scope: @project, name: "my_linter", display_name: "My Linter",
+                  description: "Runs the house linter.", docker_image: "l:1")
+
+    tools = payload(call_tool("list_project_tools", { project_id: @project.id }))["tools"]
+    linter = tools.find { |t| t["name"] == "my_linter" }
+
+    assert_equal "db", linter["source"]
+    assert_equal "My Linter", linter["display_name"]
+    assert_equal "Runs the house linter.", linter["description"]
+    assert_nil linter["requires_integration"]
+  end
+
+  test "get_agent returns the agent's persona, principles and communication style" do
+    agent = create(:agent, scope: @project, name: "release_manager", title: "Release Manager",
+                           persona: "You cut releases.", principles: "Ship small.",
+                           communication_style: "Terse.", icon: "rocket")
+
+    data = payload(call_tool("get_agent", { project_id: @project.id, agent_id: agent.id }))
+
+    assert_equal "release_manager", data["name"]
+    assert_equal "Release Manager", data["title"]
+    assert_equal "You cut releases.", data["persona"]
+    assert_equal "Ship small.", data["principles"]
+    assert_equal "Terse.", data["communication_style"]
+    assert_equal "rocket", data["icon"]
+    assert_equal "Project", data["scope"]
+  end
+
+  test "get_skill returns the full description and SKILL.md content" do
+    long_content = "# Formatter\n#{'formatting rule line.' * 60}"
+    skill = create(:skill, scope: @project, description: "d" * 400, content: long_content)
+
+    data = payload(call_tool("get_skill", { project_id: @project.id, skill_id: skill.id }))
+
+    assert_equal long_content, data["content"]
+    assert_equal skill.description, data["description"]
+    assert_equal skill.package, data["package"]
+    assert_equal skill.source_url, data["source_url"]
+    assert_equal "registry", data["origin"]
+  end
+
+  test "get_agent and get_skill never reach another company's records" do
+    other = create(:user, :with_company)
+    other_project = create(:project, company: other.companies.first, owner: other)
+    other_agent = create(:agent, scope: other_project)
+    other_skill = create(:skill, scope: other_project)
+
+    assert error?(call_tool("get_agent", { project_id: other_project.id, agent_id: other_agent.id }))
+    assert error?(call_tool("get_skill", { project_id: other_project.id, skill_id: other_skill.id }))
+
+    # Nor by pairing a foreign record id with a project the caller can reach.
+    body = call_tool("get_agent", { project_id: @project.id, agent_id: other_agent.id })
+    assert error?(body)
+    assert_match(/not found/i, text(body))
+
+    body = call_tool("get_skill", { project_id: @project.id, skill_id: other_skill.id })
+    assert error?(body)
+    assert_match(/not found/i, text(body))
   end
 
   test "list_skills and list_mcp_servers answer for the project" do

--- a/test/integration/personal_mcp_step_runs_test.rb
+++ b/test/integration/personal_mcp_step_runs_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# get_step_run: the per-step diagnostic view behind get_workflow_run's bare
+# states — error fields plus the terminal session that actually died.
+class PersonalMCPStepRunsTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user, :with_company)
+    @company = @user.companies.first
+    @project = create(:project, company: @company, owner: @user)
+    @workflow = create(:workflow, scope: @project)
+    @step = create(:step, workflow: @workflow, name: "Install BMAD", position: 2)
+    @run = @workflow.runs.create!(project: @project, user: @user, state: "running")
+    @token = @user.regenerate_mcp_token!
+  end
+
+  def call_tool(name, args = {}, token: @token)
+    post "/mcp",
+         params: { jsonrpc: "2.0", id: 1, method: "tools/call",
+                   params: { name: name, arguments: args } }.to_json,
+         headers: { "Content-Type" => "application/json",
+                    "Accept" => "application/json, text/event-stream",
+                    "Authorization" => "Bearer #{token}" }
+    response.parsed_body
+  end
+
+  def payload(body) = JSON.parse(body.dig("result", "content").first["text"])
+  def error?(body) = body.dig("result", "isError")
+
+  def failed_session(context_metadata: {}, error_message: "container exited with code 1")
+    create(:terminal_session, :failed, user: @user, project: @project,
+           session_type: "workflow_step", error_message: error_message,
+           context_metadata: context_metadata)
+  end
+
+  test "get_step_run surfaces the error fields get_workflow_run leaves out" do
+    step_run = @run.step_runs.create!(
+      step: @step, state: "failed", retry_count: 2,
+      started_at: 2.minutes.ago, completed_at: 1.minute.ago,
+      error_category: "container_start", error_message: "BMAD install failed",
+      error_history: [ { "attempt" => 1, "message" => "timeout" } ],
+      step_note: "needs a bigger image"
+    )
+
+    # get_workflow_run knows only that it failed.
+    listed = payload(call_tool("get_workflow_run", { project_id: @project.id, run_id: @run.id }))["step_runs"]
+    assert_equal [ "failed" ], listed.map { |sr| sr["state"] }
+    assert_not listed.first.key?("error_message")
+
+    detail = payload(call_tool("get_step_run", { project_id: @project.id, step_run_id: step_run.id }))
+    assert_equal "failed", detail["state"]
+    assert_equal "Install BMAD", detail["step"]
+    assert_equal 2, detail["step_position"]
+    assert_equal 2, detail["retry_count"]
+    assert_equal "container_start", detail["error_category"]
+    assert_equal "BMAD install failed", detail["error_message"]
+    assert_equal [ { "attempt" => 1, "message" => "timeout" } ], detail["error_history"]
+    assert_equal 0, detail["error_history_omitted"]
+    assert_equal "needs a bigger image", detail["step_note"]
+    assert_nil detail["terminal_session"]
+  end
+
+  test "get_step_run reports the terminal session's context_metadata" do
+    session = failed_session(context_metadata: { "bmad_install_status" => "failed",
+                                                 "bmad_install_error" => "npm registry unreachable" })
+    step_run = @run.step_runs.create!(step: @step, state: "failed", terminal_session: session,
+                                      error_message: "step session failed")
+
+    detail = payload(call_tool("get_step_run", { project_id: @project.id, step_run_id: step_run.id }))
+    assert_equal session.id, detail["terminal_session"]["id"]
+    assert_equal "failed", detail["terminal_session"]["state"]
+    assert_equal "container exited with code 1", detail["terminal_session"]["error_message"]
+    assert_equal "failed", detail["terminal_session"]["context_metadata"]["bmad_install_status"]
+    assert_equal "npm registry unreachable", detail["terminal_session"]["context_metadata"]["bmad_install_error"]
+  end
+
+  test "get_step_run truncates an error message big enough to be a log dump" do
+    step_run = @run.step_runs.create!(step: @step, state: "failed", error_message: "x" * 9000)
+
+    detail = payload(call_tool("get_step_run", { project_id: @project.id, step_run_id: step_run.id }))
+    assert_operator detail["error_message"].length, :<, 9000
+    assert_match(/truncated, 9000 chars total/, detail["error_message"])
+  end
+
+  test "get_step_run keeps only the most recent error_history entries" do
+    history = (1..15).map { |i| { "attempt" => i } }
+    step_run = @run.step_runs.create!(step: @step, state: "failed", error_history: history)
+
+    detail = payload(call_tool("get_step_run", { project_id: @project.id, step_run_id: step_run.id }))
+    assert_equal 10, detail["error_history"].size
+    assert_equal 6, detail["error_history"].first["attempt"]
+    assert_equal 5, detail["error_history_omitted"]
+  end
+
+  test "get_step_run cannot reach another company's step run" do
+    other = create(:user, :with_company)
+    other_project = create(:project, company: other.companies.first, owner: other)
+    other_workflow = create(:workflow, scope: other_project)
+    other_run = other_workflow.runs.create!(project: other_project, user: other, state: "running")
+    other_step_run = other_run.step_runs.create!(step: create(:step, workflow: other_workflow), state: "failed",
+                                                 error_message: "not yours")
+
+    stolen = call_tool("get_step_run", { project_id: @project.id, step_run_id: other_step_run.id })
+    assert error?(stolen)
+    assert_match(/not found/i, stolen.dig("result", "content").map { |c| c["text"] }.join(" "))
+
+    denied = call_tool("get_step_run", { project_id: other_project.id, step_run_id: other_step_run.id })
+    assert error?(denied)
+    assert_match(/not found/i, denied.dig("result", "content").first["text"])
+  end
+
+  test "a read-only viewer can read a step run" do
+    viewer = create(:user, :viewer, company: @company)
+    @project.add_collaborator(viewer)
+    step_run = @run.step_runs.create!(step: @step, state: "failed", error_message: "boom")
+
+    detail = payload(call_tool("get_step_run", { project_id: @project.id, step_run_id: step_run.id },
+                               token: viewer.regenerate_mcp_token!))
+    assert_equal "boom", detail["error_message"]
+  end
+end

--- a/test/integration/personal_mcp_triggers_test.rb
+++ b/test/integration/personal_mcp_triggers_test.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Personal MCP workflow-trigger CRUD: the one surface over ColumnWorkflowBinding
+# (kind=column) and TriggerBinding (slack / schedule / webhook / event).
+class PersonalMCPTriggersTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user, :with_company)
+    @company = @user.companies.first
+    @project = create(:project, company: @company, owner: @user)
+    @board = create(:board, project: @project)
+    @column = create(:board_column, board: @board)
+    @workflow = create(:workflow, scope: @project)
+    @token = @user.regenerate_mcp_token!
+  end
+
+  def call_tool(name, args = {}, token: @token)
+    post "/mcp",
+         params: { jsonrpc: "2.0", id: 1, method: "tools/call",
+                   params: { name: name, arguments: args } }.to_json,
+         headers: { "Content-Type" => "application/json",
+                    "Accept" => "application/json, text/event-stream",
+                    "Authorization" => "Bearer #{token}" }
+    response.parsed_body
+  end
+
+  def payload(body) = JSON.parse(body.dig("result", "content").first["text"])
+  def error?(body) = body.dig("result", "isError")
+  def text(body) = body.dig("result", "content").map { |c| c["text"] }.join(" ")
+
+  def column_trigger!(mode: :auto, cooldown: 5)
+    ColumnWorkflowBinding.create!(board_column: @column, workflow: @workflow,
+                                  trigger_mode: mode, cooldown_seconds: cooldown)
+  end
+
+  def event_trigger!(**attrs)
+    create(:trigger_binding, project: @project, workflow: @workflow, created_by: @user,
+                             event_type: "slack.message", **attrs)
+  end
+
+  test "list_workflow_triggers reports column and event triggers together" do
+    column_trigger!
+    event_trigger!(name: "standup")
+
+    triggers = payload(call_tool("list_workflow_triggers",
+                                 { project_id: @project.id, workflow_id: @workflow.id }))["triggers"]
+
+    assert_equal %w[column slack], triggers.map { |t| t["kind"] }.sort
+    column = triggers.find { |t| t["kind"] == "column" }
+    assert_equal @column.id, column["board_column_id"]
+    assert_equal @column.name, column["column_name"]
+    assert_equal "standup", triggers.find { |t| t["kind"] == "slack" }["name"]
+  end
+
+  test "create_workflow_trigger binds a board column" do
+    body = call_tool("create_workflow_trigger",
+                     { project_id: @project.id, workflow_id: @workflow.id, kind: "column",
+                       board_column_id: @column.id, trigger_mode: "auto", cooldown_seconds: 7 })
+
+    assert_not error?(body)
+    trigger = payload(body)
+    assert_equal "column", trigger["kind"]
+    assert_equal 7, trigger["cooldown_seconds"]
+    assert_equal @column.id, ColumnWorkflowBinding.find(trigger["id"]).board_column_id
+  end
+
+  test "create_workflow_trigger creates a slack trigger with a filter predicate" do
+    body = call_tool("create_workflow_trigger",
+                     { project_id: @project.id, workflow_id: @workflow.id, kind: "slack",
+                       name: "on mention", filter_predicate: { channel: "C123" },
+                       subject_policy: "create_task", subject_column_id: @column.id })
+
+    assert_not error?(body)
+    trigger = payload(body)
+    assert_equal "slack", trigger["kind"]
+    assert_equal "slack.message", trigger["event_type"]
+    assert_equal({ "channel" => "C123" }, trigger["filter_predicate"])
+    assert_equal "create_task", trigger["subject_policy"]
+    assert_equal @user.id, TriggerBinding.find(trigger["id"]).created_by_id
+  end
+
+  test "create_workflow_trigger creates a cron schedule trigger" do
+    body = call_tool("create_workflow_trigger",
+                     { project_id: @project.id, workflow_id: @workflow.id, kind: "schedule",
+                       name: "weekday standup",
+                       schedule_config: { cron: "0 9 * * 1-5", timezone: "Europe/Berlin" } })
+
+    assert_not error?(body)
+    trigger = payload(body)
+    assert_equal "schedule", trigger["kind"]
+    assert_equal "schedule.fired", trigger["event_type"]
+    assert_equal({ "cron" => "0 9 * * 1-5", "timezone" => "Europe/Berlin" }, trigger["schedule_config"])
+  end
+
+  test "create_workflow_trigger provisions a webhook endpoint and returns its url and secret" do
+    body = call_tool("create_workflow_trigger",
+                     { project_id: @project.id, workflow_id: @workflow.id, kind: "webhook",
+                       verification_strategy: "hmac_sha256", secret: "shh" })
+
+    assert_not error?(body)
+    trigger = payload(body)
+    assert_match(/\Awebhook\./, trigger["event_type"])
+    assert_match %r{/webhooks/in/wh-}, trigger["webhook_url"]
+    assert_equal "shh", trigger["webhook_secret"]
+
+    endpoint = WebhookEndpoint.find_by(slug: trigger["webhook_url"].split("/").last)
+    assert_equal trigger["event_type"], endpoint.config["event_type"]
+    assert_equal @project.id, endpoint.project_id
+  end
+
+  test "an off-board trigger is rejected while a step still waits on a human" do
+    create(:step, workflow: @workflow, name: "Review copy", allow_non_interactive: false)
+
+    body = call_tool("create_workflow_trigger",
+                     { project_id: @project.id, workflow_id: @workflow.id, kind: "slack" })
+
+    assert error?(body)
+    assert_match(/can't run unattended/i, text(body))
+    assert_match(/Review copy/, text(body))
+    assert_equal 0, @workflow.trigger_bindings.count
+  end
+
+  test "a schedule trigger without a cron expression is rejected" do
+    body = call_tool("create_workflow_trigger",
+                     { project_id: @project.id, workflow_id: @workflow.id, kind: "schedule",
+                       schedule_config: { timezone: "UTC" } })
+
+    assert error?(body)
+    assert_match(/cron/i, text(body))
+    assert_equal 0, @workflow.trigger_bindings.count
+  end
+
+  test "update_workflow_trigger edits each kind and leaves omitted fields alone" do
+    column = column_trigger!
+    event = event_trigger!(name: "standup", cooldown_seconds: 0)
+
+    col_body = call_tool("update_workflow_trigger",
+                         { project_id: @project.id, workflow_id: @workflow.id, kind: "column",
+                           trigger_id: column.id, trigger_mode: "manual", cooldown_seconds: 30 })
+    assert_not error?(col_body)
+    assert_equal "manual", column.reload.trigger_mode
+    assert_equal 30, column.cooldown_seconds
+
+    evt_body = call_tool("update_workflow_trigger",
+                         { project_id: @project.id, workflow_id: @workflow.id, kind: "slack",
+                           trigger_id: event.id, enabled: false, filter_predicate: { channel: "C9" } })
+    assert_not error?(evt_body)
+    event.reload
+    assert_not event.enabled
+    assert_equal({ "channel" => "C9" }, event.filter_predicate)
+    assert_equal "standup", event.name
+  end
+
+  test "delete_workflow_trigger removes each kind" do
+    column = column_trigger!
+    event = event_trigger!
+
+    assert_difference -> { ColumnWorkflowBinding.count }, -1 do
+      body = call_tool("delete_workflow_trigger",
+                       { project_id: @project.id, workflow_id: @workflow.id, kind: "column", trigger_id: column.id })
+      assert_not error?(body)
+    end
+
+    assert_difference -> { TriggerBinding.count }, -1 do
+      body = call_tool("delete_workflow_trigger",
+                       { project_id: @project.id, workflow_id: @workflow.id, kind: "slack", trigger_id: event.id })
+      assert_not error?(body)
+    end
+  end
+
+  test "another company's workflow and triggers are unreachable" do
+    outsider = create(:user, :with_company)
+    other_project = create(:project, company: outsider.companies.first, owner: outsider)
+    other_workflow = create(:workflow, scope: other_project)
+    other_trigger = create(:trigger_binding, project: other_project, workflow: other_workflow,
+                                             created_by: outsider, event_type: "slack.message")
+
+    listed = call_tool("list_workflow_triggers", { project_id: @project.id, workflow_id: other_workflow.id })
+    assert error?(listed)
+    assert_match(/not found/i, text(listed))
+
+    deleted = call_tool("delete_workflow_trigger",
+                        { project_id: @project.id, workflow_id: @workflow.id,
+                          kind: "slack", trigger_id: other_trigger.id })
+    assert error?(deleted)
+    assert TriggerBinding.exists?(other_trigger.id)
+  end
+
+  test "a read-only viewer can list triggers but not create them" do
+    viewer = create(:user, :viewer, company: @company)
+    @project.add_collaborator(viewer)
+    vtoken = viewer.regenerate_mcp_token!
+
+    assert_not error?(call_tool("list_workflow_triggers",
+                                { project_id: @project.id, workflow_id: @workflow.id }, token: vtoken))
+
+    write = call_tool("create_workflow_trigger",
+                      { project_id: @project.id, workflow_id: @workflow.id, kind: "column",
+                        board_column_id: @column.id }, token: vtoken)
+    assert error?(write)
+    assert_match(/not allowed/i, text(write))
+  end
+end

--- a/test/integration/personal_mcp_workflows_test.rb
+++ b/test/integration/personal_mcp_workflows_test.rb
@@ -23,6 +23,7 @@ class PersonalMCPWorkflowsTest < ActionDispatch::IntegrationTest
 
   def payload(body) = JSON.parse(body.dig("result", "content").first["text"])
   def error?(body) = body.dig("result", "isError")
+  def text(body) = body.dig("result", "content").map { |c| c["text"] }.join(" ")
 
   test "list_workflows lists project-visible workflows" do
     names = payload(call_tool("list_workflows", { project_id: @project.id }))["workflows"].map { |w| w["name"] }
@@ -41,6 +42,134 @@ class PersonalMCPWorkflowsTest < ActionDispatch::IntegrationTest
     detail = payload(call_tool("get_workflow", { project_id: @project.id, workflow_id: wf_id }))
     assert_equal 1, detail["steps_count"]
     assert_equal "Step 1", detail["steps"].first["name"]
+  end
+
+  test "update_workflow edits name, description and base resources, and get_workflow reports them" do
+    tool = create(:tool, scope: @project)
+    skill = create(:skill, scope: @project)
+    server = create(:mcp_server, scope: @project)
+
+    updated = payload(call_tool("update_workflow",
+                                { project_id: @project.id, workflow_id: @workflow.id,
+                                  name: "Renamed", description: "new description",
+                                  base_tool_ids: [ tool.id ], base_skill_ids: [ skill.id ],
+                                  base_mcp_server_ids: [ server.id ] }))
+    assert_equal "Renamed", updated["name"]
+    assert_includes updated["updated_fields"], "base_tool_ids"
+
+    detail = payload(call_tool("get_workflow", { project_id: @project.id, workflow_id: @workflow.id }))
+    assert_equal "Renamed", detail["name"]
+    assert_equal "new description", detail["description"]
+    assert_equal [ tool.id ], detail["base_tool_ids"]
+    assert_equal [ skill.id ], detail["base_skill_ids"]
+    assert_equal [ server.id ], detail["base_mcp_server_ids"]
+    assert_nil detail["published_at"]
+
+    nothing = call_tool("update_workflow", { project_id: @project.id, workflow_id: @workflow.id })
+    assert error?(nothing)
+    assert_match(/no fields/i, text(nothing))
+  end
+
+  test "get_workflow_step returns full instructions and wiring while get_workflow truncates and flags" do
+    long = "x" * 900
+    agent = create(:agent, scope: @project)
+    tool = create(:tool, scope: @project)
+    step = create(:step, workflow: @workflow, instructions: long, agent: agent,
+                         tool_ids: [ tool.id ], bmad_enabled: true, mount_repositories: false, max_retries: 2)
+    create(:sub_step, step: step, name: "check A", instructions: long)
+
+    listed = payload(call_tool("get_workflow", { project_id: @project.id, workflow_id: @workflow.id }))["steps"].first
+    assert_equal 500, listed["instructions"].length
+    assert listed["instructions_truncated"]
+    assert listed["sub_steps"].first["instructions_truncated"]
+
+    full = payload(call_tool("get_workflow_step",
+                             { project_id: @project.id, workflow_id: @workflow.id, step_id: step.id }))
+    assert_equal long, full["instructions"]
+    assert_equal long, full["sub_steps"].first["instructions"]
+    assert_equal agent.id, full.dig("agent", "id")
+    assert_equal [ tool.id ], full["tool_ids"]
+    assert full["bmad_enabled"]
+    assert_equal false, full["mount_repositories"] # rubocop:disable Minitest/RefuteFalse
+    assert_equal 2, full["max_retries"]
+    assert_equal "fail", full["on_failure"]
+    assert_equal "never", full["skip_policy"]
+  end
+
+  test "create_workflow_step wires agent, tools, skills, servers, deps and flags in one call" do
+    first = payload(call_tool("create_workflow_step",
+                              { project_id: @project.id, workflow_id: @workflow.id, name: "S1" }))
+    agent = create(:agent, scope: @project)
+    tool = create(:tool, scope: @project)
+    skill = create(:skill, scope: @project)
+    server = create(:mcp_server, scope: @project)
+
+    created = payload(call_tool("create_workflow_step",
+                                { project_id: @project.id, workflow_id: @workflow.id, name: "S2",
+                                  instructions: "do it", agent_id: agent.id,
+                                  tool_ids: [ tool.id ], skill_ids: [ skill.id ],
+                                  mcp_server_ids: [ server.id ], depends_on_step_ids: [ first["id"] ],
+                                  bmad_enabled: true, allow_non_interactive: true }))
+
+    step = Step.find(created["id"])
+    assert_equal agent.id, step.agent_id
+    assert_equal [ tool.id ], step.tool_ids
+    assert_equal [ skill.id ], step.skill_ids
+    assert_equal [ server.id ], step.mcp_server_ids
+    assert_equal [ first["id"] ], step.depends_on_step_ids
+    assert step.bmad_enabled
+    assert step.allow_non_interactive
+  end
+
+  test "update_workflow_step toggles bmad_enabled and allow_non_interactive" do
+    step = create(:step, workflow: @workflow)
+
+    body = call_tool("update_workflow_step",
+                     { project_id: @project.id, workflow_id: @workflow.id, step_id: step.id,
+                       bmad_enabled: true, allow_non_interactive: true })
+    assert_not error?(body)
+    assert_includes payload(body)["updated_fields"], "bmad_enabled"
+
+    step.reload
+    assert step.bmad_enabled
+    assert step.allow_non_interactive
+  end
+
+  test "duplicate_workflow copies steps and reports what needs manual setup" do
+    step = create(:step, workflow: @workflow, name: "S1", instructions: "work")
+    create(:sub_step, step: step, name: "check A")
+
+    copy = payload(call_tool("duplicate_workflow",
+                             { project_id: @project.id, workflow_id: @workflow.id, name: "Copy of it" }))
+    assert_not_equal @workflow.id, copy["id"]
+    assert_equal "Copy of it", copy["name"]
+    assert_equal @project.id, copy["project_id"]
+    assert_equal @workflow.id, copy["source_workflow_id"]
+    assert_equal 1, copy["steps_count"]
+    assert copy["needs_setup"].any? { |m| m.match?(/not copied/i) }
+
+    duplicated_step = Workflow.find(copy["id"]).steps.not_deleted.first
+    assert_equal "S1", duplicated_step.name
+    assert_equal [ "check A" ], duplicated_step.sub_steps.active.map(&:name)
+  end
+
+  test "duplicate_workflow copies into another reachable project and refuses an unreachable one" do
+    create(:step, workflow: @workflow, name: "S1")
+    target = create(:project, company: @company, owner: @user)
+
+    copied = payload(call_tool("duplicate_workflow",
+                               { project_id: @project.id, workflow_id: @workflow.id,
+                                 target_project_id: target.id }))
+    assert_equal target.id, copied["project_id"]
+    assert_equal target.id, Workflow.find(copied["id"]).scope_id
+
+    outsider = create(:user, :with_company)
+    outsider_project = create(:project, company: outsider.companies.first, owner: outsider)
+    denied = call_tool("duplicate_workflow",
+                       { project_id: @project.id, workflow_id: @workflow.id,
+                         target_project_id: outsider_project.id })
+    assert error?(denied)
+    assert_match(/not found/i, text(denied))
   end
 
   test "trigger_workflow starts a run and list/get_workflow_run report it" do


### PR DESCRIPTION
## Why

A user built four workflows end-to-end through the personal MCP server and could not connect a single one to anything: no tool spoke to `TriggerBinding` or `ColumnWorkflowBinding`, so every trigger — a board column, a cron report, a Slack intake — had to be wired by hand in the UI. Three smaller gaps forced the same fallback: a workflow could not be renamed, a step's instructions could only be blind-overwritten because `get_workflow` truncates them at 500 chars, and a step run that died in ten seconds reported nothing beyond its state.

`list_project_tools` returning `[]` turned out to be a real bug rather than a missing feature. `Tool.visible_for_project` yields attachable platform tools **or** the project's custom ones; the chained `.ui_visible` (`db_source`) ANDed the platform half straight back out, so any project without custom tools got an empty list and `tool_ids` had to be copied between steps sight unseen.

## What

**Triggers** (`list` / `create` / `update` / `delete_workflow_trigger`) — one surface over both binding kinds, mirroring `Api::V1::Projects::Workflows::TriggersController`. `kind` is `column | slack | schedule | webhook | event`; `kind=webhook` also provisions a `WebhookEndpoint` and returns its URL and secret. Model validation messages reach the caller verbatim, so the auto-run rejection names the steps still waiting on a human, and `Temporalio::Error` reports "saved, but scheduling failed — re-save to retry".

**Workflow authoring** — `update_workflow` (name, description, base resources), `get_workflow_step` (full untruncated instructions plus every wiring field), `duplicate_workflow` (wraps `WorkflowDuplicator`, returns its `needs_setup` summary).

**Introspection** — `get_agent` (full persona), `get_skill` (full content), and the `list_project_tools` fix, which now also carries description, tags and `requires_integration` so ids stop being opaque.

**Board and runs** — `archive_board_task`, `list_gates`, `delete_gate`, `get_step_run` (error category/message/history, skip reason, retries, plus the terminal session's `context_metadata`, where `bmad_install_status` lands).

**Existing tools** — `create_workflow_step` takes the whole wiring in one call; `update_workflow_step` gains `bmad_enabled` and `allow_non_interactive`; `get_workflow` reports base resources and flags each truncated instruction; `create_board_column` inserts at a taken position by shifting instead of failing.

Every param that replaces a list wholesale now says so and names the tool to read the current value with.

## Deliberately not included

- **`create_gate` / `resolve_gate`** — `Gate` supports exactly three CI gate types, created and resolved by GitHub/GitLab webhooks. A manual resolve is an override of that path, which is a product decision rather than a tool. `list_gates` says so in its description.
- **`bmad_modules` on a step** — not a step column at all; it lives in `terminal_sessions.session_config`. Exposing it needs a migration. `bmad_enabled` is included.
- **Integration channel listing / test message** — a live Slack API call with an outbound side effect, not a field addition.

## Notes

- `create_board_column` shifts the tail in descending order inside a transaction: there is a DB unique index on `(board_id, position)` on top of the model validation, and the association's default `order(:position)` means a chained `.order(position: :desc)` would silently stay ascending — hence `.reorder`.
- `duplicate_workflow` authorizes `duplicate?` on the target project as well when it differs from the source; membership alone does not imply write access there.
- The webhook path is wrapped in a transaction, unlike the controller it mirrors: since the auto-run rule rejects most first attempts, the controller's create-endpoint-then-create-binding order leaks a `WebhookEndpoint` per retry. **That leak still exists in `triggers_controller.rb` and is worth a separate fix.**
- The agent-facing `references/aixle-system-reference.md` documented only column bindings and still called gates `TaskWaits`; §6 now covers event triggers, the all-steps-auto-run rule and the UTC/DST timezone trap. The `build_workflow` / `author_step` MCP prompts and the in-app MCP docs page were updated to match.

## Verification

`docker compose exec -T web make check_all` — green across all eight checks (rails-test, system-test, rubocop, brakeman, eslint, typescript, fe-test, vite-build). Coverage: backend 90.76%, frontend 78.34%.

New/extended integration tests: `personal_mcp_triggers_test.rb` (new), `personal_mcp_step_runs_test.rb` (new), plus additions to `personal_mcp_workflows_test.rb`, `personal_mcp_resources_test.rb` and `personal_mcp_board_test.rb`. Each new tool is covered for its happy path and for cross-tenant isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
