### PR TITLE
feat(personal-mcp): add connector catalog and registry-read tools

### DIFF
--- a/app/controllers/web/company/projects/skills_controller.rb
+++ b/app/controllers/web/company/projects/skills_controller.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class Web::Company::Projects::SkillsController < Web::Company::Projects::ApplicationController
-  CATALOG_PAGE_SIZE = 60
-  # Upstream is rate-limited per IP with no published number, and every debounced
-  # keystroke from every member arrives here. Short-lived caching keeps a room full of
-  # people typing from spending the whole deployment's budget on the same queries.
-  SEARCH_CACHE_TTL = 5.minutes
-
   def index
     skills = Skill.visible_for_project(current_project).order(created_at: :desc)
 
@@ -14,7 +8,7 @@ class Web::Company::Projects::SkillsController < Web::Company::Projects::Applica
       project: project_props,
       skills: skills.map { |s| SkillResource.new(s).to_h },
       catalogQuery: catalog_query,
-      catalogSkills: catalog_entries.map { |c| CatalogSkillResource.new(c).to_h },
+      catalogSkills: Skills::CatalogSearch.call(catalog_query).map { |c| CatalogSkillResource.new(c).to_h },
       catalogSyncedAt: CatalogSkill.maximum(:registry_synced_at)
     }
 
@@ -131,70 +125,6 @@ class Web::Company::Projects::SkillsController < Web::Company::Projects::Applica
 
   def catalog_query
     params[:catalog_q].to_s.strip
-  end
-
-  # Blank (or too-short) query → the default browse view, served from the mirror.
-  # A real query → upstream, because skills.sh's fuzzy search beats anything the
-  # mirror can do and the mirror is incomplete by construction.
-  #
-  # NOTHING IS PERSISTED HERE. `index` authorizes as a project READ, so a viewer who
-  # is denied `create?` must not be able to write rows into a table shared by every
-  # tenant, or trigger an outbound request per keystroke, just by loading a URL.
-  # Upstream hits are rendered from unsaved records; the weekly sweep owns the mirror.
-  def catalog_entries
-    return default_catalog_entries if catalog_query.length < Skills::RegistryClient::MIN_QUERY_LENGTH
-
-    entries = cached_search(catalog_query)
-    # Upstream unreachable, or nothing matched: fall back to full-text over whatever
-    # is mirrored rather than showing an empty catalog.
-    return CatalogSkill.search(catalog_query).limit(CATALOG_PAGE_SIZE) if entries.empty?
-
-    merge_with_mirror(entries)
-  end
-
-  def default_catalog_entries
-    CatalogSkill.one_per_source.popular.limit(CATALOG_PAGE_SIZE)
-  end
-
-  # Recording happens inside the cache-miss block on purpose: a debounced field would
-  # otherwise write once per keystroke, and with the 5-minute cache a term is recorded
-  # at most once per window no matter how many people are typing it. The term steers a
-  # later sweep and is stored unattributed — see CatalogSearchQuery.
-  def cached_search(query)
-    Rails.cache.fetch([ "skills-catalog-search", query ], expires_in: SEARCH_CACHE_TTL) do
-      CatalogSearchQuery.record(query)
-      Skills::RegistryClient.search(query, limit: CATALOG_PAGE_SIZE)
-    end
-  end
-
-  # Upstream relevance order is preserved: the endpoint ranks by fuzzy match, and
-  # re-sorting by popularity would push the exact-name hit below a tangential match
-  # with more installs. Mirrored rows are reused where they exist so a result keeps
-  # its description and audit verdicts; anything unmirrored renders from the search
-  # payload alone.
-  def merge_with_mirror(entries)
-    mirrored = CatalogSkill.where(registry_id: entries.map(&:id).compact).index_by(&:registry_id)
-
-    entries.map { |entry| mirrored[entry.id] || transient_catalog_skill(entry) }
-  end
-
-  def transient_catalog_skill(entry)
-    source, slug = split_registry_id(entry)
-
-    CatalogSkill.new(
-      registry_id: entry.id.presence || "#{source}/#{slug}",
-      source: source,
-      slug: slug,
-      title: (entry.name if entry.name.present? && entry.name != slug),
-      installs: entry.installs.to_i
-    )
-  end
-
-  def split_registry_id(entry)
-    parts = entry.id.to_s.split("/").reject(&:blank?)
-    return [ entry.source, entry.slug ] if parts.size < 2
-
-    [ parts[0..-2].join("/"), parts.last ]
   end
 
   # The download endpoint reports no install count, so the figure comes from the

--- a/app/services/personal_tools/get_connector.rb
+++ b/app/services/personal_tools/get_connector.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  # Everything install_connector needs and nothing it does not: the install
+  # targets and the inputs each one declares. Serialized through
+  # ConnectorResource, the single place that knows the registry's manifest
+  # dialect — a second hand-rolled reading of it here would drift from the UI's.
+  class GetConnector < Base
+    tool do
+      display_name "Get Connector"
+      description "Return one MCP connector catalog entry in full: every install target (remote endpoint " \
+                  "or package, with the exact launch command) and the inputs it declares. Read this " \
+                  "before install_connector — target_id and the input keys come from here."
+      audience :user
+      tags :resources
+      read_only
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :connector_name, type: :string,
+            description: "Registry name, e.g. \"com.linear.linear\" (see search_connector_catalog).",
+            required: true
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project, :index?, policy: Web::Company::Projects::MCPServersPolicy, project: project)
+
+      connector = Connector.find_by(name: params[:connector_name].to_s)
+      return error("Connector '#{params[:connector_name]}' is not in the catalog") unless connector
+
+      success(ConnectorResource.new(connector, params: { snake_keys: true }).to_h
+        .merge(already_installed: installed_names(project, connector)))
+    end
+
+    private
+
+    # Installing the same connector twice is allowed (the installer suffixes the
+    # name), so this is information rather than a block — but an agent that is
+    # about to add a second Linear should be able to see the first one.
+    def installed_names(project, connector)
+      MCPServer.visible_for_project(project).where(connector_name: connector.name).pluck(:name)
+    end
+  end
+end

