### PR TITLE
fix(workflows): preselect the member's default agent runtime

### DIFF
--- a/app/controllers/web/company/projects/aixle_builder_controller.rb
+++ b/app/controllers/web/company/projects/aixle_builder_controller.rb
@@ -17,6 +17,7 @@ class Web::Company::Projects::AixleBuilderController < Web::Company::Projects::A
       sessions: -> { sessions.map { |s| TerminalSessionResource.new(s).to_h } },
       active_session_id: -> { active_session&.id },
       configured_agents: -> { current_project_membership&.configured_agents || [] },
+      default_agent_runtime: -> { current_project_membership&.default_agent_runtime },
       assets: -> { Asset.accessible_from_project(current_project).map { |a| PickerResource.new(a).to_h } },
       agent_models: InertiaRails.defer { current_project_membership&.agent_models_for_props || [] }
     }

--- a/app/controllers/web/company/projects/workflows_controller.rb
+++ b/app/controllers/web/company/projects/workflows_controller.rb
@@ -13,6 +13,7 @@ class Web::Company::Projects::WorkflowsController < Web::Company::Projects::Appl
         )
       },
       configured_agents: current_project_membership&.configured_agents || [],
+      default_agent_runtime: current_project_membership&.default_agent_runtime,
       # Company-scoped assets are shared with every project in the company and are
       # already offered by the assets page, the session form and the Aixle Builder.
       # `current_project.assets` walks the has_many and sees project-owned rows only,
@@ -43,6 +44,7 @@ class Web::Company::Projects::WorkflowsController < Web::Company::Projects::Appl
         { id: c.id, name: c.name, bound_workflow_name: c.column_workflow_binding&.workflow&.name }
       } || [],
       configured_agents: current_project_membership&.configured_agents || [],
+      default_agent_runtime: current_project_membership&.default_agent_runtime,
       agents: InertiaRails.defer(group: "resources") {
         Agent.visible_for_project(current_project).map { |r| PickerResource.new(r).to_h }
       },

--- a/app/frontend/pages/Projects/AixleBuilder/LandingPage.test.tsx
+++ b/app/frontend/pages/Projects/AixleBuilder/LandingPage.test.tsx
@@ -54,6 +54,20 @@ describe('Projects/AixleBuilder/LandingPage', () => {
     );
   });
 
+  it("starts with the member's default agent runtime rather than the first configured one", async () => {
+    renderAuthedPage(<LandingPage />, {
+      props: { ...baseProps, configuredAgents: ['cursor_cli', 'claude_code'], defaultAgentRuntime: 'claude_code' },
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /Start Builder/i }));
+
+    expect(router.post).toHaveBeenCalledWith(
+      '/company/projects/7/aixle_builder/start',
+      expect.objectContaining({ agentRuntime: 'claude_code' }),
+      expect.any(Object),
+    );
+  });
+
   it('posts the chosen model and project assets with the start request', async () => {
     const user = userEvent.setup();
     renderAuthedPage(<LandingPage />, {

--- a/app/frontend/pages/Projects/AixleBuilder/LandingPage.tsx
+++ b/app/frontend/pages/Projects/AixleBuilder/LandingPage.tsx
@@ -57,6 +57,7 @@ interface Props {
   sessions: Session[];
   activeSessionId: number | null;
   configuredAgents: string[];
+  defaultAgentRuntime?: string | null;
   assets: AssetOption[];
   agentModels?: AgentModelsEntry[];
 }
@@ -74,12 +75,19 @@ const LandingPage = () => {
     sessions,
     activeSessionId,
     configuredAgents,
+    defaultAgentRuntime,
     assets,
     agentModels = [],
   } = usePage<{ props: Props }>().props as unknown as Props;
   const { canExecute } = useProjectPermissions();
 
-  const [runtime, setRuntime] = useState<string | null>(configuredAgents[0] ?? null);
+  // The member's default agent for this company wins; the first configured
+  // credential is only a fallback (its order is whatever Postgres returns).
+  const [runtime, setRuntime] = useState<string | null>(
+    defaultAgentRuntime && configuredAgents.includes(defaultAgentRuntime)
+      ? defaultAgentRuntime
+      : (configuredAgents[0] ?? null),
+  );
   const [selectedModel, setSelectedModel] = useState<string | null>(null);
   const [selectedAssets, setSelectedAssets] = useState<string[]>([]);
   const [starting, setStarting] = useState(false);

--- a/app/frontend/pages/Projects/Workflows/BuilderPage.tsx
+++ b/app/frontend/pages/Projects/Workflows/BuilderPage.tsx
@@ -113,6 +113,7 @@ interface Props {
   agentModels?: AgentModelsEntry[];
   readOnly: boolean;
   configuredAgents: string[];
+  defaultAgentRuntime?: string | null;
   boardColumns?: { id: number; name: string; boundWorkflowName?: string | null }[];
 }
 
@@ -159,6 +160,7 @@ const BuilderPage = () => {
     agentModels: rawAgentModels,
     readOnly,
     configuredAgents,
+    defaultAgentRuntime,
     boardColumns,
   } = usePage<{ props: Props }>().props as unknown as Props;
 
@@ -755,6 +757,7 @@ const BuilderPage = () => {
           }))}
           projectId={project.id}
           configuredAgents={configuredAgents}
+          defaultAgentRuntime={defaultAgentRuntime}
           agentModels={agentModels}
           repositories={repositories}
           assets={assets}

--- a/app/frontend/pages/Projects/Workflows/WorkflowsPage.tsx
+++ b/app/frontend/pages/Projects/Workflows/WorkflowsPage.tsx
@@ -74,6 +74,7 @@ interface Props {
   assets?: NamedItem[];
   repositories?: NamedItem[];
   configuredAgents: string[];
+  defaultAgentRuntime?: string | null;
   agentModels?: AgentModelsEntry[];
 }
 
@@ -91,6 +92,7 @@ const WorkflowsPage = () => {
     assets: rawAssets,
     repositories: rawRepositories,
     configuredAgents,
+    defaultAgentRuntime,
     agentModels,
   } = usePage<{ props: Props }>().props as unknown as Props;
   const { canExecute } = useProjectPermissions();
@@ -553,6 +555,7 @@ const WorkflowsPage = () => {
           steps={runWorkflow.steps}
           projectId={project.id}
           configuredAgents={configuredAgents}
+          defaultAgentRuntime={defaultAgentRuntime}
           agentModels={agentModels}
           repositories={repositories}
           assets={assets}

--- a/app/frontend/shared/components/RunWorkflowModal.test.tsx
+++ b/app/frontend/shared/components/RunWorkflowModal.test.tsx
@@ -125,6 +125,38 @@ describe('RunWorkflowModal', () => {
     });
   });
 
