### PR TITLE
feat(mcp): add sub-step update, delete and reorder tools

### DIFF
--- a/app/frontend/pages/Projects/AixleBuilder/SessionPage.tsx
+++ b/app/frontend/pages/Projects/AixleBuilder/SessionPage.tsx
@@ -74,6 +74,8 @@ const ACTION_LABELS: Record<string, string> = {
   deleted_workflow: 'Deleted workflow',
   created_step: 'Created step',
   created_sub_step: 'Created sub-step',
+  updated_sub_step: 'Updated sub-step',
+  deleted_sub_step: 'Deleted sub-step',
   updated_step: 'Updated step',
   deleted_step: 'Deleted step',
   reordered_steps: 'Reordered steps',

--- a/app/services/internal_tools/meta_delete_sub_step.rb
+++ b/app/services/internal_tools/meta_delete_sub_step.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module InternalTools
+  class MetaDeleteSubStep < Base
+    tool do
+      display_name "Meta Delete Sub-Step"
+      description "Delete a sub-step from a step. A sub-step that already has runs is soft-deleted " \
+                  "so past run history stays readable."
+      tags :builder
+      user_attachable false
+      input_schema({
+        type: "object",
+        required: %w[sub_step_id],
+        properties: {
+          sub_step_id: {
+            type: "integer",
+            description: "Sub-step ID to delete (see meta_get_workflow)"
+          }
+        }
+      })
+    end
+
+    include MetaToolHelpers
+
+    def execute
+      require_project_context!
+
+      sub_step = SubStep.find(params[:sub_step_id])
+      name = sub_step.name
+      step_id = sub_step.step_id
+      sub_step.destroy
+
+      broadcast_meta_activity(
+        action: "deleted_sub_step",
+        entity_type: "SubStep",
+        entity_name: name,
+        entity_id: sub_step.id,
+        details: { step_id: step_id }
+      )
+
+      success({ deleted: true, sub_step_name: name, step_id: step_id, soft_deleted: sub_step.deleted? }.to_json)
+    rescue ActiveRecord::RecordNotFound => e
+      error("Sub-step not found: #{e.message}")
+    end
+  end
+end

--- a/app/services/internal_tools/meta_update_sub_step.rb
+++ b/app/services/internal_tools/meta_update_sub_step.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module InternalTools
+  class MetaUpdateSubStep < Base
+    tool do
+      display_name "Meta Update Sub-Step"
+      description "Update an existing sub-step's fields (name, instructions, position, required)."
+      tags :builder
+      user_attachable false
+      input_schema({
+        type: "object",
+        required: %w[sub_step_id],
+        properties: {
+          name: {
+            type: "string"
+          },
+          position: {
+            type: "integer",
+            description: "Position within the step"
+          },
+          required: {
+            type: "boolean",
+            description: "Must be completed for the step to finish"
+          },
+          instructions: {
+            type: "string",
+            description: "What the agent must do in this unit of work"
+          },
+          sub_step_id: {
+            type: "integer",
+            description: "Sub-step ID to update (see meta_get_workflow)"
+          }
+        }
+      })
+    end
+
+    include MetaToolHelpers
+
+    def execute
+      require_project_context!
+
+      sub_step = SubStep.find(params[:sub_step_id])
+      attrs = %i[name instructions position required].each_with_object({}) do |key, acc|
+        acc[key] = params[key] if params.key?(key)
+      end
+      return error("No fields to update") if attrs.empty?
+
+      sub_step.update!(attrs)
+
+      broadcast_meta_activity(
+        action: "updated_sub_step",
+        entity_type: "SubStep",
+        entity_name: sub_step.name,
+        entity_id: sub_step.id,
+        details: { step_id: sub_step.step_id, updated_fields: attrs.keys.map(&:to_s) }
+      )
+
+      success({
+        id: sub_step.id,
+        step_id: sub_step.step_id,
+        name: sub_step.name,
+        position: sub_step.position,
+        updated_fields: attrs.keys.map(&:to_s)
+      }.to_json)
+    rescue ActiveRecord::RecordNotFound => e
+      error("Sub-step not found: #{e.message}")
+    rescue ActiveRecord::RecordInvalid => e
+      error("Failed to update sub-step: #{e.message}")
+    end
+  end
+end

--- a/app/services/personal_tools/base.rb
+++ b/app/services/personal_tools/base.rb
@@ -87,6 +87,13 @@ module PersonalTools
       step
     end
 
+    def find_sub_step!(step, id = params[:sub_step_id])
+      sub_step = step.sub_steps.active.find_by(id: id)
+      raise NotFoundError, "Sub-step #{id} not found in this step" unless sub_step
+
+      sub_step
+    end
+
     # Ambiguity is an error, never a silent pick: a multi-company user writing
     # into the wrong company is not recoverable from the agent's side.
     def sole_membership!(memberships)

--- a/app/services/personal_tools/delete_sub_step.rb
+++ b/app/services/personal_tools/delete_sub_step.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class DeleteSubStep < Base
+    tool do
+      display_name "Delete Sub-Step"
+      description "Delete a sub-step (checklist item) from a workflow step. A sub-step that already has " \
+                  "runs is soft-deleted so past run history stays readable."
+      audience :user
+      tags :workflows
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :workflow_id, type: :integer, description: "Workflow id.", required: true
+      param :step_id, type: :integer, description: "Step id.", required: true
+      param :sub_step_id, type: :integer, description: "Sub-step id (from get_workflow_step).", required: true
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project, :update?, policy: Web::Company::Projects::WorkflowsPolicy, project: project)
+      step = find_step!(find_workflow!(project))
+      sub_step = find_sub_step!(step)
+
+      name = sub_step.name
+      sub_step.destroy
+      success(deleted_sub_step_id: sub_step.id, name: name, step_id: step.id,
+              soft_deleted: sub_step.deleted?)
+    end
+  end
+end

