### PR TITLE
feat(mcp): add refresh_github_token session tool

### DIFF
--- a/app/services/internal_tools/refresh_github_token.rb
+++ b/app/services/internal_tools/refresh_github_token.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+module InternalTools
+  # refresh_github_token — re-mint this session's GitHub credential and rewrite
+  # the `origin` remote of every clone with it.
+  #
+  # Repositories are cloned at session start from
+  # `https://x-access-token:<token>@github.com/<owner>/<repo>.git` (see
+  # SessionContextService#inject_repositories). That token is a GitHub App
+  # installation token and GitHub expires it one hour after minting, so a session
+  # that outlives the hour fails its first push with a 403 and cannot recover on
+  # its own: the dead credential sits in `.git/config` and nothing inside the
+  # container can mint a replacement. This tool is the way back.
+  class RefreshGithubToken < Base
+    CLONE_ROOT = "/workspace/repo"
+
+    tool do
+      display_name "Refresh GitHub Token"
+      description "Re-mint the GitHub credential for the repositories cloned into this session and " \
+                  "rewrite each clone's `origin` remote with it. Use this when git push or fetch fails " \
+                  'with a 403, "Invalid username or password" or "could not read Username": the token ' \
+                  "baked into the clone URL is a GitHub App installation token that expires one hour " \
+                  "after the session starts, so a session that has been running longer than an hour " \
+                  "needs this before it can push. Run it, then retry the push — no re-clone and no " \
+                  "manual git remote surgery. GitLab clones do not expire and are left alone."
+      tags :repositories
+      inject_when :github_repositories_attached
+      user_attachable false
+      idempotent true
+      destructive false
+      input_schema({
+        type: "object",
+        required: [],
+        properties: {
+          repository: {
+            type: "string",
+            description: "Optional owner/repo (or bare repo name) to refresh. " \
+                         "Defaults to every GitHub repository attached to this session."
+          }
+        }
+      })
+    end
+
+    def execute
+      container_id = session.container_id
+      return error("This session has no running container — there is no clone to re-point.") if container_id.blank?
+
+      repos = target_repositories
+      return error(nothing_to_refresh_message) if repos.empty?
+
+      refreshed = []
+      failed = []
+      runtime = ContainerRuntime.build
+
+      repos.each do |repo|
+        outcome = refresh(repo, runtime, container_id)
+        outcome[:error] ? failed << outcome : refreshed << outcome
+      end
+
+      report(refreshed, failed)
+    end
+
+    private
+
+    def github_repositories
+      session.repositories.includes(:integration).select { |repo| repo.integration&.github? }
+    end
+
+    # `repository` accepts either form the agent has at hand: the full_name it
+    # sees in the context file, or the bare directory name under /workspace/repo.
+    def target_repositories
+      repos = github_repositories
+      filter = params[:repository].to_s.strip
+      return repos if filter.blank?
+
+      repos.select { |repo| repo.full_name.casecmp?(filter) || repo.repo_name.casecmp?(filter) }
+    end
+
+    def nothing_to_refresh_message
+      if params[:repository].present?
+        "No GitHub repository matching #{params[:repository]} is attached to this session. " \
+          "Attached GitHub repositories: #{github_repositories.map(&:full_name).presence&.join(', ') || 'none'}."
+      else
+        "No GitHub repository is attached to this session. Public and GitLab clones carry no " \
+          "expiring installation token, so there is nothing to refresh."
+      end
+    end
+
+    def refresh(repo, runtime, container_id)
+      return { repository: repo.full_name, error: "its integration is not active" } unless repo.integration.active?
+
+      token = mint_token(repo)
+      path = File.join(CLONE_ROOT, repo.repo_name)
+      result = runtime.exec(container_id, set_url_command(repo, path, token))
+      exit_code = result[2].to_i
+
+      return { repository: repo.full_name, path: path } if exit_code.zero?
+
+      { repository: repo.full_name,
+        error: "git remote set-url exited with #{exit_code}: #{scrub(Array(result[1]).join.strip, token)}" }
+    rescue Github::TokenService::ConfigurationError, Github::TokenService::AuthenticationError => e
+      { repository: repo.full_name, error: e.message }
+    end
+
+    # Scoped to the one repository: unlike the clone-time group token, a
+    # repository the installation can no longer reach fails only itself.
+    def mint_token(repo)
+      Github::TokenService.new(repo.integration).generate_installation_token(repositories: [ repo.repo_name ])
+    end
+
+    # `safe.directory` because the clone is owned by the container user while
+    # exec runs as root, and git refuses to touch a repository it considers
+    # foreign. The chown puts `.git/config` back under the agent's uid — git
+    # rewrites it through a lock file + rename, which would otherwise leave it
+    # owned by root and unwritable by the agent.
+    def set_url_command(repo, path, token)
+      safe_path = Shellwords.escape(path)
+      url = Shellwords.escape("https://x-access-token:#{token}@github.com/#{repo.full_name}.git")
+
+      [ "sh", "-c",
+        "git -c safe.directory=#{safe_path} -C #{safe_path} remote set-url origin #{url} && " \
+        "chown #{container_uid}:#{container_uid} #{safe_path}/.git/config" ]
+    end
+
+    # Same uid the clone was chowned to. An unknown agent_type raises rather than
+    # guessing elsewhere in the app; here the fallback is the shared adapter
+    # default, since a wrong owner is better than no refresh at all.
+    def container_uid
+      @container_uid ||= AgentCredentialsService.for(session.agent_type).adapter.container_uid
+    rescue ArgumentError
+      1001
+    end
+
+    # A token that leaks into an error string ends up in the agent transcript and
+    # the tool_results row — the one place the credential must never land.
+    def scrub(text, token)
+      return text if token.blank?
+
+      text.gsub(token, "[REDACTED]")
+    end
+
+    def report(refreshed, failed)
+      payload = {
+        refreshed: refreshed.map { |r| { repository: r[:repository], path: r[:path] } },
+        failed: failed.map { |r| { repository: r[:repository], error: r[:error] } },
+        expires_at: 1.hour.from_now.utc.iso8601,
+        next_step: "Retry the git push. The credential is good for one hour from now."
+      }
+
+      return error(payload.to_json) if refreshed.empty?
+
+      success(payload.to_json)
+    end
+  end
+end

