### PR TITLE
fix(workflows): offer company assets in the workflow asset pickers

### DIFF
--- a/app/controllers/web/company/projects/workflows_controller.rb
+++ b/app/controllers/web/company/projects/workflows_controller.rb
@@ -13,8 +13,12 @@ class Web::Company::Projects::WorkflowsController < Web::Company::Projects::Appl
         )
       },
       configured_agents: current_project_membership&.configured_agents || [],
+      # Company-scoped assets are shared with every project in the company and are
+      # already offered by the assets page, the session form and the Aixle Builder.
+      # `current_project.assets` walks the has_many and sees project-owned rows only,
+      # so the workflow builder was the one picker that could not reach them.
       assets: InertiaRails.defer(group: "resources") {
-        current_project.assets.active.map { |r| PickerResource.new(r).to_h }
+        Asset.accessible_from_project(current_project).map { |r| PickerResource.new(r).to_h }
       },
       repositories: InertiaRails.defer(group: "resources") {
         Repository.visible_for_project(current_project).map { |r| PickerResource.new(r).to_h }
@@ -56,8 +60,12 @@ class Web::Company::Projects::WorkflowsController < Web::Company::Projects::Appl
       mcp_servers: InertiaRails.defer(group: "resources") {
         MCPServer.visible_for_project(current_project).map { |r| PickerResource.new(r).to_h }
       },
+      # Company-scoped assets are shared with every project in the company and are
+      # already offered by the assets page, the session form and the Aixle Builder.
+      # `current_project.assets` walks the has_many and sees project-owned rows only,
+      # so the workflow builder was the one picker that could not reach them.
       assets: InertiaRails.defer(group: "resources") {
-        current_project.assets.active.map { |r| PickerResource.new(r).to_h }
+        Asset.accessible_from_project(current_project).map { |r| PickerResource.new(r).to_h }
       },
       repositories: InertiaRails.defer(group: "resources") {
         Repository.visible_for_project(current_project).map { |r| PickerResource.new(r).to_h }

--- a/test/integration/web/company/projects/workflows_controller_test.rb
+++ b/test/integration/web/company/projects/workflows_controller_test.rb
@@ -24,6 +24,46 @@ class Web::Company::Projects::WorkflowsControllerTest < ActionDispatch::Integrat
     assert_inertia_page "Projects/Workflows/BuilderPage"
   end
 
+  # The picker is the only way to put an asset on a workflow step, so a company
+  # asset missing here is invisible even though every other surface offers it and
+  # the step would happily mount it.
+  test "builder offers company assets alongside the project's own" do
+    wf = create(:workflow, scope: @project)
+    project_asset = create(:asset, scope: @project)
+    company_asset = create(:asset, scope: @company)
+
+    names = deferred_prop(builder_company_project_workflow_path(@project, wf),
+                          component: "Projects/Workflows/BuilderPage", key: "assets")
+             .map { |a| a["name"] }
+
+    assert_includes names, project_asset.name
+    assert_includes names, company_asset.name
+  end
+
+  test "index offers company assets alongside the project's own" do
+    project_asset = create(:asset, scope: @project)
+    company_asset = create(:asset, scope: @company)
+
+    names = deferred_prop(company_project_workflows_path(@project),
+                          component: "Projects/Workflows/WorkflowsPage", key: "assets")
+             .map { |a| a["name"] }
+
+    assert_includes names, project_asset.name
+    assert_includes names, company_asset.name
+  end
+
+  test "builder does not offer assets from another company" do
+    wf = create(:workflow, scope: @project)
+    other_company = create(:company)
+    outsider = create(:asset, scope: other_company)
+
+    names = deferred_prop(builder_company_project_workflow_path(@project, wf),
+                          component: "Projects/Workflows/BuilderPage", key: "assets")
+             .map { |a| a["name"] }
+
+    assert_not_includes names, outsider.name
+  end
+
   test "create redirects on success" do
     post company_project_workflows_path(@project), params: { workflow: { name: "Proj WF", description: "D" } }
     assert_response :redirect
@@ -55,5 +95,21 @@ class Web::Company::Projects::WorkflowsControllerTest < ActionDispatch::Integrat
     end
 
     assert_response :redirect
+  end
+
+  private
+
+  # Resource pickers are deferred props: the first render omits them and the client
+  # asks again for that group alone. Fetching one means replaying that second
+  # request, headers and all — a plain GET returns a page where the key is absent.
+  def deferred_prop(path, component:, key:)
+    get path, headers: {
+      "X-Inertia" => "true",
+      "X-Inertia-Partial-Component" => component,
+      "X-Inertia-Partial-Data" => key
+    }
+
+    assert_response :success
+    JSON.parse(response.body).dig("props", key)
   end
 end


### PR DESCRIPTION
## The bug

A company-scoped asset never appeared in the workflow builder's asset picker, so it could not be attached to a workflow step — even though every other surface offers it and the step would happily mount it.

Both actions read assets through the project's `has_many`, which by definition only sees project-owned rows:

```ruby
current_project.assets.active        # project rows only
```

Every other asset call site in the app already spans project + company: the assets page, the session form, the Aixle Builder, `share_asset`, `list_assets`, the assets API. So do the pickers sitting right next to this one in the same method — `Agent`, `Tool`, `Skill`, `MCPServer` and `Repository` all resolve through `visible_for_project`. Assets were the single call site reaching around the model.

```ruby
Asset.accessible_from_project(current_project)
```

## Why it stayed hidden

Nothing downstream objects to a company asset, which is what made this look like "the project has no assets" rather than a bug:

- `SessionService#scoped_resources` filters through `Asset.visible_for_project`, which **includes** company rows
- `WorkspacePreparator` mounts by id with no scope check

So the asset was mountable the whole time — it just could not be chosen. Setting it via the MCP server worked.

## Testing

Three integration tests, all through a real Inertia partial reload, since these are deferred props and a plain GET omits the key entirely:

- builder offers project **and** company assets
- index offers project **and** company assets
- builder does **not** offer another company's assets — a guard so the fix widens visibility to the company and no further

Verified they fail against the old scope (`Expected ["asset-1.md"] to include "asset-2.md"`) and pass with the new one. The third passes either way by design — it exists to catch over-broadening.

`make check_all` green: 4012 backend tests, eslint, tsc, vitest, rubocop, brakeman, system tests.

## Note for the reviewer

`Asset.accessible_from_project` and `Asset.visible_for_project` are defined separately but resolve to the same thing (active rows, project OR company). Worth collapsing one day; left alone here to keep this a one-line behavior fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
