### PR TITLE
feat(personal-mcp): teach the server to explain itself

### DIFF
--- a/app/frontend/pages/Docs/data/pages/board.md
+++ b/app/frontend/pages/Docs/data/pages/board.md
@@ -50,6 +50,9 @@ Each preset column has a `purpose` field — a short description that
 gets injected into the agent's context so it knows what "Code Review"
 means in your team.
 
+Over the personal MCP server the same choice is the `setup_board` tool —
+a project created there has no board until it runs.
+
 ## Tasks and agents — what context the agent sees
 
 When a board-triggered workflow run starts, the agent receives:

--- a/app/frontend/pages/Docs/data/pages/mcp.md
+++ b/app/frontend/pages/Docs/data/pages/mcp.md
@@ -52,8 +52,21 @@ so you can only do in a project what you could do by hand. It exposes the
 things you do in the app: list your companies and projects, manage board
 tasks, columns and gates, build and run workflows (steps, sub-steps,
 triggers, runs), manage agents, custom tools, skills, MCP servers, config
-items and repositories, and update project settings. Two built-in prompts,
-`build_workflow` and `author_step`, guide multi-step construction.
+items and repositories, and update project settings.
+
+The server also documents itself, so a client does not have to guess. Its
+`instructions` — in your agent's context from the moment it connects —
+explain the entity model and the rules that keep it from doing damage.
+Four prompts go deeper on demand: `setup_project` (a project from nothing
+to a running workflow), `build_workflow`, `author_step`, and
+`tool_catalog` (every tool grouped by area, generated from the live
+registry). The full platform reference is served as the resource
+`aixle://reference/system`.
+
+Starting from an empty project works end to end: a new project has no
+board until `setup_board` creates one from a preset (`simple_kanban`,
+`dev_team`, `full_sdlc`), and everything else on the board follows from
+there.
 
 A workflow built this way can be wired up end to end: `create_workflow_trigger`
 attaches a board column, a Slack message, a cron schedule or an inbound

--- a/app/services/personal_tools/create_board_column.rb
+++ b/app/services/personal_tools/create_board_column.rb
@@ -19,7 +19,7 @@ module PersonalTools
       project = find_project!
       authorize!(project.board, :create?, policy: Web::Company::Projects::Board::ColumnsPolicy, project: project)
       board = project.board
-      return error("This project has no board") unless board
+      return error("This project has no board — create one with setup_board") unless board
 
       column = ActiveRecord::Base.transaction { insert_column(board) }
       success(id: column.id, name: column.name, position: column.position)

--- a/app/services/personal_tools/create_board_task.rb
+++ b/app/services/personal_tools/create_board_task.rb
@@ -22,7 +22,7 @@ module PersonalTools
       project = find_project!
       authorize!(project.board, :create?, policy: Web::Company::Projects::Board::TasksPolicy, project: project)
       board = project.board
-      return error("This project has no board") unless board
+      return error("This project has no board — create one with setup_board") unless board
 
       column = board.board_columns.find_by(id: params[:column_id])
       return error("Column #{params[:column_id]} not found on this board") unless column

--- a/app/services/personal_tools/create_workflow_trigger.rb
+++ b/app/services/personal_tools/create_workflow_trigger.rb
@@ -62,7 +62,7 @@ module PersonalTools
 
       success(build_trigger(project, workflow, kind))
     rescue BoardMissingError
-      error("This project has no board. Create a board before adding a column trigger.")
+      error("This project has no board — create one with setup_board before adding a column trigger.")
     rescue ActiveRecord::RecordInvalid => e
       error(e.record.errors.full_messages.join(", "))
     rescue Temporalio::Error => e

--- a/app/services/personal_tools/list_board_columns.rb
+++ b/app/services/personal_tools/list_board_columns.rb
@@ -15,7 +15,7 @@ module PersonalTools
       project = find_project!
       authorize!(project.board, :index?, policy: board_columns_policy, project: project)
       board = project.board
-      return error("This project has no board") unless board
+      return error("This project has no board — create one with setup_board") unless board
 
       columns = board.board_columns.order(:position).map do |c|
         { id: c.id, name: c.name, position: c.position, purpose: c.purpose }

--- a/app/services/personal_tools/list_board_tasks.rb
+++ b/app/services/personal_tools/list_board_tasks.rb
@@ -19,7 +19,7 @@ module PersonalTools
       project = find_project!
       authorize!(project.board, :index?, policy: Web::Company::Projects::Board::TasksPolicy, project: project)
       board = project.board
-      return error("This project has no board") unless board
+      return error("This project has no board — create one with setup_board") unless board
 
       tasks = board.board_tasks.includes(:board_column, :assignee)
       tasks = tasks.where(board_column_id: params[:column_id]) if params[:column_id].present?

--- a/app/services/personal_tools/reorder_board_columns.rb
+++ b/app/services/personal_tools/reorder_board_columns.rb
@@ -15,7 +15,7 @@ module PersonalTools
       project = find_project!
       authorize!(project.board, :reorder?, policy: Web::Company::Projects::Board::ColumnsPolicy, project: project)
       board = project.board
-      return error("This project has no board") unless board
+      return error("This project has no board — create one with setup_board") unless board
 
       ids = params[:column_ids]
       return error("column_ids must be a non-empty array") unless ids.is_a?(Array) && ids.any?