--- a/app/services/tools/injection_rules.rb
+++ b/app/services/tools/injection_rules.rb
@@ -14,7 +14,13 @@ module Tools
       non_interactive_session: ->(ctx) { ctx.mode == "non_interactive" },
       # coder_* tools — surface through aixle-tools whenever the project has an
       # active Coder integration (mirrors how slack_post_message is gated).
-      coder_integration_connected: ->(ctx) { ctx.connected?(:coder) }
+      coder_integration_connected: ->(ctx) { ctx.connected?(:coder) },
+      # refresh_github_token — only sessions holding a GitHub clone carry the
+      # one-hour installation token that can expire mid-run.
+      github_repositories_attached: lambda { |ctx|
+        ctx.session.present? &&
+          ctx.session.repositories.includes(:integration).any? { |repo| repo.integration&.github? }
+      }
     }.freeze
 
     def self.fetch(rule)

--- a/app/services/tools/tag_catalog.rb
+++ b/app/services/tools/tag_catalog.rb
@@ -27,6 +27,7 @@ module Tools
       Entry.new(tag: :workflow_control, label: "Workflow control", ui_visible: false, presentation: :individual),
       Entry.new(tag: :async_results, label: "Async results", ui_visible: false, presentation: :individual),
       Entry.new(tag: :session_lifecycle, label: "Session lifecycle", ui_visible: false, presentation: :individual),
+      Entry.new(tag: :repositories, label: "Repositories", ui_visible: false, presentation: :individual),
       Entry.new(tag: :builder, label: "Aixle Builder", ui_visible: false, presentation: :individual)
     ].freeze
 

--- a/test/models/terminal_session_available_tools_test.rb
+++ b/test/models/terminal_session_available_tools_test.rb
@@ -73,6 +73,24 @@ class TerminalSessionAvailableToolsTest < ActiveSupport::TestCase
     refute_includes names, "mark_sub_step"
   end
 