--- a/app/services/personal_tools/get_mcp_server.rb
+++ b/app/services/personal_tools/get_mcp_server.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  # `list_mcp_servers` answers "what is wired up here" in five fields. This
+  # answers "should I trust and use this one": where it points, what it was
+  # installed from, whether its tool declarations moved after approval, and
+  # whether the caller still has to sign in.
+  class GetMCPServer < Base
+    tool do
+      display_name "Get MCP Server"
+      description "Return one configured MCP server in full: transport and endpoint, connector provenance " \
+                  "and version, tool-baseline drift, and auth state. Header and env VALUES are never " \
+                  "returned — only which keys exist."
+      audience :user
+      tags :resources
+      read_only
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :mcp_server_id, type: :integer, description: "MCP server id (see list_mcp_servers).", required: true
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project, :index?, policy: Web::Company::Projects::MCPServersPolicy, project: project)
+
+      server = MCPServer.visible_for_project(project).find_by(id: params[:mcp_server_id])
+      return error("MCP server not found in this project") unless server
+
+      success({ id: server.id, name: server.name, kind: server.kind, enabled: server.enabled,
+                transport: server.transport, url: server.url, command: server.command_line.presence,
+                description: server.description,
+                auth_type: server.auth_type.to_s, credential_scope: server.credential_scope.to_s,
+                # Keys only: a value here can be a bearer token or an API key, and a
+                # read tool has no business handing those back out (see MCPServerResource).
+                header_names: (server.headers || {}).keys, env_names: (server.env || {}).keys }
+                .merge(connector_provenance(server)).merge(tool_health(server)))
+    end
+
+    private
+
+    def connector_provenance(server)
+      return { from_connector: false } unless server.from_connector?
+
+      catalog = Connector.find_by(name: server.connector_name)
+      { from_connector: true, connector_name: server.connector_name,
+        connector_version: server.connector_version,
+        # An unpinned package install can resolve a different release at any session
+        # start — the one shape a rug pull can move under us, so it is stated.
+        connector_version_pinned: server.connector_version_pinned?,
+        # "deleted" means the registry pulled the entry (possible spam or malware);
+        # the install keeps working, so the warning has to travel with the read.
+        catalog_status: catalog&.status&.to_s,
+        catalog_version: catalog&.version,
+        update_available: update_available?(server, catalog) }
+    end
+
+    def update_available?(server, catalog)
+      return false if catalog.nil? || catalog.version.blank? || server.connector_version.blank?
+
+      catalog.version != server.connector_version
+    end
+
+    # stdio servers are never probed (that would mean running their package here),
+    # so a missing baseline is "not checked", never "verified clean".
+    def tool_health(server)
+      { tool_baseline_recorded: server.tool_baseline?, tool_drift: server.tool_drift.presence }
+    end
+  end
+end

--- a/app/services/personal_tools/get_registry_skill.rb
+++ b/app/services/personal_tools/get_registry_skill.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  # Reading a skill BEFORE installing it. `search_skill_registry` returns a
+  # one-line description, and `get_skill` only works once the skill is already in
+  # the project — so without this the only way to see what a third-party skill
+  # actually instructs an agent to do is to install it first.
+  class GetRegistrySkill < Base
+    tool do
+      display_name "Get Registry Skill"
+      description "Fetch a registry skill's full SKILL.md without installing it, so its instructions can " \
+                  "be reviewed first. Content can be thousands of tokens — narrow the choice with " \
+                  "search_skill_registry and read only the candidate you are deciding on."
+      audience :user
+      tags :resources
+      read_only
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :skill_id, type: :string, description: "Registry skill id (see search_skill_registry).",
+            required: true
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project, :index?, policy: Web::Company::Projects::SkillsPolicy, project: project)
+
+      skill_id = params[:skill_id].to_s
+      detail = SkillsRegistryService.fetch_skill_detail(skill_id)
+      # Names the publisher rather than shrugging: a two-segment id from a host
+      # that publishes no discovery index is a different problem from a typo.
+      return error(SkillsRegistryService.unresolved_message(skill_id)) if detail.blank?
+
+      success({ id: skill_id, source: detail["source"], slug: detail["slug"], name: detail["name"],
+                content: detail["content"] }.merge(catalog_metadata(skill_id)))
+    rescue SkillsRegistryService::RegistryError, SkillsRegistryService::ResolveTimeout => e
+      error("Registry fetch failed: #{e.message}")
+    end
+
+    private
+
+    # The mirrored catalog row carries what the fetched SKILL.md cannot: the
+    # audit verdict. A skill that reaches out to a third-party provider is a
+    # decision the caller should make with the finding in hand, not after.
+    def catalog_metadata(skill_id)
+      entry = CatalogSkill.find_by(registry_id: skill_id)
+      return { catalog_entry: false } if entry.nil?
+
+      { catalog_entry: true, description: entry.description, source_url: entry.registry_url,
+        audited: entry.audited?, audit_warning: entry.audit_warning?,
+        audit_providers: entry.audit_providers }
+    end
+  end
+end