--- a/app/services/personal_tools/setup_board.rb
+++ b/app/services/personal_tools/setup_board.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  # The one board tool that has to exist before any other board tool works: a
+  # project created over MCP has no board at all (boards are built from a
+  # preset, historically only in the UI picker), so without this every
+  # `create_board_column` / `create_board_task` call dead-ends on "This project
+  # has no board".
+  class SetupBoard < Base
+    tool do
+      display_name "Setup Board"
+      description "Create a project's board from a preset — required before any other board tool works, " \
+                  "since a project starts without one. Presets: simple_kanban (Backlog / In Progress / Done), " \
+                  "dev_team (7 columns: backlog through tech design, implementation, code review, QA, release), " \
+                  "full_sdlc (19 columns: design, tech design, dev, QA, UAT, release). Requires project-admin " \
+                  "(owner). Rejected if the project already has a board — edit that one with the column tools."
+      audience :user
+      tags :board
+      param :project_id, type: :integer, description: "Project id (from list_projects).", required: true
+      param :preset, type: :string, description: "Which column set to create.",
+                     enum: %w[simple_kanban dev_team full_sdlc], required: true
+      param :name, type: :string, description: "Board name; defaults to the preset's display name."
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project.board, :create?, policy: Web::Company::Projects::BoardsPolicy, project: project)
+      if project.board
+        return error("This project already has a board — use create_board_column / update_board_column " \
+                     "/ delete_board_column to change its columns.")
+      end
+      unless BoardPresets.valid?(params[:preset])
+        return error("Unknown preset: #{params[:preset]}. Use simple_kanban, dev_team or full_sdlc.")
+      end
+
+      board = Board.create_from_preset(project: project, preset_key: params[:preset], name: params[:name])
+      success(board_id: board.id, name: board.name, preset: params[:preset], columns: columns_for(board))
+    rescue ActiveRecord::RecordInvalid => e
+      error("Failed to set up board: #{e.message}")
+    end
+
+    private
+
+    def columns_for(board)
+      board.board_columns.order(:position).map do |c|
+        { id: c.id, name: c.name, position: c.position, purpose: c.purpose }
+      end
+    end
+  end
+end