+  # == refresh_github_token: auto-injected when a GitHub clone is attached ==
+
+  test "refresh_github_token is injected for a session holding a GitHub repository" do
+    integration = create(:integration, company: @company, connected_by: @user, status: :active)
+    session = create(:terminal_session, :agent_session, user: @user, project: @project)
+    session.repositories << create(:repository, integration: integration, scope: @project)
+
+    assert_includes session.available_tools.map(&:name), "refresh_github_token"
+  end
+
+  test "refresh_github_token is NOT injected without a GitHub repository" do
+    session = create(:terminal_session, :agent_session, user: @user, project: @project)
+    session.repositories << create(:repository, :public_source, full_name: "torvalds/linux",
+      scope: @project, clone_url: "https://github.com/torvalds/linux.git")
+
+    refute_includes session.available_tools.map(&:name), "refresh_github_token"
+  end
+
   # == System tools: explicitly attached ==
 
   test "system tool is NOT included unless explicitly selected" do

--- a/test/services/internal_tools/refresh_github_token_test.rb
+++ b/test/services/internal_tools/refresh_github_token_test.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InternalTools::RefreshGithubTokenTest < ActiveSupport::TestCase
+  setup do
+    @company     = create(:company)
+    @user        = create(:user, :admin, company: @company)
+    @project     = create(:project, company: @company, owner: @user)
+    @integration = create(:integration, company: @company, connected_by: @user, status: :active)
+    @repo        = create(:repository, full_name: "acme/my-app", integration: @integration, scope: @project)
+    @session     = create(:terminal_session, :agent_session, :running, user: @user, project: @project,
+                          agent_type: "claude_code")
+    @session.repositories << @repo
+
+    @runtime = stub_container_runtime
+    @tokens  = FakeGithub::TokenService.new(token: "ghs_fresh")
+    Github::TokenService.stubs(:new).returns(@tokens)
+  end
+
+  teardown { cleanup_runtime_overrides }
+
+  def run_tool(params = {})
+    InternalTools::RefreshGithubToken.new(params: params, session: @session).execute
+  end
+
+  test "re-points origin at a freshly minted token scoped to the repository" do
+    result = run_tool
+
+    assert_equal 0, result[:exit_code]
+
+    command = @runtime.execs.last.last
+    assert_match(%r{git -c safe\.directory=/workspace/repo/my-app -C /workspace/repo/my-app}, command)
+    assert_match(%r{remote set-url origin.*x-access-token:ghs_fresh@github\.com/acme/my-app\.git}, command)
+    assert_match(%r{chown 1001:1001 /workspace/repo/my-app/\.git/config}, command)
+
+    assert_equal [ { repositories: [ "my-app" ] } ],
+                 @tokens.calls_to(:generate_installation_token).map { |c| c.except(:method) }
+
+    payload = JSON.parse(result[:stdout])
+    assert_equal [ "acme/my-app" ], payload["refreshed"].map { |r| r["repository"] }
+    assert_empty payload["failed"]
+    assert_not_includes result[:stdout], "ghs_fresh"
+  end
+
+  test "refreshes every attached GitHub repository by default" do
+    other = create(:repository, full_name: "acme/infra", integration: @integration, scope: @project)
+    @session.repositories << other
+
+    result = run_tool
+    payload = JSON.parse(result[:stdout])
+
+    assert_equal %w[acme/infra acme/my-app], payload["refreshed"].map { |r| r["repository"] }.sort
+    assert_equal 2, @runtime.execs.size
+  end
+
+  test "the repository argument narrows the refresh to one clone, by full name or bare name" do
+    other = create(:repository, full_name: "acme/infra", integration: @integration, scope: @project)
+    @session.repositories << other
+
+    payload = JSON.parse(run_tool("repository" => "acme/infra")[:stdout])
+    assert_equal [ "acme/infra" ], payload["refreshed"].map { |r| r["repository"] }
+
+    payload = JSON.parse(run_tool("repository" => "my-app")[:stdout])
+    assert_equal [ "acme/my-app" ], payload["refreshed"].map { |r| r["repository"] }
+  end
+
+  test "an unknown repository argument lists what is actually attached" do
+    result = run_tool("repository" => "acme/nope")
+
+    assert_equal 1, result[:exit_code]
+    assert_match(/No GitHub repository matching acme\/nope/, result[:stderr])
+    assert_match(/acme\/my-app/, result[:stderr])
+  end
+
+  test "errors when the session has no container to re-point" do
+    @session.update!(container_id: nil)
+
+    result = run_tool
+
+    assert_equal 1, result[:exit_code]
+    assert_match(/no running container/, result[:stderr])
+    assert_empty @runtime.execs
+  end
+
+  test "public and GitLab clones carry no expiring token, so there is nothing to refresh" do
+    @session.repositories.destroy_all
+    gitlab = create(:integration, :gitlab, :active, company: @company, connected_by: @user)
+    @session.repositories << create(:repository, full_name: "acme/gl", integration: gitlab, scope: @project,
+                                    clone_url: "https://gitlab.com/acme/gl.git")
+    @session.repositories << create(:repository, :public_source, full_name: "torvalds/linux", scope: @project,
+                                    clone_url: "https://github.com/torvalds/linux.git")
+
+    result = run_tool
+
+    assert_equal 1, result[:exit_code]
+    assert_match(/No GitHub repository is attached/, result[:stderr])
+    assert_empty @runtime.execs
+  end
+
+  test "a repository whose token cannot be minted fails alone and does not stop the others" do
+    other = create(:repository, full_name: "acme/gone", integration: @integration, scope: @project)
+    @session.repositories << other
+    @tokens = FakeGithub::TokenService.new(token: "ghs_fresh", unreachable: [ "gone" ])
+    Github::TokenService.stubs(:new).returns(@tokens)
+
+    result = run_tool
+    payload = JSON.parse(result[:stdout])
+
+    assert_equal 0, result[:exit_code]
+    assert_equal [ "acme/my-app" ], payload["refreshed"].map { |r| r["repository"] }
+    assert_equal [ "acme/gone" ], payload["failed"].map { |r| r["repository"] }
+    assert_match(/does not exist or is not accessible/, payload["failed"].first["error"])
+  end
+
+  test "an inactive integration is reported rather than called" do
+    @integration.update!(status: :inactive)
+
+    result = run_tool
+
+    assert_equal 1, result[:exit_code]
+    assert_match(/integration is not active/, result[:stderr])
+    assert_not @tokens.called?(:generate_installation_token)
+    assert_empty @runtime.execs
+  end
+
+  test "a failing git command surfaces its stderr with the token redacted" do
+    @runtime.fail_exec("remote set-url", stderr: "fatal: 'origin' does not appear to be a git repository ghs_fresh", exit_code: 128)
+
+    result = run_tool
+
+    assert_equal 1, result[:exit_code]
+    payload = JSON.parse(result[:stderr])
+    assert_equal [ "acme/my-app" ], payload["failed"].map { |r| r["repository"] }
+    assert_match(/exited with 128/, payload["failed"].first["error"])
+    assert_match(/\[REDACTED\]/, payload["failed"].first["error"])
+    assert_not_includes result[:stderr], "ghs_fresh"
+  end
+end