--- a/app/services/personal_tools/install_connector.rb
+++ b/app/services/personal_tools/install_connector.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  # The catalog install path, as the web Connectors controller performs it.
+  # A connector is not a resource of its own — it is a pre-described way to
+  # create an MCPServer — so this returns the server it created.
+  class InstallConnector < Base
+    tool do
+      display_name "Install Connector"
+      description "Install an MCP connector from the catalog into a project as an MCP server. " \
+                  "Read the entry with get_connector first: target_id picks which install option to use, " \
+                  "and values answers the inputs that target declares."
+      audience :user
+      tags :resources
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :connector_name, type: :string, description: "Registry name (see search_connector_catalog).",
+            required: true
+      param :target_id, type: :string,
+            description: "Install target id from get_connector. Omit to use the connector's only " \
+                         "supported target; required when it offers several.",
+            required: false
+      param :values, type: :object,
+            description: "Answers to the target's declared inputs, keyed by the input's `key` verbatim " \
+                         "(header names and env vars are case- and punctuation-sensitive)."
+    end
+
+    # Raised when the caller named no target and the manifest does not settle it
+    # on its own — the message names what to do instead.
+    class TargetSelectionError < StandardError; end
+
+    def execute
+      project = find_project!
+      authorize!(project, :create?, policy: Web::Company::Projects::MCPServersPolicy, project: project)
+
+      connector = Connector.find_by(name: params[:connector_name].to_s)
+      return error("Connector '#{params[:connector_name]}' is not in the catalog") unless connector
+
+      install(connector, params[:target_id].presence || sole_target_id!(connector), project)
+    rescue TargetSelectionError => e
+      error(e.message)
+    rescue MCP::ConnectorInstaller::Error => e
+      error("Install failed: #{e.message}")
+    rescue ActiveRecord::RecordInvalid => e
+      error("Install failed: #{e.record.errors.full_messages.join(', ')}")
+    end
+
+    private
+
+    def install(connector, target_id, project)
+      result = MCP::ConnectorInstaller.call(
+        connector: connector, target_id: target_id, values: string_values, project: project
+      )
+      server = result.server
+
+      success(id: server.id, name: server.name, transport: server.transport,
+              connector_name: server.connector_name, connector_version: server.connector_version,
+              # The registry was unreachable, so the install was built from the
+              # mirrored manifest, which can be up to an hour stale.
+              installed_from_mirror: result.stale,
+              # Detected, not guessed: the server answered 401. An installed but
+              # unauthenticated connector looks identical to a working one until an
+              # agent tries to use it, so say it plainly and name the next action.
+              needs_auth: result.needs_auth,
+              next_step: result.needs_auth ? "Sign in to this server from the project's MCP servers page — " \
+                                             "OAuth needs a browser and cannot be completed over MCP." : nil)
+    end
+
+    # Unsupported targets travel with a reason, so an agent that picked nothing
+    # gets told why rather than "not found".
+    def sole_target_id!(connector)
+      targets = Array(connector.manifest["targets"])
+      supported = targets.select { |t| t["supported"] == true }
+      return supported.first["id"] if supported.one?
+
+      raise TargetSelectionError, unsupported_message(targets) if supported.empty?
+
+      raise TargetSelectionError,
+            "This connector offers #{supported.size} install targets — pass target_id " \
+            "(#{supported.map { |t| t['id'] }.join(', ')}); see get_connector."
+    end
+
+    def unsupported_message(targets)
+      reasons = targets.filter_map { |t| t["unsupported_reason"] }.uniq
+      return "This connector has no installable target" if reasons.empty?
+
+      "This connector cannot be installed: #{reasons.join('; ')}"
+    end
+
+    # Inputs are wired into headers, env vars and argv, all of which are strings.
+    # Coerce here so a JSON number or boolean does not reach the manifest layer
+    # as a non-string and fail to match its declared input.
+    def string_values
+      (params[:values] || {}).each_with_object({}) do |(key, value), memo|
+        next if value.nil? || value.is_a?(Hash)
+
+        memo[key.to_s] = value.is_a?(Array) ? value.map(&:to_s) : value.to_s
+      end
+    end
+  end
+end

--- a/app/services/personal_tools/search_connector_catalog.rb
+++ b/app/services/personal_tools/search_connector_catalog.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  # The MCP connector catalog, as the MCP servers page browses it. Two different
+  # jobs, so two different scopes — same split as the web controller:
+  # search goes over the whole mirror (the upstream registry API can only match
+  # server-name substrings, so "issue tracker" finds nothing there), while the
+  # default view is the curated set, because the open registry is mostly long tail.
+  class SearchConnectorCatalog < Base
+    tool do
+      display_name "Search Connector Catalog"
+      description "Search the public MCP connector catalog, or omit the query to browse the curated set. " \
+                  "Returns catalog entries, not installs — read one with get_connector, then " \
+                  "install_connector. Everything outside the curated set is reachable by search only."
+      audience :user
+      tags :resources
+      read_only
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :query, type: :string, description: "Search query. Omit to browse the curated set."
+    end
+
+    LIMIT = 30
+
+    def execute
+      project = find_project!
+      authorize!(project, :index?, policy: Web::Company::Projects::MCPServersPolicy, project: project)
+
+      query = params[:query].to_s.strip
+      success(query: query.presence, results: rows(query))
+    end
+
+    private
+
+    def rows(query)
+      entries(query).map do |connector|
+        { name: connector.name, title: connector.picker_name,
+          description: connector.description&.truncate(200),
+          version: connector.version, status: connector.status.to_s,
+          # The registry verified this publisher owns the domain, rather than
+          # merely holding a GitHub account — the one provenance signal the
+          # catalog actually has.
+          vendor_published: connector.vendor_published?,
+          installable: connector.installable? }
+      end
+    end
+
+    def entries(query)
+      scope = Connector.discoverable
+      return scope.search(query).limit(LIMIT) if query.present?
+
+      scope.where(featured: true).popular.limit(LIMIT)
+    end
+  end
+end