--- a/app/services/tools/personal_mcp_guides.rb
+++ b/app/services/tools/personal_mcp_guides.rb
@@ -1,0 +1,371 @@
+# frozen_string_literal: true
+
+module Tools
+  # Everything the personal MCP server says about itself: the always-on
+  # `instructions` block returned from `initialize`, the four on-demand prompts,
+  # and the platform reference served as a resource.
+  #
+  # Split from PersonalMCPRequestHandler so that file stays wiring. The
+  # division of labour between the three surfaces:
+  #
+  # - `INSTRUCTIONS` — in the client's context on every connection, so it holds
+  #   only what a caller must know BEFORE its first call: the entity shape, the
+  #   rules that prevent damage, and where the rest lives.
+  # - prompts — pulled deliberately, one per flow, so they can be long.
+  # - the reference resource — the full domain model, read when a prompt isn't
+  #   enough. Not inlined into a prompt: it is ~500 lines, half of them about
+  #   the in-container session runtime a personal-token caller never sees.
+  module PersonalMCPGuides
+    REFERENCE_PATH = "references/aixle-system-reference.md"
+    REFERENCE_URI = "aixle://reference/system"
+
+    INSTRUCTIONS = <<~TEXT
+      Aixle runs business processes as workflows: ordered steps executed by AI
+      agents in containers, launched by hand or by a trigger. This server is
+      your personal Aixle account — every call runs as you, with your own
+      permissions, across every company you belong to. There is no "current
+      project": nearly every tool takes an explicit `project_id`.
+
+      The shape of the world:
+
+        Company -> Projects. A project owns a board (columns + tasks), its
+        workflows (steps -> sub-steps), and the resources steps draw on: agents,
+        tools, skills, MCP servers, repositories, config items, assets. Those
+        resources can be company-scoped (shared by every project in the company)
+        or project-scoped; a project sees both.
+
+      How to work here:
+
+      - Start from `list_companies` / `list_projects`. Every id you pass comes
+        from a list tool — never invent one, never carry an id across projects.
+      - Read before you write: `get_workflow`, `get_workflow_step`, `get_agent`,
+        `get_skill`, `get_mcp_server`. `get_workflow` truncates step
+        instructions; `get_workflow_step` returns them in full.
+      - Every id list on an update (`tool_ids`, `skill_ids`, `mcp_server_ids`,
+        `depends_on_step_ids`, the workflow's `base_*` lists) REPLACES the
+        current one. Read the current value first, then send the whole list.
+      - Ask the user before anything destructive: every `delete_*`,
+        `uninstall_skill`, `cancel_workflow_run`, `skip_step_run`.
+      - Secrets never travel over this server. Config item values are
+        write-only and come back masked, MCP header/env values are never
+        returned, and integrations are connected by the user in the browser
+        (`get_integration_setup_url`).
+      - Installing from a public catalog (`install_connector`, `install_skill`)
+        puts third-party code or prompt text into a project. Read the entry
+        first (`get_connector`, `get_registry_skill`) and confirm with the user.
+      - "Not allowed" means your role lacks that permission in that project.
+        Retrying will not help — tell the user what needs granting.
+
+      More detail, on demand:
+
+      - prompt `setup_project` — a project from nothing to a running workflow.
+      - prompt `build_workflow` — workflow concepts and the order to call the
+        workflow tools.
+      - prompt `author_step` — how to write a step an agent can actually run.
+      - prompt `tool_catalog` — every tool on this server, grouped by area.
+      - resource `#{REFERENCE_URI}` — the full platform reference.
+    TEXT
+
+    # Tag -> how the tool catalog presents that slice of the registry. The tags
+    # come from the tool definitions themselves, so a new tool joins its group
+    # with no edit here.
+    CATALOG_GROUPS = [
+      { tag: :account, title: "Account & projects",
+        blurb: "Where every flow starts — these return the ids the other tools take." },
+      { tag: :integrations, title: "Integrations",
+        blurb: "Connection status, and the browser URL where the user connects one. " \
+               "Credentials are never handled over MCP." },
+      { tag: :resources, title: "Project resources",
+        blurb: "What a workflow step can be given: agents, tools, skills, MCP servers, " \
+               "repositories, config items, assets — plus the public catalogs to install from." },
+      { tag: :board, title: "Board",
+        blurb: "Columns and tasks. A new project has no board at all until `setup_board` " \
+               "creates one, and moving a card is what fires a column trigger." },
+      { tag: :workflows, title: "Workflows & runs",
+        blurb: "Define workflows and their steps, attach triggers, then start runs and " \
+               "diagnose them." }
+    ].freeze
+
+    class << self
+      def system_reference
+        path = Rails.root.join(REFERENCE_PATH)
+        return "(Aixle system reference is unavailable in this environment.)" unless path.exist?
+
+        path.read
+      end
+
+      # Generated from the live registry: adding a tool updates the catalog,
+      # and a tool that carries no known tag still shows up (under "Other")
+      # rather than silently vanishing from the map.
+      def tool_catalog
+        defs = Registry.for_audience(:user)
+        known = CATALOG_GROUPS.map { |g| g[:tag] }
+        sections = CATALOG_GROUPS.filter_map do |group|
+          section(group[:title], group[:blurb], defs.select { |d| d.tags.include?(group[:tag]) })
+        end
+        sections << section("Other", nil, defs.reject { |d| d.tags.intersect?(known) })
+
+        <<~TEXT
+          # Aixle tools on this server
+
+          Every tool your token can call, grouped by area, one line each —
+          generated from the live registry. Full parameter schemas are in
+          `tools/list`; the flows these tools serve are in the `setup_project`,
+          `build_workflow` and `author_step` prompts.
+
+          #{sections.compact.join("\n").rstrip}
+
+          Two rules worth repeating, because they are what usually goes wrong:
+          read a workflow step with `get_workflow_step` before editing it (the
+          listing truncates instructions), and remember that an id list on an
+          update replaces the current one wholesale.
+        TEXT
+      end
+
+      def setup_project
+        <<~GUIDE
+          # Setting up an Aixle project from scratch
+
+          Order matters: each stage needs ids or connections the earlier ones
+          create. Carry the `project_id` from stage 1 into every later call.
+
+          ## 1. Company, then project
+          - `list_companies` — your active memberships and your role in each.
+          - `create_project` — name + description; pass `company_id` when you
+            belong to more than one company. Returns the `project_id`.
+          - `update_project_settings` — name, description, artifacts language,
+            state.
+          - `list_project_members` — who can reach the project; their ids are
+            what a board task's assignee takes.
+
+          ## 2. Integrations, before anything that depends on them
+          - `list_integrations` — GitHub / GitLab / Slack / Coder and whether
+            each is connected.
+          - Missing one? `get_integration_setup_url` returns the settings page;
+            the user connects it in the browser. Credentials never come through
+            MCP.
+          - A git integration gates private repositories; Slack gates a Slack
+            trigger. Connect them now rather than half-way through.
+
+          ## 3. Repositories
+          - `create_repository` — `full_name` + `integration_id` for a repo the
+            app is installed on, or `public_url` for a public one (attached
+            read-only and cloned without credentials, so no integration is
+            needed). Requires company admin.
+          - `list_repositories` / `update_repository` — branch, purpose,
+            description.
+
+          ## 4. Config items (the only place secrets live)
+          - `create_config_item` — `secret` is stored encrypted, `variable` is
+            plain text.
+          - MCP server headers and env values reference a config item by key
+            instead of carrying the secret. `list_config_items` masks values,
+            and nothing ever reads one back.
+
+          ## 5. Capabilities the steps will use
+          - Tools: `list_project_tools` (attachable platform tools plus the
+            project's own). `create_custom_tool` adds a docker-image tool.
+          - MCP servers: `list_mcp_servers`. Add from the public catalog with
+            `search_connector_catalog` -> `get_connector` -> `install_connector`,
+            or register one by hand with `create_mcp_server`.
+          - Skills: `list_skills`. Add from the registry with
+            `search_skill_registry` -> `get_registry_skill` -> `install_skill`,
+            or write your own with `create_skill` (SKILL.md content; the
+            frontmatter needs a name and a description).
+          - Files: `list_assets` shows what the project already has to work
+            with.
+          - Read the entry before installing anything: a connector's install
+            target decides what actually runs, and a skill's SKILL.md is prompt
+            text your agents will follow.
+
+          ## 6. Agents
+          - `list_agents` — company-scoped agents are already visible here.
+          - `create_agent` — the persona a step runs as. `get_agent` reads one
+            in full before you reuse it.
+
+          ## 7. The board
+          - A new project has NO board, and every other board tool fails until
+            it exists. `setup_board` creates one from a preset:
+            `simple_kanban` (3 columns), `dev_team` (7), `full_sdlc` (19).
+          - `list_board_columns`, `create_board_column`, `update_board_column`,
+            `reorder_board_columns`, `delete_board_column` shape it (all
+            project-admin). A column with tasks cannot be deleted.
+          - `create_board_task` puts work on it; `move_board_task` between
+            columns is what a column trigger reacts to.
+
+          ## 8. The workflow
+          - Read the `build_workflow` prompt for the full sequence and
+            `author_step` for writing one step. In short: `create_workflow` ->
+            `create_workflow_step` per unit of work (agent + wiring in the same
+            call) -> `create_sub_step` for checklists ->
+            `reorder_workflow_steps`.
+
+          ## 9. Automation
+          - `create_workflow_trigger` with a `kind`: `column` (a card entering a
+            board column — the column must already exist), `slack`, `schedule`
+            (cron AND an explicit timezone, or Temporal schedules in UTC and
+            drifts under daylight saving), `webhook` (returns the endpoint URL
+            and a secret shown only in that response), or `event`.
+          - The off-board kinds fire with nobody watching, so every step needs
+            `allow_non_interactive` first — otherwise the trigger is rejected
+            and the error names the steps.
+
+          ## 10. Run it, then read the run
+          - `trigger_workflow` starts one by hand. `list_workflow_runs` /
+            `get_workflow_run` report state; `get_step_run` is what explains a
+            failure (error category, retries, session diagnostics).
+          - `approve_step_run`, `retry_step_run`, `skip_step_run` and
+            `cancel_workflow_run` drive a run in flight.
+
+          Shortcut: if a workflow elsewhere already does most of the job,
+          `duplicate_workflow` copies it — steps, sub-steps and wiring — into
+          this project. It returns a `needs_setup` list, because secrets,
+          assets, repositories and integrations are never copied.
+        GUIDE
+      end
+
+      def build_workflow
+        <<~GUIDE
+          # Building an Aixle workflow
+
+          A workflow is an ordered set of steps. Each step runs an agent in a
+          container with the tools, skills, MCP servers and files you give it.
+          Steps can depend on other steps (a DAG), and each step can carry
+          sub-steps — a checklist the agent ticks off as it works.
+
+          Build top-down, and prefer inspecting before mutating:
+
+          1. `list_projects` — pick the project; every workflow tool takes its `project_id`.
+          2. `list_workflows` / `get_workflow` — see what already exists before adding.
+             `get_workflow` also reports the workflow's base resources (tools, skills
+             and MCP servers every step gets) — read them before wiring per-step ones.
+          3. `create_workflow` — name + description. Returns the `workflow_id`.
+             `update_workflow` renames it and sets the base resources.
+             `duplicate_workflow` copies an existing one, into this project or another.
+          4. Inspect what you can wire in: `list_project_tools`, `list_skills`,
+             `list_mcp_servers`, `list_agents`. `get_agent`, `get_skill` and
+             `get_mcp_server` return the full persona / skill content / server wiring
+             when the list entry isn't enough to decide. Nothing suitable in the
+             project yet? Add it from the public catalogs first:
+             `search_connector_catalog` → `get_connector` → `install_connector` for
+             MCP servers, `search_skill_registry` → `get_registry_skill` →
+             `install_skill` for skills. Read the entry before installing — a
+             connector's install target decides what runs, and a skill's SKILL.md is
+             prompt text your agents will follow.
+          5. For each step: `create_workflow_step` takes the wiring in one call —
+             name, instructions, agent_id, position, plus `tool_ids`, `skill_ids`,
+             `mcp_server_ids`, `depends_on_step_ids`, `bmad_enabled` and
+             `allow_non_interactive`. Dependencies must already exist, so create
+             the steps they point at first (or set them later with
+             `update_workflow_step`).
+          6. `create_sub_step` — break a step into a checklist when it has several
+             distinct deliverables. `update_sub_step` / `delete_sub_step` /
+             `reorder_sub_steps` edit, remove and reorder them; all take the
+             `sub_step_id`s reported by `get_workflow_step`. See the `author_step`
+             prompt for how to write a good step.
+          7. `reorder_workflow_steps` — fix execution order by passing step ids.
+          8. Connect a trigger, or the workflow only ever starts by hand:
+             `create_workflow_trigger` with a `kind` —
+             `column` (a card entering a board column), `slack` (an inbound message),
+             `schedule` (cron), `webhook` (an inbound HTTP call, which also returns the
+             endpoint URL and secret), or `event` (a custom platform event).
+             `list_workflow_triggers` / `update_workflow_trigger` /
+             `delete_workflow_trigger` manage them.
+          9. `trigger_workflow` — start a run by hand (interactive or non_interactive).
+             Track it with `list_workflow_runs` / `get_workflow_run`; read a single
+             step run's error, retries and session diagnostics with `get_step_run`;
+             stop a run with `cancel_workflow_run`.
+
+          Rules:
+          - Ask the user before destructive actions (`delete_workflow`,
+            `delete_workflow_step`, `delete_sub_step`, `delete_workflow_trigger`).
+          - `get_workflow` truncates step instructions. Read a step with
+            `get_workflow_step` before editing it, or you will overwrite text you
+            never saw. The same applies to every id list (`tool_ids`, `skill_ids`,
+            `mcp_server_ids`, `depends_on_step_ids`, and the workflow's `base_*`
+            lists): an update REPLACES the list, so read the current value first.
+          - The off-board trigger kinds (slack, schedule, webhook, event) fire with
+            nobody watching, so every step must have `allow_non_interactive` set.
+            A trigger whose workflow still has a human-gated step is rejected on
+            save, and the error names the steps.
+          - A `schedule` trigger needs a cron expression AND an explicit timezone —
+            leave the timezone out and Temporal schedules in UTC, which drifts by an
+            hour under daylight saving.
+          - Everything is scoped to what your account can access — a tool that
+            returns "not allowed" means your role can't do that in this project.
+
+          Starting from an empty project instead of an existing one? The
+          `setup_project` prompt covers what has to exist first. The full domain
+          model — entities, scoping, the container runtime a step executes in —
+          is the `#{REFERENCE_URI}` resource.
+        GUIDE
+      end
+
+      def author_step
+        <<~GUIDE
+          # Writing a good Aixle workflow step
+
+          A step is one unit of agent work. Use `create_workflow_step` /
+          `update_workflow_step`; break it into `create_sub_step` items when it has
+          multiple deliverables.
+
+          Instructions (the `instructions` field, markdown):
+          - Say WHAT to do and WHAT to produce — the concrete deliverable and where
+            it goes. Be specific about output files/paths.
+          - Do NOT restate platform mechanics: session-completion rules, /workspace
+            layout, sub-step tracking, or which tools are available. The platform
+            injects those automatically — repeating them wastes context.
+          - Keep it focused on this step alone; earlier steps' outputs are available
+            to later steps that depend on them.
+
+          Wiring:
+          - `agent_id` (from `list_agents`) picks who runs the step. `get_agent`
+            returns that agent's full persona when the title isn't enough.
+          - `tool_ids` / `skill_ids` / `mcp_server_ids` grant capabilities — attach
+            only what the step needs (list them with list_project_tools / list_skills /
+            list_mcp_servers, and read a skill's content with `get_skill` before
+            deciding). Check the workflow's `base_*` lists in `get_workflow` first:
+            those already apply to every step, so don't re-attach them here.
+          - `depends_on_step_ids` builds the DAG: a step runs after every step it
+            depends on. A step can't be deleted while others depend on it.
+          - `allow_non_interactive` lets the step run unattended. Every step needs it
+            before a slack / schedule / webhook trigger can be attached to the
+            workflow.
+          - Each of those id lists is REPLACED wholesale by an update — read the
+            current value with `get_workflow_step` before changing one.
+
+          Sub-steps:
+          - One `create_sub_step` per distinct, checkable deliverable.
+          - `required: false` for optional work.
+          - The running agent marks them off, giving progress visibility.
+          - `get_workflow_step` reports each sub-step's id; edit one with
+            `update_sub_step` (name, instructions, position, required), drop one with
+            `delete_sub_step`, and fix the order with `reorder_sub_steps` (which
+            takes every sub-step id of the step).
+
+          Prefer `get_workflow` to inspect the current shape and `get_workflow_step`
+          to read a step in full before editing, and make one focused change per
+          tool call.
+        GUIDE
+      end
+
+      private
+
+      def section(title, blurb, definitions)
+        return nil if definitions.empty?
+
+        lines = definitions.sort_by(&:name).map { |d| "- `#{d.name}` — #{summary(d.description)}" }
+        [ "## #{title}", blurb, lines.join("\n") ].compact.join("\n") + "\n"
+      end
+
+      # First sentence only: this is a map, and the full text of all ~85
+      # descriptions is already on the wire in `tools/list`.
+      def summary(description)
+        first = description.to_s.split(/(?<=[.!?])\s+/).first.to_s.strip
+        return first if first.length <= 200
+
+        "#{first[0, 200].sub(/\s+\S*\z/, '')}…"
+      end
+    end
+  end
+end

--- a/app/services/tools/personal_mcp_request_handler.rb
+++ b/app/services/tools/personal_mcp_request_handler.rb
@@ -36,8 +36,10 @@ module Tools
     def server
       MCP::Server.new(
         name: "aixle",
+        instructions: PersonalMCPGuides::INSTRUCTIONS,
         tools: Registry.for_audience(:user).sort_by(&:name).map { |defn| define_tool(defn) },
-        prompts: [ build_workflow_prompt, author_step_prompt ],
+        prompts: PROMPTS.map { |spec| define_prompt(spec) },
+        resources: [ reference_resource ],
         server_context: { user: user }
       )
     end
@@ -79,163 +81,52 @@ module Tools
     end
 
     # Complex flows need more guidance than tool descriptions can carry —
-    # served as MCP prompts the client can pull in on demand.
-    def build_workflow_prompt
-      text = PersonalMCPRequestHandler.workflow_guide
-      MCP::Prompt.define(
-        name: "build_workflow",
+    # served as MCP prompts the client pulls in on demand. `guide` names the
+    # PersonalMCPGuides method, called inside the block so nothing is rendered
+    # until a client actually asks for that prompt.
+    PROMPTS = [
+      { name: "setup_project", guide: :setup_project, title: "Aixle project setup guide",
+        description: "How to take an Aixle project from nothing to a running workflow: company and " \
+                     "project, integrations, repositories, secrets, tools/skills/MCP servers, agents, " \
+                     "the board, then the workflow and its trigger." },
+      { name: "build_workflow", guide: :build_workflow, title: "Aixle workflow building guide",
         description: "How to build an Aixle workflow end-to-end: concepts, the order to call the " \
-                     "workflow tools, step/sub-step structure, running and inspecting runs."
-      ) do |_args, server_context: nil|
-        MCP::Prompt::Result.new(
-          description: "Aixle workflow building guide",
-          messages: [ MCP::Prompt::Message.new(role: "user", content: { type: "text", text: text }) ]
-        )
-      end
-    end
-
-    def author_step_prompt
-      text = PersonalMCPRequestHandler.step_guide
-      MCP::Prompt.define(
-        name: "author_step",
+                     "workflow tools, step/sub-step structure, running and inspecting runs." },
+      { name: "author_step", guide: :author_step, title: "Aixle step authoring guide",
         description: "How to write a good Aixle workflow step: instructions, agent/tools/skills, " \
-                     "sub-steps, dependencies, and failure handling."
-      ) do |_args, server_context: nil|
+                     "sub-steps, dependencies, and failure handling." },
+      { name: "tool_catalog", guide: :tool_catalog, title: "Aixle tool catalog",
+        description: "Every tool this server exposes, grouped by area (account, integrations, project " \
+                     "resources, board, workflows) with a one-line summary each." }
+    ].freeze
+
+    def define_prompt(spec)
+      MCP::Prompt.define(name: spec[:name], description: spec[:description]) do |_args, server_context: nil|
         MCP::Prompt::Result.new(
-          description: "Aixle step authoring guide",
-          messages: [ MCP::Prompt::Message.new(role: "user", content: { type: "text", text: text }) ]
+          description: spec[:title],
+          messages: [ MCP::Prompt::Message.new(
+            role: "user", content: { type: "text", text: PersonalMCPGuides.public_send(spec[:guide]) }
+          ) ]
         )
       end
     end
 
-    GUIDE_PATH = "references/aixle-system-reference.md"
-
-    def self.workflow_guide
-      path = Rails.root.join(GUIDE_PATH)
-      reference = path.exist? ? path.read : "(Aixle system reference is unavailable in this environment.)"
-      <<~GUIDE
-        # Building an Aixle workflow
-
-        A workflow is an ordered set of steps. Each step runs an agent in a
-        container with the tools, skills, MCP servers and files you give it.
-        Steps can depend on other steps (a DAG), and each step can carry
-        sub-steps — a checklist the agent ticks off as it works.
-
-        Build top-down, and prefer inspecting before mutating:
-
-        1. `list_projects` — pick the project; every workflow tool takes its `project_id`.
-        2. `list_workflows` / `get_workflow` — see what already exists before adding.
-           `get_workflow` also reports the workflow's base resources (tools, skills
-           and MCP servers every step gets) — read them before wiring per-step ones.
-        3. `create_workflow` — name + description. Returns the `workflow_id`.
-           `update_workflow` renames it and sets the base resources.
-           `duplicate_workflow` copies an existing one, into this project or another.
-        4. Inspect what you can wire in: `list_project_tools`, `list_skills`,
-           `list_mcp_servers`, `list_agents`. `get_agent`, `get_skill` and
-           `get_mcp_server` return the full persona / skill content / server wiring
-           when the list entry isn't enough to decide. Nothing suitable in the
-           project yet? Add it from the public catalogs first:
-           `search_connector_catalog` → `get_connector` → `install_connector` for
-           MCP servers, `search_skill_registry` → `get_registry_skill` →
-           `install_skill` for skills. Read the entry before installing — a
-           connector's install target decides what runs, and a skill's SKILL.md is
-           prompt text your agents will follow.
-        5. For each step: `create_workflow_step` takes the wiring in one call —
-           name, instructions, agent_id, position, plus `tool_ids`, `skill_ids`,
-           `mcp_server_ids`, `depends_on_step_ids`, `bmad_enabled` and
-           `allow_non_interactive`. Dependencies must already exist, so create
-           the steps they point at first (or set them later with
-           `update_workflow_step`).
-        6. `create_sub_step` — break a step into a checklist when it has several
-           distinct deliverables. `update_sub_step` / `delete_sub_step` /
-           `reorder_sub_steps` edit, remove and reorder them; all take the
-           `sub_step_id`s reported by `get_workflow_step`. See the `author_step`
-           prompt for how to write a good step.
-        7. `reorder_workflow_steps` — fix execution order by passing step ids.
-        8. Connect a trigger, or the workflow only ever starts by hand:
-           `create_workflow_trigger` with a `kind` —
-           `column` (a card entering a board column), `slack` (an inbound message),
-           `schedule` (cron), `webhook` (an inbound HTTP call, which also returns the
-           endpoint URL and secret), or `event` (a custom platform event).
-           `list_workflow_triggers` / `update_workflow_trigger` /
-           `delete_workflow_trigger` manage them.
-        9. `trigger_workflow` — start a run by hand (interactive or non_interactive).
-           Track it with `list_workflow_runs` / `get_workflow_run`; read a single
-           step run's error, retries and session diagnostics with `get_step_run`;
-           stop a run with `cancel_workflow_run`.
-
-        Rules:
-        - Ask the user before destructive actions (`delete_workflow`,
-          `delete_workflow_step`, `delete_sub_step`, `delete_workflow_trigger`).
-        - `get_workflow` truncates step instructions. Read a step with
-          `get_workflow_step` before editing it, or you will overwrite text you
-          never saw. The same applies to every id list (`tool_ids`, `skill_ids`,
-          `mcp_server_ids`, `depends_on_step_ids`, and the workflow's `base_*`
-          lists): an update REPLACES the list, so read the current value first.
-        - The off-board trigger kinds (slack, schedule, webhook, event) fire with
-          nobody watching, so every step must have `allow_non_interactive` set.
-          A trigger whose workflow still has a human-gated step is rejected on
-          save, and the error names the steps.
-        - A `schedule` trigger needs a cron expression AND an explicit timezone —
-          leave the timezone out and Temporal schedules in UTC, which drifts by an
-          hour under daylight saving.
-        - Everything is scoped to what your account can access — a tool that
-          returns "not allowed" means your role can't do that in this project.
-
-        ---
-
-        Platform reference:
-
-        #{reference}
-      GUIDE
-    end
-
-    def self.step_guide
-      <<~GUIDE
-        # Writing a good Aixle workflow step
-
-        A step is one unit of agent work. Use `create_workflow_step` /
-        `update_workflow_step`; break it into `create_sub_step` items when it has
-        multiple deliverables.
-
-        Instructions (the `instructions` field, markdown):
-        - Say WHAT to do and WHAT to produce — the concrete deliverable and where
-          it goes. Be specific about output files/paths.
-        - Do NOT restate platform mechanics: session-completion rules, /workspace
-          layout, sub-step tracking, or which tools are available. The platform
-          injects those automatically — repeating them wastes context.
-        - Keep it focused on this step alone; earlier steps' outputs are available
-          to later steps that depend on them.
-
-        Wiring:
-        - `agent_id` (from `list_agents`) picks who runs the step. `get_agent`
-          returns that agent's full persona when the title isn't enough.
-        - `tool_ids` / `skill_ids` / `mcp_server_ids` grant capabilities — attach
-          only what the step needs (list them with list_project_tools / list_skills /
-          list_mcp_servers, and read a skill's content with `get_skill` before
-          deciding). Check the workflow's `base_*` lists in `get_workflow` first:
-          those already apply to every step, so don't re-attach them here.
-        - `depends_on_step_ids` builds the DAG: a step runs after every step it
-          depends on. A step can't be deleted while others depend on it.
-        - `allow_non_interactive` lets the step run unattended. Every step needs it
-          before a slack / schedule / webhook trigger can be attached to the
-          workflow.
-        - Each of those id lists is REPLACED wholesale by an update — read the
-          current value with `get_workflow_step` before changing one.
-
-        Sub-steps:
-        - One `create_sub_step` per distinct, checkable deliverable.
-        - `required: false` for optional work.
-        - The running agent marks them off, giving progress visibility.
-        - `get_workflow_step` reports each sub-step's id; edit one with
-          `update_sub_step` (name, instructions, position, required), drop one with
-          `delete_sub_step`, and fix the order with `reorder_sub_steps` (which
-          takes every sub-step id of the step).
-
-        Prefer `get_workflow` to inspect the current shape and `get_workflow_step`
-        to read a step in full before editing, and make one focused change per
-        tool call.
-      GUIDE
+    # The full domain model, served as a resource rather than inlined into a
+    # prompt: it is ~500 lines and only some callers ever need it.
+    def reference_resource
+      MCP::Resource.define(
+        uri: PersonalMCPGuides::REFERENCE_URI,
+        name: "aixle-system-reference",
+        description: "The Aixle platform reference: entities and their relationships, scoping, " \
+                     "triggers and automation, agent runtimes and the container a step executes in.",
+        mime_type: "text/markdown"
+      ) do
+        MCP::Resource::TextContents.new(
+          uri: PersonalMCPGuides::REFERENCE_URI,
+          mime_type: "text/markdown",
+          text: PersonalMCPGuides.system_reference
+        )
+      end
     end
   end
 end