--- a/app/services/personal_tools/reorder_sub_steps.rb
+++ b/app/services/personal_tools/reorder_sub_steps.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class ReorderSubSteps < Base
+    tool do
+      display_name "Reorder Sub-Steps"
+      description "Set the order of a step's sub-steps by passing every sub-step id in the desired order. " \
+                  "Read the step with get_workflow_step first — it reports the current ids and order."
+      audience :user
+      tags :workflows
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :workflow_id, type: :integer, description: "Workflow id.", required: true
+      param :step_id, type: :integer, description: "Step id.", required: true
+      param :sub_step_ids, type: :array, description: "Sub-step ids in the new order.", required: true,
+            items: { type: "integer" }
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project, :update?, policy: Web::Company::Projects::WorkflowsPolicy, project: project)
+      step = find_step!(find_workflow!(project))
+
+      ids = params[:sub_step_ids]
+      return error("sub_step_ids must be a non-empty array") unless ids.is_a?(Array) && ids.any?
+
+      by_id = step.sub_steps.active.index_by(&:id)
+      ids = ids.map(&:to_i)
+      unknown = ids - by_id.keys
+      return error("Sub-steps not in this step: #{unknown.join(', ')}") if unknown.any?
+
+      missing = by_id.keys - ids
+      return error("Missing sub-step ids — pass every sub-step of the step: #{missing.join(', ')}") if missing.any?
+
+      ActiveRecord::Base.transaction do
+        ids.each_with_index { |id, idx| by_id.fetch(id).update_column(:position, idx + 1) }
+      end
+      success(step_id: step.id, new_order: ids)
+    end
+  end
+end

--- a/app/services/personal_tools/update_sub_step.rb
+++ b/app/services/personal_tools/update_sub_step.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class UpdateSubStep < Base
+    tool do
+      display_name "Update Sub-Step"
+      description "Update a sub-step (checklist item) of a workflow step. Read the step with " \
+                  "get_workflow_step first — it reports each sub-step's id."
+      audience :user
+      tags :workflows
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :workflow_id, type: :integer, description: "Workflow id.", required: true
+      param :step_id, type: :integer, description: "Step id.", required: true
+      param :sub_step_id, type: :integer, description: "Sub-step id (from get_workflow_step).", required: true
+      param :name, type: :string, description: "Updated name."
+      param :instructions, type: :string, description: "Updated instructions (markdown)."
+      param :position, type: :integer, description: "Updated position within the step."
+      param :required, type: :boolean, description: "Whether the sub-step is required."
+    end
+
+    UPDATABLE = %i[name instructions position required].freeze
+
+    def execute
+      project = find_project!
+      authorize!(project, :update?, policy: Web::Company::Projects::WorkflowsPolicy, project: project)
+      step = find_step!(find_workflow!(project))
+      sub_step = find_sub_step!(step)
+
+      attrs = UPDATABLE.each_with_object({}) { |k, h| h[k] = params[k] if params.key?(k) }
+      return error("No fields to update") if attrs.empty?
+
+      sub_step.update!(attrs)
+      success(id: sub_step.id, step_id: step.id, name: sub_step.name, position: sub_step.position,
+              updated_fields: attrs.keys.map(&:to_s))
+    rescue ActiveRecord::RecordInvalid => e
+      error("Failed to update sub-step: #{e.message}")
+    end
+  end
+end