--- a/app/services/personal_tools/search_skill_registry.rb
+++ b/app/services/personal_tools/search_skill_registry.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
 module PersonalTools
+  # The skills catalog, through the same service the skills page uses
+  # (Skills::CatalogSearch): browse the ranked mirror with no query, go upstream
+  # with one. Agents get what the UI gets — including the audit verdicts, which
+  # only exist on mirrored rows and were previously dropped on the search path.
   class SearchSkillRegistry < Base
     tool do
       display_name "Search Skill Registry"
-      description "Search the public skill registry, or omit the query to browse the ranked catalog."
+      description "Search the public skill registry, or omit the query to browse the ranked catalog. " \
+                  "Results carry each entry's audit verdict where one exists — read the candidate with " \
+                  "get_registry_skill before installing it."
       audience :user
       tags :resources
       read_only
@@ -12,41 +18,21 @@ module PersonalTools
       param :query, type: :string, description: "Search query. Omit to browse the default catalog view."
     end
 
-    BROWSE_LIMIT = 30
+    LIMIT = 30
 
     def execute
       project = find_project!
       authorize!(project, :index?, policy: Web::Company::Projects::SkillsPolicy, project: project)
 
-      query = params[:query].to_s.strip
       # No query is a real request, not a mistake: browsing the ranked default view is
       # the headline capability the catalog adds, and an agent must be able to reach
-      # what the UI reaches.
-      return success(query: nil, results: browse) if query.blank?
-
-      results = Array(SkillsRegistryService.search(query)).first(50)
-      success(query: query, results: results)
+      # what the UI reaches. A query too short for the upstream endpoint browses too,
+      # rather than coming back empty.
+      search = ::Skills::CatalogSearch.new(params[:query], limit: LIMIT)
+      success(query: (params[:query].to_s.strip.presence if search.reaches_upstream?),
+              results: search.call.map { |entry| CatalogSkillResource.new(entry, params: { snake_keys: true }).to_h })
     rescue StandardError => e
       error("Registry search failed: #{e.message}")
-    end
-
-    private
-
-    # Same ordering and per-publisher dedup the browse UI gets, so an agent is not
-    # handed twenty near-identical skills from one collection repo.
-    def browse
-      CatalogSkill.one_per_source.popular.limit(BROWSE_LIMIT).map do |entry|
-        {
-          id: entry.registry_id,
-          slug: entry.slug,
-          name: entry.picker_name,
-          source: entry.source,
-          installs: entry.installs,
-          description: entry.description,
-          featured: entry.featured,
-          audit_risk: entry.audit_risk
-        }
-      end
     end
   end
 end

--- a/app/services/skills/catalog_search.rb
+++ b/app/services/skills/catalog_search.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module Skills
+  # Browsing and searching the skills catalog, for every surface that offers it
+  # (the skills page and the personal-MCP `search_skill_registry` tool).
+  #
+  # Blank (or too-short) query → the default browse view, served from the mirror.
+  # A real query → upstream, because skills.sh's fuzzy search beats anything the
+  # mirror can do and the mirror is incomplete by construction.
+  #
+  # NOTHING IS PERSISTED HERE. Both callers authorize as a project READ, so a
+  # viewer who is denied `create?` must not be able to write rows into a table
+  # shared by every tenant, or trigger an outbound request per keystroke, just by
+  # loading a URL or calling a read-only tool. Upstream hits are returned as
+  # UNSAVED records; the weekly sweep owns the mirror.
+  class CatalogSearch
+    # Comfortably above the curated seed so the default view is never a truncated
+    # version of it.
+    PAGE_SIZE = 60
+    # Upstream is rate-limited per IP with no published number, and every debounced
+    # keystroke from every member arrives here. Short-lived caching keeps a room full
+    # of people typing from spending the whole deployment's budget on the same queries.
+    CACHE_TTL = 5.minutes
+
+    def self.call(...) = new(...).call
+
+    def initialize(query, limit: PAGE_SIZE)
+      @query = query.to_s.strip
+      @limit = limit
+    end
+
+    # @return [Array<CatalogSkill>] mirrored rows, plus unsaved rows for upstream
+    #   hits that are not mirrored yet
+    def call
+      return default_entries unless reaches_upstream?
+
+      entries = cached_search
+      # Upstream unreachable, or nothing matched: fall back to full-text over
+      # whatever is mirrored rather than returning an empty catalog.
+      return CatalogSkill.search(@query).limit(@limit).to_a if entries.empty?
+
+      merge_with_mirror(entries)
+    end
+
+    # Whether this query is long enough for the upstream endpoint to accept it.
+    def reaches_upstream?
+      @query.length >= RegistryClient::MIN_QUERY_LENGTH
+    end
+
+    private
+
+    def default_entries
+      CatalogSkill.one_per_source.popular.limit(@limit).to_a
+    end
+
+    # Recording happens inside the cache-miss block on purpose: a debounced field
+    # would otherwise write once per keystroke, and with the cache a term is
+    # recorded at most once per window no matter how many people are typing it.
+    # The term steers a later sweep and is stored unattributed — see CatalogSearchQuery.
+    def cached_search
+      Rails.cache.fetch([ "skills-catalog-search", @query ], expires_in: CACHE_TTL) do
+        CatalogSearchQuery.record(@query)
+        RegistryClient.search(@query, limit: @limit)
+      end
+    end
+
+    # Upstream relevance order is preserved: the endpoint ranks by fuzzy match, and
+    # re-sorting by popularity would push the exact-name hit below a tangential match
+    # with more installs. Mirrored rows are reused where they exist so a result keeps
+    # its description and audit verdicts; anything unmirrored renders from the search
+    # payload alone.
+    def merge_with_mirror(entries)
+      mirrored = CatalogSkill.where(registry_id: entries.map(&:id).compact).index_by(&:registry_id)
+
+      entries.map { |entry| mirrored[entry.id] || transient(entry) }
+    end
+
+    def transient(entry)
+      source, slug = split_registry_id(entry)
+
+      CatalogSkill.new(
+        registry_id: entry.id.presence || "#{source}/#{slug}",
+        source: source,
+        slug: slug,
+        title: (entry.name if entry.name.present? && entry.name != slug),
+        installs: entry.installs.to_i
+      )
+    end
+
+    def split_registry_id(entry)
+      parts = entry.id.to_s.split("/").reject(&:blank?)
+      return [ entry.source, entry.slug ] if parts.size < 2
+
+      [ parts[0..-2].join("/"), parts.last ]
+    end
+  end
+end