--- a/test/services/tools/registry_test.rb
+++ b/test/services/tools/registry_test.rb
@@ -39,7 +39,8 @@ class Tools::RegistryTest < ActiveSupport::TestCase
   test "injectable covers the auto-injection rule groups" do
     rules = Tools::Registry.injectable.flat_map(&:inject_rules).uniq.sort
 
-    assert_equal %i[coder_integration_connected container_tools_present non_interactive_session workflow_step_session], rules
+    assert_equal %i[coder_integration_connected container_tools_present github_repositories_attached
+                    non_interactive_session workflow_step_session], rules
   end
 
   test "grouping axes cover every definition" do

--- a/test/services/tools/tag_catalog_test.rb
+++ b/test/services/tools/tag_catalog_test.rb
@@ -8,7 +8,7 @@ class Tools::TagCatalogTest < ActiveSupport::TestCase
     assert Tools::TagCatalog.group?(:board)
     assert_equal "Board management", Tools::TagCatalog.label(:board)
 
-    %i[workflow_control async_results session_lifecycle builder slack coder].each do |tag|
+    %i[workflow_control async_results session_lifecycle repositories builder slack coder].each do |tag|
       assert_not Tools::TagCatalog.ui_visible?(tag), "#{tag} must stay out of the picker"
     end
   end

