### PR TITLE
fix(integrations): delete legacy company-wide GitHub integrations

### DIFF
--- a/db/migrate/20260808000001_remove_company_wide_github_integrations.rb
+++ b/db/migrate/20260808000001_remove_company_wide_github_integrations.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Company-wide GitHub integrations are legacy. Integrations kept Company scope
+# when RestrictResourceScopesToProject (20260724000001) pushed everything else
+# down to Project, but only because a Slack install genuinely serves the whole
+# company (Slack::IntegrationService builds it with project_id: nil). GitHub has
+# been connected per project since then — GithubSetupController treats a callback
+# without a project as a misroute.
+#
+# The rows that predate that change are still visible on EVERY project's
+# integrations page, because Integration.visible_for_project unions
+# `project_id IS NULL` with the project's own rows, and they cannot be removed
+# from the UI at all: IntegrationsController#destroy looks them up through
+# `for_project`, which a company-wide row never matches.
+#
+# This migration DELETES those integrations and the repositories attached to
+# them. The repositories go too: their clone credentials come from the
+# installation being deleted, so leaving them behind would leave rows that look
+# connected and fail on clone. Attached sessions lose their join rows through the
+# session_repositories cascade; stale ids left in steps.repository_ids /
+# workflows.config are resolved through a lookup and simply drop out.
+#
+# GitLab, Coder and Slack are untouched. The data deletion is irreversible.
+class RemoveCompanyWideGithubIntegrations < ActiveRecord::Migration[8.0]
+  def up
+    # repositories -> integrations is RESTRICT, so the children go first.
+    say_with_time "Removing repositories attached to company-wide GitHub integrations" do
+      execute(<<~SQL.squish)
+        DELETE FROM repositories
+        WHERE integration_id IN (
+          SELECT id FROM integrations WHERE project_id IS NULL AND provider = 'github'
+        )
+      SQL
+    end
+
+    # integration_data cascades at the DB.
+    say_with_time "Removing company-wide GitHub integrations" do
+      execute("DELETE FROM integrations WHERE project_id IS NULL AND provider = 'github'")
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_07_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_08_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"


### PR DESCRIPTION
## What

Data migration `20260808000001` deletes company-wide GitHub integrations (`project_id IS NULL AND provider = 'github'`) and the repositories attached to them.

## Why

`RestrictResourceScopesToProject` (`20260724000001`) pushed MCP servers, skills, agents, tools, config items, workflows and repositories down to Project scope, but deliberately left Integrations at Company scope — a Slack install genuinely serves the whole company (`Slack::IntegrationService` builds it with `project_id: nil`).

GitHub has been connected per project ever since: every creation path passes a project (`Web::Company::Projects::IntegrationsController#create`), and `GithubSetupController` treats a callback without a project as a misroute. The rows that predate that change are stranded:

- `Integration.visible_for_project` unions `project_id IS NULL` with the project's own rows, so a legacy company-wide row shows up on **every** project's integrations page.
- `IntegrationsController#destroy` looks the record up through `for_project`, which a company-wide row never matches — nothing in the UI can delete it.

## Repositories go too

Their clone credentials come from the installation being deleted, so a repository left behind would look connected and fail on clone. `repositories -> integrations` is `RESTRICT`, so the children are deleted first; `integration_data` cascades at the DB.

GitLab, Coder and Slack are untouched.

## Blast radius

- Any project still cloning through a legacy company-wide GitHub integration loses git access and must reconnect the GitHub App per project.
- CI gates matching inbound webhooks via `Repository.project_ids_for` (`app/models/gate.rb:49`) stop matching for the deleted repositories.
- Attached sessions lose their `session_repositories` rows through the DB cascade — deploy outside a window with active runs.
- Stale ids left in `steps.repository_ids` / `workflows.config` / `workflow_runs.repository_ids` are resolved through `.where(id: ids)` (`app/services/session_service.rb:231`) and simply drop out — no raise.

Irreversible: `down` raises `IrreversibleMigration`. Snapshot both tables before running it on an environment whose data matters.

## Checks

`make check_all` green in Docker (rails-test, rubocop, brakeman, system-test, eslint, typescript, fe-test, vite-build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)