--- a/app/services/skills_registry_service.rb
+++ b/app/services/skills_registry_service.rb
@@ -271,8 +271,11 @@ class SkillsRegistryService
     http.request(request)
   end
 
+  # `unresolved_message` stays public: `install` is no longer the only caller that
+  # has to explain an id that resolved to nothing (see PersonalTools::GetRegistrySkill),
+  # and two callers inventing their own wording is how "not found" starts hiding
+  # "that publisher has no index".
   private_class_method :time_left?, :parse_skill_id, :github_source?,
                        :fetch_skill_md_from_github, :fetch_raw_skill_md,
-                       :list_github_skill_directories, :source_url_for, :http_get,
-                       :unresolved_message
+                       :list_github_skill_directories, :source_url_for, :http_get
 end

--- a/app/services/tools/personal_mcp_request_handler.rb
+++ b/app/services/tools/personal_mcp_request_handler.rb
@@ -131,8 +131,15 @@ module Tools
            `update_workflow` renames it and sets the base resources.
            `duplicate_workflow` copies an existing one, into this project or another.
         4. Inspect what you can wire in: `list_project_tools`, `list_skills`,
-           `list_mcp_servers`, `list_agents`. `get_agent` and `get_skill` return the
-           full persona / skill content when the list entry isn't enough to decide.
+           `list_mcp_servers`, `list_agents`. `get_agent`, `get_skill` and
+           `get_mcp_server` return the full persona / skill content / server wiring
+           when the list entry isn't enough to decide. Nothing suitable in the
+           project yet? Add it from the public catalogs first:
+           `search_connector_catalog` → `get_connector` → `install_connector` for
+           MCP servers, `search_skill_registry` → `get_registry_skill` →
+           `install_skill` for skills. Read the entry before installing — a
+           connector's install target decides what runs, and a skill's SKILL.md is
+           prompt text your agents will follow.
         5. For each step: `create_workflow_step` takes the wiring in one call —
            name, instructions, agent_id, position, plus `tool_ids`, `skill_ids`,
            `mcp_server_ids`, `depends_on_step_ids`, `bmad_enabled` and

--- a/test/integration/personal_mcp_resource_crud_test.rb
+++ b/test/integration/personal_mcp_resource_crud_test.rb
@@ -70,6 +70,160 @@ class PersonalMCPResourceCrudTest < ActionDispatch::IntegrationTest
     assert_not MCPServer.exists?(id)
   end
 