--- a/test/support/fakes/fake_runtime.rb
+++ b/test/support/fakes/fake_runtime.rb
@@ -30,6 +30,14 @@ module ContainerRuntime
       @agent_type = agent_type
       @fs = filesystem || build_filesystem(agent_type)
       @execs = []
+      @exec_failures = []
+    end
+
+    # Command failure injection: register a substring of the command line and
+    # the failure to answer it with. Everything else keeps succeeding, so the
+    # default behavior is unchanged for callers that never call this.
+    def fail_exec(substring, stderr: "", exit_code: 1)
+      @exec_failures << { substring: substring, stderr: stderr, exit_code: exit_code }
     end
 
     # -- Lifecycle ------------------------------------------------------------
@@ -70,6 +78,9 @@ module ContainerRuntime
 
     def exec(_id, cmd, _opts = {})
       @execs << cmd
+      failure = @exec_failures.find { |f| command_string(cmd).include?(f[:substring]) }
+      return [ [ "" ], [ failure[:stderr] ], failure[:exit_code] ] if failure
+
       [ [ resolve_command(cmd) ], [ "" ], 0 ]
     end
 
@@ -111,8 +122,12 @@ module ContainerRuntime
 
     # Command router — maps the handful of shell commands the strategies run to
     # deterministic output backed by the virtual FS (ports StubSupport.resolve_command).
+    def command_string(cmd)
+      cmd.is_a?(Array) ? cmd.join(" ") : cmd.to_s
+    end
+
     def resolve_command(cmd)
-      cmd_str = cmd.is_a?(Array) ? cmd.join(" ") : cmd.to_s
+      cmd_str = command_string(cmd)
 
       return "open\n" if cmd_str.include?("echo 'open'")
       return "0\n" if cmd_str.include?(".agent_done")


### PR DESCRIPTION
## Why

Repositories are cloned into a session from `https://x-access-token:<token>@github.com/<owner>/<repo>.git`, and that token is a **GitHub App installation token — GitHub expires it one hour after minting**. A session that runs longer than an hour fails its first `git push` with a 403 and cannot recover on its own: the dead credential lives in `.git/config`, and nothing inside the container can mint a replacement. Today that means the work is stranded.

## What

A session-only platform tool, `refresh_github_token`:

- mints a fresh installation token **per repository** (unlike the clone-time group token, one unreachable repo then fails alone instead of taking the batch down)
- rewrites the clone's remote inside the container:
  `git -c safe.directory=<path> -C <path> remote set-url origin <fresh-url> && chown <uid>:<uid> <path>/.git/config`
  - `safe.directory` because exec runs as root while the clone is owned by the container user, and git otherwise refuses to touch a repository it considers foreign
  - the `chown` because git rewrites config through a lock file + rename, which would leave it root-owned and unwritable by the agent
- optional `repository` argument (full name or bare directory name); defaults to every GitHub repository attached to the session
- returns `{refreshed, failed, expires_at, next_step}`; **the token never appears in the output**, and is redacted out of git's stderr — that output lands in the agent transcript and the `tool_results` row
- GitLab and public clones carry no expiring token and are left alone

The description tells the agent exactly when to reach for it: push/fetch failing with a 403, `Invalid username or password`, or `could not read Username` after a long session — run it, then retry the push. No re-clone, no manual remote surgery.

## Wiring

- new injection rule `github_repositories_attached` — the tool auto-injects only into sessions that actually hold a GitHub clone (covers both `agent_session` and `workflow_step`)
- `user_attachable false`, tag `:repositories` (hidden in the picker, registered in `TagCatalog`)

## Tests

- `test/services/internal_tools/refresh_github_token_test.rb` — happy path (command shape, scoped token request, no token in output), multi-repo, `repository` filter by both forms, unknown filter, no container, nothing-to-refresh, per-repo token failure isolating itself, inactive integration, failing git command with stderr redaction
- two injection tests in `terminal_session_available_tools_test.rb`
- `FakeRuntime` gains an opt-in `fail_exec` knob so a non-zero exec is exercised through the canonical fake rather than an ad-hoc runtime mock; default behavior is unchanged

`docker compose exec -T web make check_all` is green (backend coverage 90.94%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)