--- a/docs/user-guide/board.md
+++ b/docs/user-guide/board.md
@@ -48,6 +48,9 @@ Each preset column has a `purpose` field — a short description that
 gets injected into the agent's context so it knows what "Code Review"
 means in your team.
 
+Over the personal MCP server the same choice is the `setup_board` tool —
+a project created there has no board until it runs.
+
 ## Tasks and agents — what context the agent sees
 
 When a board-triggered workflow run starts, the agent receives:

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -19,7 +19,8 @@ Read in any order:
 - **[Tools](tools.md)** — tool kinds, execution modes, the built-in board
   tools, and resource resolution.
 - **[MCP servers](mcp.md)** — transports, the internal `aixle-tools` server,
-  and Config Items credentials.
+  Config Items credentials, and the personal token that turns Aixle itself
+  into an MCP server.
 - **[Integrations](integrations.md)** — GitHub, GitLab, Linear,
   Google OAuth, and webhooks.
 - **[Configuration](configuration.md)** — env vars, OAuth, agent

--- a/docs/user-guide/mcp.md
+++ b/docs/user-guide/mcp.md
@@ -62,6 +62,40 @@ Custom HTTP/SSE servers are validated against SSRF: the URL must be
 endpoints, or private / loopback / link-local addresses (including
 hostnames that resolve to them).
 