+  test "get_mcp_server returns the wiring but never a header or env VALUE" do
+    server = create(:mcp_server, scope: @project, name: "ctx7", url: "https://x/mcp", transport: :http,
+                                 headers: { "Authorization" => "Bearer super-secret" },
+                                 env: { "API_KEY" => "sk-live-1" })
+
+    body = payload(call_tool("get_mcp_server", { project_id: @project.id, mcp_server_id: server.id }))
+
+    assert_equal "https://x/mcp", body["url"]
+    assert_equal [ "Authorization" ], body["header_names"]
+    assert_equal [ "API_KEY" ], body["env_names"]
+    assert_not_includes body.to_json, "super-secret"
+    assert_not_includes body.to_json, "sk-live-1"
+    assert_not body["from_connector"]
+  end
+
+  test "get_mcp_server reports catalog provenance and an available update" do
+    connector = create(:connector, version: "2.0.0")
+    server = create(:mcp_server, scope: @project, connector_name: connector.name, connector_version: "1.0.0")
+
+    body = payload(call_tool("get_mcp_server", { project_id: @project.id, mcp_server_id: server.id }))
+
+    assert body["from_connector"]
+    assert_equal "1.0.0", body["connector_version"]
+    assert_equal "2.0.0", body["catalog_version"]
+    assert body["update_available"]
+    assert_equal "active", body["catalog_status"]
+    # Never probed here, so it must not come back claiming a verified baseline.
+    assert_not body["tool_baseline_recorded"]
+  end
+
+  test "get_mcp_server refuses a server from another project" do
+    other = create(:project, company: @company, owner: @user)
+    foreign = create(:mcp_server, scope: other)
+
+    body = call_tool("get_mcp_server", { project_id: @project.id, mcp_server_id: foreign.id })
+    assert error?(body)
+    assert_match(/not found/i, text(body))
+  end
+
+  test "search_connector_catalog browses the curated set and searches the whole mirror" do
+    create(:connector, name: "com.acme/tracker", title: "Acme Tracker", featured: true)
+    create(:connector, name: "io.github.someone/obscure", title: "Obscure Notes", featured: false)
+    create(:connector, :deleted, name: "com.spam/pulled", title: "Pulled Entry", featured: true)
+
+    browsed = payload(call_tool("search_connector_catalog", { project_id: @project.id }))
+    names = browsed["results"].map { |r| r["name"] }
+    assert_nil browsed["query"]
+    assert_includes names, "com.acme/tracker"
+    # Curated-only browse, and a registry-pulled entry is never discoverable.
+    assert_not_includes names, "io.github.someone/obscure"
+    assert_not_includes names, "com.spam/pulled"
+
+    found = payload(call_tool("search_connector_catalog", { project_id: @project.id, query: "obscure" }))
+    assert_equal [ "io.github.someone/obscure" ], found["results"].map { |r| r["name"] }
+    assert found["results"].first["installable"]
+  end
+
+  test "get_connector returns install targets with their inputs and existing installs" do
+    connector = create(:connector, name: "com.acme/tracker")
+    connector.update!(manifest: connector.manifest.deep_merge(
+      "targets" => [ connector.manifest["targets"].first.merge(
+        "id" => "remote-http", "inputs" => [ { "key" => "X-Api-Key", "kind" => "header", "required" => true,
+                                               "secret" => true } ]
+      ) ]
+    ))
+    create(:mcp_server, scope: @project, name: "Tracker", connector_name: connector.name)
+
+    body = payload(call_tool("get_connector", { project_id: @project.id, connector_name: connector.name }))
+
+    target = body["targets"].first
+    assert_equal "remote-http", target["id"]
+    assert_equal "X-Api-Key", target["inputs"].first["key"]
+    assert target["inputs"].first["required"]
+    assert_equal [ "Tracker" ], body["already_installed"]
+
+    missing = call_tool("get_connector", { project_id: @project.id, connector_name: "com.nope/nothing" })
+    assert error?(missing)
+    assert_match(/not in the catalog/i, text(missing))
+  end
+
+  test "install_connector installs the sole supported target as an MCP server" do
+    connector = create(:connector, :package, name: "com.acme/cli")
+    target = connector.manifest["targets"].first.merge("id" => "package-stdio")
+    connector.update!(manifest: connector.manifest.merge("targets" => [ target ]))
+    # Stub the registry ADAPTER, not the installer under test: the manifest is
+    # re-fetched at install time and this is the seam that call reaches the network through.
+    MCP::ConnectorRegistryClient.stubs(:fetch).returns(connector.manifest)
+
+    body = payload(call_tool("install_connector", { project_id: @project.id, connector_name: connector.name }))
+
+    server = MCPServer.find(body["id"])
+    assert_equal "stdio", server.transport.to_s
+    assert_equal connector.name, server.connector_name
+    assert_not body["installed_from_mirror"]
+  end
+
+  test "install_connector names the choice when a connector offers several targets" do
+    connector = create(:connector, name: "com.acme/both")
+    connector.update!(manifest: connector.manifest.merge(
+      "targets" => [
+        connector.manifest["targets"].first.merge("id" => "remote-http"),
+        { "kind" => "package", "transport" => "stdio", "id" => "package-stdio", "supported" => true,
+          "inputs" => [] }
+      ]
+    ))
+
+    body = call_tool("install_connector", { project_id: @project.id, connector_name: connector.name })
+    assert error?(body)
+    assert_match(/remote-http/, text(body))
+    assert_match(/package-stdio/, text(body))
+  end
+
+  test "install_connector explains why an uninstallable connector cannot be installed" do
+    connector = create(:connector, :uninstallable, name: "com.acme/mcpb")
+
+    body = call_tool("install_connector", { project_id: @project.id, connector_name: connector.name })
+    assert error?(body)
+    assert_match(/no known runtime for mcpb/i, text(body))
+  end
+
+  test "get_registry_skill returns the SKILL.md plus the catalog audit verdict" do
+    entry = create(:catalog_skill, source: "test-org/skills", slug: "fmt",
+                                   audit_risk: "high", audit: { "socket" => { "risk" => "high", "score" => 0.2 } })
+    SkillsRegistryService.stubs(:fetch_skill_detail)
+                         .returns({ "source" => "test-org/skills", "slug" => "fmt", "name" => "fmt",
+                                    "content" => "---\nname: fmt\n---\nFormat things" })
+
+    body = payload(call_tool("get_registry_skill", { project_id: @project.id, skill_id: entry.registry_id }))
+
+    assert_includes body["content"], "Format things"
+    assert body["catalog_entry"]
+    assert body["audited"]
+    assert body["audit_warning"]
+    assert_equal "socket", body["audit_providers"].first["provider"]
+    # Reading a registry skill must not install it.
+    assert_empty Skill.visible_for_project(@project).where(name: "fmt")
+  end
+
+  test "get_registry_skill reports an id the registry cannot resolve" do
+    SkillsRegistryService.stubs(:fetch_skill_detail).returns(nil)
+
+    body = call_tool("get_registry_skill", { project_id: @project.id, skill_id: "test-org/skills/ghost" })
+    assert error?(body)
+    assert_match(/skill not found: test-org\/skills\/ghost/i, text(body))
+  end
+
+  test "get_registry_skill names the publisher when a host has no skill index" do
+    SkillsRegistryService.stubs(:fetch_skill_detail).returns(nil)
+
+    body = call_tool("get_registry_skill", { project_id: @project.id, skill_id: "example.com/ghost" })
+    assert error?(body)
+    assert_match(/example\.com does not publish an installable skill index/i, text(body))
+  end
+
   test "skill search / install / uninstall" do
     SkillsRegistryService.stubs(:search).returns([ { "id" => "s1", "name" => "fmt" } ])
     results = payload(call_tool("search_skill_registry", { project_id: @project.id, query: "fmt" }))["results"]