--- a/app/services/tools/personal_mcp_request_handler.rb
+++ b/app/services/tools/personal_mcp_request_handler.rb
@@ -140,8 +140,10 @@ module Tools
            the steps they point at first (or set them later with
            `update_workflow_step`).
         6. `create_sub_step` — break a step into a checklist when it has several
-           distinct deliverables. See the `author_step` prompt for how to write
-           a good step.
+           distinct deliverables. `update_sub_step` / `delete_sub_step` /
+           `reorder_sub_steps` edit, remove and reorder them; all take the
+           `sub_step_id`s reported by `get_workflow_step`. See the `author_step`
+           prompt for how to write a good step.
         7. `reorder_workflow_steps` — fix execution order by passing step ids.
         8. Connect a trigger, or the workflow only ever starts by hand:
            `create_workflow_trigger` with a `kind` —
@@ -157,7 +159,7 @@ module Tools
 
         Rules:
         - Ask the user before destructive actions (`delete_workflow`,
-          `delete_workflow_step`, `delete_workflow_trigger`).
+          `delete_workflow_step`, `delete_sub_step`, `delete_workflow_trigger`).
         - `get_workflow` truncates step instructions. Read a step with
           `get_workflow_step` before editing it, or you will overwrite text you
           never saw. The same applies to every id list (`tool_ids`, `skill_ids`,
@@ -218,6 +220,10 @@ module Tools
         - One `create_sub_step` per distinct, checkable deliverable.
         - `required: false` for optional work.
         - The running agent marks them off, giving progress visibility.
+        - `get_workflow_step` reports each sub-step's id; edit one with
+          `update_sub_step` (name, instructions, position, required), drop one with
+          `delete_sub_step`, and fix the order with `reorder_sub_steps` (which
+          takes every sub-step id of the step).
 
         Prefer `get_workflow` to inspect the current shape and `get_workflow_step`
         to read a step in full before editing, and make one focused change per

--- a/db/seeds/aixle_builder.rb
+++ b/db/seeds/aixle_builder.rb
@@ -156,6 +156,7 @@ module Seeds
              - meta_create_workflow — creates the workflow
              - meta_create_step — for each step (write focused, task-specific instructions)
              - meta_create_sub_step — for progress tracking within steps
+               (meta_update_sub_step / meta_delete_sub_step to edit or drop one)
              - meta_link_resource_to_step — attach tools, skills, MCP servers
 
           6. **Configure Board (if requested)** — Set up automation:
@@ -189,7 +190,8 @@ module Seeds
     def self.tool_names
       %w[
         meta_create_workflow meta_create_agent meta_create_step
-        meta_create_sub_step meta_get_workflow meta_list_workflows
+        meta_create_sub_step meta_update_sub_step meta_delete_sub_step
+        meta_get_workflow meta_list_workflows
         meta_finalize_workflow meta_update_step meta_delete_step
         meta_reorder_steps meta_create_tool meta_install_skill
         meta_search_skills meta_create_mcp_server meta_link_resource_to_step

--- a/docs/design/meta-workflow.md
+++ b/docs/design/meta-workflow.md
@@ -218,6 +218,8 @@ All the tools below are **internal tools** (like `mark_sub_step`), available onl
 | `meta_create_workflow` | Create the target workflow | `workflow:created` |
 | `meta_create_step` | Add a step to the target workflow | `workflow:step_created` |
 | `meta_create_sub_step` | Add a sub-step to a step | `workflow:sub_step_created` |
+| `meta_update_sub_step` | Update a sub-step (name, instructions, position, required) | `workflow:sub_step_updated` |
+| `meta_delete_sub_step` | Delete a sub-step (soft-deleted once it has runs) | `workflow:sub_step_deleted` |
 | `meta_update_step` | Update a step (instructions, config) | `workflow:step_updated` |
 | `meta_delete_step` | Delete a step | `workflow:step_deleted` |
 | `meta_reorder_steps` | Change the order of steps | `workflow:steps_reordered` |

--- a/test/integration/personal_mcp_workflows_test.rb
+++ b/test/integration/personal_mcp_workflows_test.rb
@@ -195,6 +195,24 @@ class PersonalMCPWorkflowsTest < ActionDispatch::IntegrationTest
                     { project_id: @project.id, workflow_id: @workflow.id, step_id: s1["id"], name: "check A" })
     assert_not error?(sub)
 
+    sub_edited = payload(call_tool("update_sub_step",
+                                   { project_id: @project.id, workflow_id: @workflow.id, step_id: s1["id"],
+                                     sub_step_id: payload(sub)["id"], name: "check A (edited)",
+                                     instructions: "do A", required: false }))
+    assert_equal "check A (edited)", sub_edited["name"]
+    assert_equal [ "name", "instructions", "required" ], sub_edited["updated_fields"]
+
+    read_back = payload(call_tool("get_workflow_step",
+                                  { project_id: @project.id, workflow_id: @workflow.id, step_id: s1["id"] }))
+    assert_equal [ { "id" => payload(sub)["id"], "name" => "check A (edited)", "position" => 1,
+                     "required" => false, "instructions" => "do A" } ], read_back["sub_steps"]
+
+    dropped = payload(call_tool("delete_sub_step",
+                                { project_id: @project.id, workflow_id: @workflow.id, step_id: s1["id"],
+                                  sub_step_id: payload(sub)["id"] }))
+    refute dropped["soft_deleted"]
+    assert_not SubStep.exists?(payload(sub)["id"])
+
     upd = call_tool("update_workflow_step",
                     { project_id: @project.id, workflow_id: @workflow.id, step_id: s2["id"],
                       depends_on_step_ids: [ s1["id"] ] })
@@ -211,6 +229,68 @@ class PersonalMCPWorkflowsTest < ActionDispatch::IntegrationTest
 
     ok = call_tool("delete_workflow_step", { project_id: @project.id, workflow_id: @workflow.id, step_id: s2["id"] })
     assert_not error?(ok)
+  end
+
+  test "reorder_sub_steps rewrites positions and rejects a partial id list" do
+    step = @workflow.steps.create!(name: "S", position: 1)
+    a = create(:sub_step, step: step, name: "A", position: 1)
+    b = create(:sub_step, step: step, name: "B", position: 2)
+
+    partial = call_tool("reorder_sub_steps", { project_id: @project.id, workflow_id: @workflow.id,
+                                               step_id: step.id, sub_step_ids: [ b.id ] })
+    assert error?(partial)
+    assert_match(/missing sub-step ids/i, text(partial))
+
+    ok = payload(call_tool("reorder_sub_steps", { project_id: @project.id, workflow_id: @workflow.id,
+                                                  step_id: step.id, sub_step_ids: [ b.id, a.id ] }))
+    assert_equal [ b.id, a.id ], ok["new_order"]
+
+    read_back = payload(call_tool("get_workflow_step",
+                                  { project_id: @project.id, workflow_id: @workflow.id, step_id: step.id }))
+    assert_equal %w[B A], read_back["sub_steps"].map { |ss| ss["name"] }
+  end
+
+  test "delete_sub_step soft-deletes a sub-step that already ran, keeping run history" do
+    step = @workflow.steps.create!(name: "S", position: 1)
+    sub = create(:sub_step, step: step)
+    run = @workflow.runs.create!(project: @project, user: @user, state: "running")
+    ssr = create(:sub_step_run, sub_step: sub, step_run: run.step_runs.create!(step: step, state: "running"))
+
+    body = payload(call_tool("delete_sub_step",
+                             { project_id: @project.id, workflow_id: @workflow.id,
+                               step_id: step.id, sub_step_id: sub.id }))
+    assert body["soft_deleted"]
+    assert sub.reload.deleted?
+    assert SubStepRun.exists?(ssr.id)
+
+    read_back = payload(call_tool("get_workflow_step",
+                                  { project_id: @project.id, workflow_id: @workflow.id, step_id: step.id }))
+    assert_empty read_back["sub_steps"]
+  end
+
+  test "sub-step authoring tools reject a sub_step_id from another step" do
+    mine = @workflow.steps.create!(name: "Mine", position: 1)
+    other = @workflow.steps.create!(name: "Other", position: 2)
+    foreign = create(:sub_step, step: other)
+
+    %w[update_sub_step delete_sub_step].each do |tool|
+      body = call_tool(tool, { project_id: @project.id, workflow_id: @workflow.id,
+                               step_id: mine.id, sub_step_id: foreign.id, name: "hijacked" })
+      assert error?(body), "#{tool} accepted a foreign sub_step_id"
+      assert_match(/not found/i, text(body))
+    end
+    assert_not_equal "hijacked", foreign.reload.name
+    assert_not foreign.deleted?
+  end
+
+  test "update_sub_step with no updatable field is an error" do
+    step = @workflow.steps.create!(name: "S", position: 1)
+    sub = create(:sub_step, step: step)
+
+    body = call_tool("update_sub_step", { project_id: @project.id, workflow_id: @workflow.id,
+                                          step_id: step.id, sub_step_id: sub.id })
+    assert error?(body)
+    assert_match(/no fields to update/i, text(body))
   end
 
   test "cancel_workflow_run delegates to WorkflowService.cancel" do

--- a/test/integration/web/company/projects/aixle_builder_controller_test.rb
+++ b/test/integration/web/company/projects/aixle_builder_controller_test.rb
@@ -100,7 +100,7 @@ class Web::Company::Projects::AixleBuilderControllerTest < ActionDispatch::Integ
     # demand — no pre-seeded rows required.
     attached = Tool.where(id: captured[:params][:tool_ids])
     assert_equal Tools::Registry.tagged(:builder).map(&:name).sort, attached.pluck(:name).sort
-    assert_equal 28, attached.count
+    assert_equal 30, attached.count
   end
 
   test "start redirects back with flash alert when session save fails" do

--- a/test/models/meta_tools_seed_test.rb
+++ b/test/models/meta_tools_seed_test.rb
@@ -5,7 +5,8 @@ require "test_helper"
 class MetaToolsSeedTest < ActiveSupport::TestCase
   AIXLE_BUILDER_TOOL_NAMES = %w[
     meta_create_workflow meta_create_agent meta_create_step
-    meta_create_sub_step meta_get_workflow meta_list_workflows
+    meta_create_sub_step meta_update_sub_step meta_delete_sub_step
+    meta_get_workflow meta_list_workflows
     meta_finalize_workflow meta_update_step meta_delete_step
     meta_reorder_steps meta_create_tool meta_install_skill
     meta_search_skills meta_create_mcp_server meta_link_resource_to_step
@@ -21,7 +22,7 @@ class MetaToolsSeedTest < ActiveSupport::TestCase
     Tools::Reconciler.run!
   end
 
-  test "all 28 aixle builder tool names exist as platform tools" do
+  test "all 30 aixle builder tool names exist as platform tools" do
     found = Tool.code_source.where(name: AIXLE_BUILDER_TOOL_NAMES).pluck(:name).sort
     assert_equal AIXLE_BUILDER_TOOL_NAMES.sort, found,
       "Missing tools: #{(AIXLE_BUILDER_TOOL_NAMES - found).inspect}"

--- a/test/services/internal_tools/meta_workflow_tools_test.rb
+++ b/test/services/internal_tools/meta_workflow_tools_test.rb
@@ -146,6 +146,65 @@ class InternalTools::MetaWorkflowToolsTest < ActiveSupport::TestCase
     assert_equal step.id, data["step_id"]
   end
 
+  # ── meta_update_sub_step / meta_delete_sub_step ──
+
+  test "meta_update_sub_step edits the named fields only" do
+    sub = create(:sub_step, step: create(:step, workflow: create(:workflow, scope: @project)),
+                            name: "Old", instructions: "old text", required: true)
+
+    result = InternalTools::MetaUpdateSubStep.new(
+      params: { sub_step_id: sub.id, name: "New", required: false },
+      session: @session
+    ).execute
+
+    assert_equal 0, result[:exit_code]
+    data = JSON.parse(result[:stdout])
+    assert_equal %w[name required], data["updated_fields"]
+    sub.reload
+    assert_equal "New", sub.name
+    assert_not sub.required
+    assert_equal "old text", sub.instructions
+  end
+
+  test "meta_update_sub_step without fields is an error" do
+    sub = create(:sub_step, step: create(:step, workflow: create(:workflow, scope: @project)))
+
+    result = InternalTools::MetaUpdateSubStep.new(params: { sub_step_id: sub.id }, session: @session).execute
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "No fields to update"
+  end
+
+  test "meta_update_sub_step reports a missing sub-step" do
+    result = InternalTools::MetaUpdateSubStep.new(params: { sub_step_id: 0, name: "X" }, session: @session).execute
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "Sub-step not found"
+  end
+
+  test "meta_delete_sub_step destroys a sub-step that never ran" do
+    sub = create(:sub_step, step: create(:step, workflow: create(:workflow, scope: @project)), name: "Doomed")
+
+    result = InternalTools::MetaDeleteSubStep.new(params: { sub_step_id: sub.id }, session: @session).execute
+
+    assert_equal 0, result[:exit_code]
+    data = JSON.parse(result[:stdout])
+    assert_equal "Doomed", data["sub_step_name"]
+    assert_not data["soft_deleted"]
+    assert_not SubStep.exists?(sub.id)
+  end
+
+  test "meta_delete_sub_step soft-deletes a sub-step that already ran" do
+    sub = create(:sub_step, step: @step_run.step)
+    create(:sub_step_run, sub_step: sub, step_run: @step_run)
+
+    result = InternalTools::MetaDeleteSubStep.new(params: { sub_step_id: sub.id }, session: @session).execute
+
+    assert_equal 0, result[:exit_code]
+    assert JSON.parse(result[:stdout])["soft_deleted"]
+    assert sub.reload.deleted?
+  end
+
   # ── meta_get_workflow ──
 
   test "meta_get_workflow returns full workflow structure" do

--- a/test/services/tools/registry_test.rb
+++ b/test/services/tools/registry_test.rb
@@ -31,7 +31,7 @@ class Tools::RegistryTest < ActiveSupport::TestCase
   test "tagged returns builder tools for the Aixle Builder attach path" do
     builder_tools = Tools::Registry.tagged(:builder)
 
-    assert_equal 28, builder_tools.size
+    assert_equal 30, builder_tools.size
     assert builder_tools.all? { |d| d.name.start_with?("meta_") }
     assert builder_tools.none?(&:user_attachable)
   end
@@ -45,7 +45,7 @@ class Tools::RegistryTest < ActiveSupport::TestCase
   test "grouping axes cover every definition" do
     defs = Tools::Registry.definitions.values
 
-    assert_equal 28, defs.count { |d| d.tags.include?(:builder) }
+    assert_equal 30, defs.count { |d| d.tags.include?(:builder) }
     assert_equal 18, defs.count { |d| d.inject_rules.include?(:workflow_step_session) }
     assert_equal 3, defs.count { |d| d.inject_rules.intersect?(%i[container_tools_present non_interactive_session]) }
   end


### PR DESCRIPTION
## Why

Both tool surfaces could **create** sub-steps but never change them. An agent that named a sub-step wrong, or laid a checklist out in the wrong order, had to delete the whole step and rebuild it.

## What

**Personal MCP (`PersonalTools`)**
- `update_sub_step` — name / instructions / position / required. Empty field set is an error, matching `update_workflow_step`.
- `delete_sub_step` — reports `soft_deleted` so the caller knows whether history was kept.
- `reorder_sub_steps` — takes **every** sub-step id of the step; a partial list is rejected and names the missing ids, because a partial reorder would leave positions the caller never chose. No two-phase position parking here: `sub_steps` has no unique index on `(step_id, position)`, unlike `steps`.
- `find_sub_step!` in `PersonalTools::Base` scopes the lookup to the step and to `.active`, so a `sub_step_id` from another step returns `not found` instead of silently editing it.

**Aixle Builder (`InternalTools`)**
- `meta_update_sub_step`, `meta_delete_sub_step`, both broadcasting builder activity; the two new action labels are added to the session timeline in `SessionPage.tsx`.
- `db/seeds/aixle_builder.rb` attaches them to the Builder workflow.

Deletion goes through `SubStep#destroy`, which soft-deletes once the sub-step has runs, so past run history stays readable.

Guides updated so the agents actually reach for the new tools: the personal-MCP workflow guide + `author_step` prompt, and `docs/design/meta-workflow.md`.

## Deploy note

Existing environments need `rails db:seed` — the Builder workflow's `tool_ids` are seeded, not resolved per run, so without it the Builder won't see the two new meta tools.

## Tests

- `personal_mcp_workflows_test.rb`: create → update → read-back → delete round-trip, reorder incl. the partial-list rejection, soft-delete with an existing run, foreign `sub_step_id` rejection, empty update.
- `meta_workflow_tools_test.rb`: update (only named fields change), empty update, missing sub-step, hard vs soft delete.
- Hardcoded builder-tool counts bumped 28 → 30 (`registry_test.rb`, `meta_tools_seed_test.rb`, `aixle_builder_controller_test.rb`).

`make check_all` green on this branch (backend 90.82%, frontend 78.31%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)