+## Aixle as an MCP server (your personal token)
+
+The same `/mcp` endpoint also serves a **personal** server: not a
+session's tools, but your own Aixle account, so an outside client
+(Claude Code, Claude Desktop, any MCP client) can drive the platform for
+you — list projects, build workflows, run them, work the board.
+
+Enable it under **Profile → Personal MCP**, which hands you an `amcp_`
+token and the ready-made command:
+
+```
+claude mcp add aixle --transport http $MCP_SERVER_URL --header "Authorization: Bearer amcp_…"
+```
+
+The token carries **exactly your own access level** — every call runs
+through the same Pundit policies as the UI, across every company you are
+an active member of. There is no "current project": tools take an
+explicit `project_id`. Regenerating the token revokes the old one.
+
+Beyond its ~85 tools, the server ships its own documentation:
+
+| Surface | Name | What it carries |
+| --- | --- | --- |
+| `instructions` | — | Returned on `initialize`, so it is in the client's context from the start: the entity model, the rules that prevent damage (read before write, id lists are replaced wholesale, confirm destructive calls), and where the rest lives. |
+| prompt | `setup_project` | A project from nothing to a running workflow: company, integrations, repositories, config items, tools/skills/MCP servers, agents, board, workflow, trigger. |
+| prompt | `build_workflow` | Workflow concepts and the order to call the workflow tools. |
+| prompt | `author_step` | How to write a step an agent can actually run. |
+| prompt | `tool_catalog` | Every tool on the server, grouped by area — generated from the live registry, so it cannot drift. |
+| resource | `aixle://reference/system` | `references/aixle-system-reference.md`: the full domain model. |
+
+Implementation: `Tools::PersonalMCPRequestHandler` wires the server,
+`Tools::PersonalMCPGuides` holds the text, and the tools are the
+registry's `audience :user` definitions (`app/services/personal_tools/`).
+
 ## See also
 
 - [Tools](tools.md) — what the tools themselves are and how they execute.