--- a/test/integration/personal_mcp_resource_crud_test.rb
+++ b/test/integration/personal_mcp_resource_crud_test.rb
@@ -190,6 +190,34 @@ class PersonalMCPResourceCrudTest < ActionDispatch::IntegrationTest
     assert_match(/no known runtime for mcpb/i, text(body))
   end
 
+  test "search_skill_registry carries the audit verdict a mirrored entry has" do
+    create(:catalog_skill, registry_id: "org/skills/risky", source: "org/skills", slug: "risky",
+                           description: "Mirrored description", audit_risk: "high",
+                           audit: { "socket" => { "risk" => "high" } })
+    Skills::RegistryClient.stubs(:search)
+                          .returns([ Skills::RegistryClient::Entry.new(id: "org/skills/risky", slug: "risky",
+                                                                       name: "risky", source: "org/skills",
+                                                                       installs: 12) ])
+
+    body = payload(call_tool("search_skill_registry", { project_id: @project.id, query: "risky" }))
+
+    entry = body["results"].sole
+    assert_equal "risky", body["query"]
+    assert_equal "Mirrored description", entry["description"]
+    assert_equal "high", entry["audit_risk"]
+    assert_equal "socket", entry["audit_providers"].first["provider"]
+  end
+
+  test "search_skill_registry browses when the query is too short to reach upstream" do
+    create(:catalog_skill, registry_id: "org/skills/fmt", source: "org/skills", slug: "fmt")
+    Skills::RegistryClient.expects(:search).never
+
+    body = payload(call_tool("search_skill_registry", { project_id: @project.id, query: "a" }))
+
+    assert_nil body["query"]
+    assert_equal "org/skills/fmt", body["results"].sole["registry_id"]
+  end
+
   test "get_registry_skill returns the SKILL.md plus the catalog audit verdict" do
     entry = create(:catalog_skill, source: "test-org/skills", slug: "fmt",
                                    audit_risk: "high", audit: { "socket" => { "risk" => "high", "score" => 0.2 } })
@@ -225,9 +253,12 @@ class PersonalMCPResourceCrudTest < ActionDispatch::IntegrationTest
   end
 
   test "skill search / install / uninstall" do
-    SkillsRegistryService.stubs(:search).returns([ { "id" => "s1", "name" => "fmt" } ])
+    Skills::RegistryClient.stubs(:search)
+                          .returns([ Skills::RegistryClient::Entry.new(id: "test-org/skills/fmt", slug: "fmt",
+                                                                       name: "fmt", source: "test-org/skills",
+                                                                       installs: 3) ])
     results = payload(call_tool("search_skill_registry", { project_id: @project.id, query: "fmt" }))["results"]
-    assert_equal "s1", results.first["id"]
+    assert_equal "test-org/skills/fmt", results.first["registry_id"]
 
     skill = create(:skill, scope: @project)
     SkillsRegistryService.stubs(:install).returns(skill)

--- a/test/services/personal_tools/search_skill_registry_test.rb
+++ b/test/services/personal_tools/search_skill_registry_test.rb
@@ -28,7 +28,9 @@ module PersonalTools
       assert_equal 0, result[:exit_code]
       payload = JSON.parse(result[:stdout])
       assert_nil payload["query"]
-      assert_equal "anthropics/skills/pdf", payload["results"].sole["id"]
+      # Identity travels as the registry id: a live upstream hit has no mirror row
+      # behind it, so a database id would be null exactly when the entry is newest.
+      assert_equal "anthropics/skills/pdf", payload["results"].sole["registry_id"]
       assert_equal "Fill PDF forms", payload["results"].sole["description"]
     end
 
@@ -48,13 +50,15 @@ module PersonalTools
     end
 
     test "a query searches upstream" do
-      SkillsRegistryService.stubs(:search).returns([ { id: "org/skills/rails", slug: "rails", name: "rails",
-                                                       source: "org/skills", installs: 42 } ])
+      Skills::RegistryClient.stubs(:search)
+                            .returns([ Skills::RegistryClient::Entry.new(id: "org/skills/rails", slug: "rails",
+                                                                         name: "rails", source: "org/skills",
+                                                                         installs: 42) ])
 
       payload = JSON.parse(execute(query: "rails")[:stdout])
 
       assert_equal "rails", payload["query"]
-      assert_equal "org/skills/rails", payload["results"].sole["id"]
+      assert_equal "org/skills/rails", payload["results"].sole["registry_id"]
     end
   end
 end