+  it("preselects the member's default agent runtime rather than the first configured one", async () => {
+    renderModal({ configuredAgents: ['cursor_cli', 'claude_code'], defaultAgentRuntime: 'claude_code' });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Run Workflow' }));
+
+    await waitFor(() =>
+      expect(router.post).toHaveBeenCalledWith(
+        '/company/projects/7/workflow_runs',
+        expect.objectContaining({
+          workflowRun: expect.objectContaining({ agentRuntime: 'claude_code' }),
+        }),
+        expect.any(Object),
+      ),
+    );
+  });
+
+  it('falls back to the first configured agent when the default runtime has no credential here', async () => {
+    renderModal({ configuredAgents: ['cursor_cli'], defaultAgentRuntime: 'gemini_cli' });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Run Workflow' }));
+
+    await waitFor(() =>
+      expect(router.post).toHaveBeenCalledWith(
+        '/company/projects/7/workflow_runs',
+        expect.objectContaining({
+          workflowRun: expect.objectContaining({ agentRuntime: 'cursor_cli' }),
+        }),
+        expect.any(Object),
+      ),
+    );
+  });
+
   it('shows the empty fallback and disables Run when there are no configured agents', () => {
     renderModal({ configuredAgents: [] });
 

--- a/app/frontend/shared/components/RunWorkflowModal.tsx
+++ b/app/frontend/shared/components/RunWorkflowModal.tsx
@@ -44,6 +44,7 @@ interface RunWorkflowModalProps {
   steps: RunWorkflowStep[];
   projectId: number;
   configuredAgents: string[];
+  defaultAgentRuntime?: string | null;
   agentModels?: AgentModelsEntry[];
   repositories: NamedItem[];
   assets: NamedItem[];
@@ -117,12 +118,19 @@ export function RunWorkflowModal({
   steps,
   projectId,
   configuredAgents,
+  defaultAgentRuntime,
   agentModels = [],
   repositories,
   assets,
 }: RunWorkflowModalProps) {
   const [mode, setMode] = useState<ExecutionMode>('automatic');
-  const [agentRuntime, setAgentRuntime] = useState<string | null>(configuredAgents[0] ?? null);
+  // The member's default agent for this company wins; the first configured
+  // credential is only a fallback (its order is whatever Postgres returns).
+  const [agentRuntime, setAgentRuntime] = useState<string | null>(
+    defaultAgentRuntime && configuredAgents.includes(defaultAgentRuntime)
+      ? defaultAgentRuntime
+      : (configuredAgents[0] ?? null),
+  );
   const [selectedRepoIds, setSelectedRepoIds] = useState<string[]>([]);
   const [selectedAssetIds, setSelectedAssetIds] = useState<string[]>([]);
   const [customAutoRun, setCustomAutoRun] = useState<Record<number, boolean>>(() =>

--- a/app/models/company_membership.rb
+++ b/app/models/company_membership.rb
@@ -93,8 +93,12 @@ class CompanyMembership < ApplicationRecord
   # loading" gate rejects — while eager-loading it unconditionally trips the
   # opposite "AVOID eager loading" gate on every request that needs no
   # credentials. See User#active_memberships_with_company for the same tension.
+  # Newest first, id breaking ties: without an ORDER BY Postgres returns these
+  # in whatever order it likes, and #configured_agents drives which agent the
+  # run/session forms preselect when the member has no default credential.
   def credentials_scope
     AgentCredential.where(user_id: user_id, company_id: company_id)
+                   .order(created_at: :desc, id: :desc)
   end
 
   # Loaded once per instance: the current-user props serialise the credentials,

--- a/app/services/session_service.rb
+++ b/app/services/session_service.rb
@@ -72,7 +72,7 @@ class SessionService
                 workflow_run.agent_runtime.presence ||
                 run_membership(workflow_run)&.default_agent_runtime.presence ||
                 run_credentials(workflow_run).order(created_at: :desc).first&.agent_type ||
-                "cursor_cli"
+                "claude_code"
 
       run_model = workflow_run.shared_context&.dig("requested_model")
 

--- a/test/integration/web/company/projects/workflows_render_test.rb
+++ b/test/integration/web/company/projects/workflows_render_test.rb
@@ -34,4 +34,30 @@ class Web::Company::Projects::WorkflowsRenderTest < ActionDispatch::IntegrationT
     assert_response :success
     assert_inertia_page "Projects/Workflows/BuilderPage"
   end
+
+  # The run modal preselects this runtime. Without it the modal fell back to the
+  # first configured credential — an arbitrary row order, so a member whose
+  # default is Claude could get a Cursor run.
+  test "index carries the membership's default agent runtime for the run modal" do
+    create(:agent_credential, user: @user, company: @company, agent_type: "cursor_cli")
+    claude = create(:agent_credential, user: @user, company: @company, agent_type: "claude_code")
+    @user.company_memberships.sole.update!(default_agent_credential: claude)
+
+    get company_project_workflows_path(@project)
+
+    assert_inertia_page "Projects/Workflows/WorkflowsPage"
+    assert_inertia_props defaultAgentRuntime: "claude_code"
+  end
+
+  test "builder carries the membership's default agent runtime for the run modal" do
+    workflow = create(:workflow, scope: @project)
+    create(:agent_credential, user: @user, company: @company, agent_type: "cursor_cli")
+    claude = create(:agent_credential, user: @user, company: @company, agent_type: "claude_code")
+    @user.company_memberships.sole.update!(default_agent_credential: claude)
+
+    get builder_company_project_workflow_path(@project, workflow)
+
+    assert_inertia_page "Projects/Workflows/BuilderPage"
+    assert_inertia_props defaultAgentRuntime: "claude_code"
+  end
 end

--- a/test/models/company_membership_test.rb
+++ b/test/models/company_membership_test.rb
@@ -135,6 +135,20 @@ class CompanyMembershipTest < ActiveSupport::TestCase
     assert_equal [ legacy, oldest, newest ], @user.company_memberships.default_order.to_a
   end
 
+  # === configured_agents ordering ===
+
+  # The run/session forms preselect configured_agents.first when the member has
+  # no default credential, so an unordered scope made the choice a coin flip.
+  test "configured_agents lists this company's credentials newest first" do
+    membership = create(:company_membership, user: @user, company: @company)
+    travel_to 2.days.ago do
+      create(:agent_credential, user: @user, company: @company, agent_type: "cursor_cli")
+    end
+    create(:agent_credential, user: @user, company: @company, agent_type: "claude_code")
+
+    assert_equal %w[claude_code cursor_cli], membership.configured_agents
+  end
+
   # === cable disconnect on revoke ===
 
   test "revoking a membership disconnects the user's cable connections" do


### PR DESCRIPTION
## Problem

Starting a workflow manually ran the wrong agent: a member whose default credential is Claude got a Cursor run.

The run modal preselected `configuredAgents[0]`, and `CompanyMembership#configured_agents` came from a scope with no `ORDER BY` — so Postgres row order, not the member's choice, decided the runtime. That value is posted as `workflowRun.agentRuntime`, lands on `workflow_runs.agent_runtime`, and `SessionConfigResolver#resolve_agent_runtime` ranks the run override *above* the membership default. The backend chain was correct; the frontend was sending the wrong value into it.

## Changes

- `RunWorkflowModal` takes a `defaultAgentRuntime` prop and preselects it when the member holds that credential in this company; `configuredAgents[0]` stays as the fallback.
- `WorkflowsController#index` / `#builder` pass `default_agent_runtime` from `current_project_membership`, threaded through `WorkflowsPage` and `BuilderPage`.
- Same bug in the Aixle Builder landing page (`configuredAgents[0]`) — fixed the same way, with the matching prop from `AixleBuilderController`.
- `CompanyMembership#credentials_scope` now orders newest first (`created_at DESC, id DESC`), so the no-default fallback is deterministic and matches the resolver's "latest credential" rule.
- `SessionService.create_for_workflow_step` last-resort fallback `cursor_cli` → `claude_code`, matching `SessionConfigResolver`.

Existing runs are unaffected — this only changes what a new manual run preselects.

## Tests

- `RunWorkflowModal`: preselects the default runtime over the first configured one; falls back when the default has no credential in this company.
- `AixleBuilder/LandingPage`: starts with the default runtime.
- `workflows_render_test`: `defaultAgentRuntime` prop on both the index and builder pages.
- `company_membership_test`: `configured_agents` is ordered newest first.

`make check_all` green (backend 90.9%, frontend 78.35%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)