--- a/test/integration/personal_mcp_board_test.rb
+++ b/test/integration/personal_mcp_board_test.rb
@@ -200,6 +200,47 @@ class PersonalMCPBoardTest < ActionDispatch::IntegrationTest
     assert_equal "human", comments.first["author_type"]
   end
 
+  test "setup_board builds the board a fresh project does not have" do
+    fresh = create(:project, company: @company, owner: @user)
+    assert_nil fresh.board
+
+    created = payload(call_tool("setup_board", { project_id: fresh.id, preset: "simple_kanban" }))
+    assert_equal %w[Backlog In\ Progress Done], created["columns"].map { |c| c["name"] }
+    assert_equal [ 1, 2, 3 ], created["columns"].map { |c| c["position"] }
+    assert_equal created["board_id"], fresh.reload.board.id
+
+    # The rest of the board surface only works once the board exists.
+    task = call_tool("create_board_task",
+                     { project_id: fresh.id, column_id: created["columns"].first["id"], title: "First" })
+    assert_not tool_error?(task)
+  end
+
+  test "setup_board refuses a second board and an unknown preset" do
+    existing = call_tool("setup_board", { project_id: @project.id, preset: "dev_team" })
+    assert tool_error?(existing)
+    assert_match(/already has a board/i, existing.dig("result", "content").map { |c| c["text"] }.join(" "))
+    assert_equal @board.id, @project.reload.board.id
+
+    # An unknown preset never reaches the handler: the declared enum is
+    # enforced by the MCP SDK before dispatch.
+    fresh = create(:project, company: @company, owner: @user)
+    unknown = call_tool("setup_board", { project_id: fresh.id, preset: "kanban_deluxe" })
+    assert_match(/not one of/i, unknown.to_json)
+    assert_nil fresh.reload.board
+  end
+
+  test "setup_board requires project admin (owner)" do
+    fresh = create(:project, company: @company, owner: @user)
+    member = create(:user, company: @company)
+    fresh.add_collaborator(member)
+
+    body = call_tool("setup_board", { project_id: fresh.id, preset: "simple_kanban" },
+                     token: member.regenerate_mcp_token!)
+    assert tool_error?(body)
+    assert_match(/not allowed/i, body.dig("result", "content").map { |c| c["text"] }.join(" "))
+    assert_nil fresh.reload.board
+  end
+
   test "board column create / update / reorder / delete" do
     created = payload(call_tool("create_board_column", { project_id: @project.id, name: "Review", purpose: "PRs" }))
     cid = created["id"]