--- a/test/services/skills/catalog_search_test.rb
+++ b/test/services/skills/catalog_search_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Skills
+  # The one place both catalog surfaces (skills page, personal-MCP search tool) get
+  # their entries from, so the rules live here rather than in each caller: what
+  # reaches upstream, what falls back to the mirror, and what must never be written.
+  class CatalogSearchTest < ActiveSupport::TestCase
+    test "a query too short for the upstream endpoint browses the mirror instead" do
+      create(:catalog_skill, registry_id: "org/skills/fmt", source: "org/skills", slug: "fmt")
+      RegistryClient.expects(:search).never
+
+      entries = CatalogSearch.call("a")
+
+      assert_equal [ "org/skills/fmt" ], entries.map(&:registry_id)
+      assert_not CatalogSearch.new("a").reaches_upstream?
+    end
+
+    test "the default view shows one entry per publisher" do
+      create(:catalog_skill, source: "org/collection", slug: "one", installs: 5)
+      create(:catalog_skill, source: "org/collection", slug: "two", installs: 4)
+      create(:catalog_skill, source: "other/repo", slug: "solo", installs: 1)
+
+      sources = CatalogSearch.call("").map(&:source)
+
+      assert_equal sources, sources.uniq
+      assert_includes sources, "org/collection"
+      assert_includes sources, "other/repo"
+    end
+
+    test "upstream hits keep upstream order and reuse mirrored rows without persisting" do
+      create(:catalog_skill, registry_id: "org/skills/mirrored", source: "org/skills", slug: "mirrored",
+                             description: "Already mirrored", audit_risk: "low")
+      RegistryClient.stubs(:search).returns([
+                                              entry("org/skills/exact", "exact", installs: 10),
+                                              entry("org/skills/mirrored", "mirrored", installs: 900_000)
+                                            ])
+
+      entries = assert_no_difference -> { CatalogSkill.count } do
+        CatalogSearch.call("exact")
+      end
+
+      assert_equal %w[org/skills/exact org/skills/mirrored], entries.map(&:registry_id)
+      # The mirrored row carries what the search payload cannot: description and verdict.
+      assert_equal "Already mirrored", entries.last.description
+      assert_equal "low", entries.last.audit_risk
+      # The unmirrored hit is returned unsaved — a read must not write to a table
+      # shared by every tenant.
+      assert entries.first.new_record?
+    end
+
+    test "an id with no slash falls back to the entry's own source and slug" do
+      RegistryClient.stubs(:search).returns([
+                                              RegistryClient::Entry.new(id: "flat", slug: "flat", name: "Flat",
+                                                                        source: "org/skills", installs: 0)
+                                            ])
+
+      transient = CatalogSearch.call("flat").sole
+
+      assert_equal "org/skills", transient.source
+      assert_equal "flat", transient.slug
+    end
+
+    test "an empty upstream answer falls back to full-text over the mirror" do
+      create(:catalog_skill, registry_id: "org/skills/playwright-helper", source: "org/skills",
+                             slug: "playwright-helper", description: "Drives playwright")
+      RegistryClient.stubs(:search).returns([])
+
+      entries = CatalogSearch.call("playwright")
+
+      assert_equal [ "org/skills/playwright-helper" ], entries.map(&:registry_id)
+    end
+
+    test "a term that reached upstream is recorded, and a too-short one is not" do
+      RegistryClient.stubs(:search).returns([])
+
+      assert_difference -> { CatalogSearchQuery.count }, 1 do
+        CatalogSearch.call("playwright")
+      end
+      assert_equal "playwright", CatalogSearchQuery.sole.term
+
+      assert_no_difference -> { CatalogSearchQuery.count } do
+        CatalogSearch.call("a")
+        CatalogSearch.call("")
+      end
+    end
+
+    private
+
+    def entry(id, slug, installs:)
+      RegistryClient::Entry.new(id: id, slug: slug, name: slug, source: id.split("/")[0..-2].join("/"),
+                                installs: installs)
+    end
+  end
+end


### PR DESCRIPTION
## Why

Over personal MCP an agent could only wire up MCP servers and skills that were **already** in the project, or hand-write a server from scratch with `create_mcp_server`. The catalogs the UI browses were unreachable: no connector search, no way to read an entry before installing it, no install path at all. Skills were half-covered — `search_skill_registry` and `install_skill` existed, but nothing could read a skill's actual instructions before installing it.

## What

| Tool | Does |
|---|---|
| `search_connector_catalog` | Curated browse with no query, full-mirror search with one — the same split as the MCP servers page, because the upstream registry API only matches name substrings |
| `get_connector` | One catalog entry: every install target (remote endpoint or package, with the exact launch command) and the inputs it declares, plus which servers in this project already came from it |
| `install_connector` | Installs a target as an MCP server via `MCP::ConnectorInstaller` |
| `get_mcp_server` | One configured server in full: transport/endpoint, connector provenance and version, tool-baseline drift, auth state |
| `get_registry_skill` | A registry skill's full SKILL.md **without installing it**, plus the mirrored catalog's audit verdict |

Serialization for `get_connector` goes through `ConnectorResource` (with `snake_keys: true`), so the manifest dialect stays understood in exactly one place instead of being re-read here and drifting from the UI's reading.

## Deliberate refusals

- **`get_mcp_server` returns header/env KEYS only, never values.** A value there can be a bearer token or an API key; `MCPServerResource` masks them for the browser and a read tool has no better claim to them.
- **`get_registry_skill` installs nothing.** A third-party SKILL.md is prompt text your agents will follow — being able to read it *before* it runs is the whole point of the tool.
- **`install_connector` doesn't reimplement installing.** It calls `MCP::ConnectorInstaller`, so an MCP install behaves like the web one: manifest re-fetched at install time, mirrored-manifest fallback reported as `installed_from_mirror`, and the 401-detected `needs_auth` signal with a next step (OAuth needs a browser, so it names the UI).
- Ambiguity is an error, not a guess: with several supported targets the tool names the ids instead of picking one, and an uninstallable connector comes back with the registry's own reason.

## Incidental change

`SkillsRegistryService.unresolved_message` is no longer private. `install` used to be its only caller; now the read tool must explain an unresolvable id too, and two callers inventing their own wording is how "not found" starts hiding "that publisher publishes no skill index".

## Tests

`personal_mcp_resource_crud_test.rb` — secret values withheld from `get_mcp_server`, provenance + update-available, cross-project refusal, curated-vs-search scoping (incl. a registry-pulled entry staying undiscoverable), targets/inputs/already-installed, install of a sole target, the multi-target and uninstallable errors, registry skill read with audit verdict, and both unresolvable-id messages. Registry access is stubbed at `MCP::ConnectorRegistryClient` / `SkillsRegistryService` — the app-owned adapters — so the installer under test still runs for real.

`make check_all` green on this branch (backend 90.8%, frontend 78.31%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)