--- a/test/integration/personal_mcp_test.rb
+++ b/test/integration/personal_mcp_test.rb
@@ -22,6 +22,10 @@ class PersonalMCPTest < ActionDispatch::IntegrationTest
     response.parsed_body
   end
 
+  def prompt_text(name)
+    rpc("prompts/get", { name: name, arguments: {} }).dig("result", "messages").first.dig("content", "text")
+  end
+
   test "token lifecycle: regenerate rotates, disable revokes" do
     old_token = @token
     new_token = @user.regenerate_mcp_token!
@@ -68,20 +72,46 @@ class PersonalMCPTest < ActionDispatch::IntegrationTest
     assert_equal [ @project.id ], projects.map { |p| p["id"] }
   end
 
-  test "the build_workflow and author_step prompts are served" do
+  test "the guidance prompts are served" do
     names = rpc("prompts/list").dig("result", "prompts").map { |p| p["name"] }
-    assert_includes names, "build_workflow"
-    assert_includes names, "author_step"
+    assert_equal %w[author_step build_workflow setup_project tool_catalog], names.sort
 
-    wf = rpc("prompts/get", { name: "build_workflow", arguments: {} })
-                   .dig("result", "messages").first.dig("content", "text")
+    wf = prompt_text("build_workflow")
     assert_match(/create_workflow/, wf)
     assert_match(/trigger_workflow/, wf)
 
-    step = rpc("prompts/get", { name: "author_step", arguments: {} })
-                     .dig("result", "messages").first.dig("content", "text")
+    step = prompt_text("author_step")
     assert_match(/instructions/i, step)
     assert_match(/depends_on_step_ids/, step)
+
+    setup = prompt_text("setup_project")
+    assert_match(/create_project/, setup)
+    # The from-scratch path only works because the board can be created here.
+    assert_match(/setup_board/, setup)
+    assert_match(/get_integration_setup_url/, setup)
+
+    catalog = prompt_text("tool_catalog")
+    served = rpc("tools/list").dig("result", "tools").map { |t| t["name"] }
+    missing = served.reject { |name| catalog.include?("`#{name}`") }
+    assert_empty missing, "tool catalog prompt is missing: #{missing.join(', ')}"
+  end
+
+  test "the server introduces itself with instructions on initialize" do
+    result = rpc("initialize", { protocolVersion: "2025-06-18", capabilities: {},
+                                 clientInfo: { name: "test-client", version: "1" } })["result"]
+
+    assert_match(/project_id/, result["instructions"])
+    assert_match(/list_companies/, result["instructions"])
+    assert_match(/setup_project/, result["instructions"])
+  end
+
+  test "the platform reference is served as a resource" do
+    listed = rpc("resources/list").dig("result", "resources")
+    assert_equal [ "aixle://reference/system" ], listed.map { |r| r["uri"] }
+
+    contents = rpc("resources/read", { uri: "aixle://reference/system" }).dig("result", "contents").first
+    assert_equal "text/markdown", contents["mimeType"]
+    assert_match(/Aixle Platform/, contents["text"])
   end
 
   test "the last-used timestamp is touched on requests" do


### PR DESCRIPTION
## Why

A client connecting with a personal `amcp_` token got 84 tool descriptions and two prompts about workflows. Enough to edit an existing project — not enough to know what Aixle is, which call comes first, or that an id list on an update replaces the current one wholesale. And a project created over MCP dead-ended at the first board call, because boards are only ever built from a preset (UI picker / builder meta tool).

## What

Three surfaces, split by *when* a caller needs the text:

| Surface | Name | Delivered |
| --- | --- | --- |
| `instructions` | — | On `initialize`, so it is in the client's context from the start: entity model, the rules that prevent damage (read before write, id lists replace wholesale, confirm destructive calls, secrets never travel here), and where the rest lives. |
| prompt | `setup_project` | **New.** A project from nothing to a running workflow: company → integrations → repositories → config items → tools/skills/MCP servers → agents → board → workflow → trigger → run. |
| prompt | `build_workflow` | Unchanged guidance; the inlined reference is gone (see below). |
| prompt | `author_step` | Unchanged. |
| prompt | `tool_catalog` | **New.** Every tool grouped by area, one line each — generated from `Registry.for_audience(:user)`, so a new tool joins its group with no edit here. |
| resource | `aixle://reference/system` | **New.** `references/aixle-system-reference.md`, moved out of the `build_workflow` prompt body. |

`setup_board` closes the from-scratch hole: it creates the board from a preset (`simple_kanban` / `dev_team` / `full_sdlc`), project-admin only, rejected if a board already exists. The six "This project has no board" errors now name it.

## Notes

- The ~500-line reference was previously rendered into the `build_workflow` prompt on **every** MCP request, and half of it describes the in-container session runtime a personal-token caller never sees. It is now read only when the resource is actually fetched, and all four prompts render lazily inside their handler block.
- `PersonalMCPRequestHandler` drops from 241 to 132 lines — it is wiring again; the text lives in the new `Tools::PersonalMCPGuides`.
- No new dependency: `instructions:` and class-based resources are already supported by the vendored `mcp` 1.1.0 gem (`instructions` is dropped automatically for a `2024-11-05` client).

## Tests

- `personal_mcp_test.rb`: prompts served, `initialize` carries instructions, the reference reads back as `text/markdown`, and a drift guard that fails if any served tool is missing from the `tool_catalog` prompt.
- `personal_mcp_board_test.rb`: `setup_board` builds a fresh project's board and unblocks the rest of the board surface; refuses a second board; requires project admin.
- `docker compose exec -T web make check_all` green (backend 90.92%, frontend 78.35%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)