### PR TITLE
fix(mcp): keep refreshable credentials active

### DIFF
--- a/app/controllers/web/company/projects/mcp_servers_controller.rb
+++ b/app/controllers/web/company/projects/mcp_servers_controller.rb
@@ -2,12 +2,13 @@
 
 class Web::Company::Projects::MCPServersController < Web::Company::Projects::ApplicationController
   def index
-    # includes(:oauth_credentials): MCPServerResource#oauth_status reads the loaded
-    # association in memory, so the status column is not an N+1 across the list.
-    # :manual_oauth_client for the same reason — the form needs to know whether one
-    # is configured, on every row.
+    # includes(oauth_credentials: :oauth_client): MCPServerResource#oauth_status
+    # reads the loaded association in memory — and asks each credential whether it
+    # is refreshable, which touches its oauth_client — so the status column is not
+    # an N+1 across the list. :manual_oauth_client for the same reason — the form
+    # needs to know whether one is configured, on every row.
     servers = MCPServer.visible_for_project(current_project)
-                       .includes(:oauth_credentials, :manual_oauth_client)
+                       .includes({ oauth_credentials: :oauth_client }, :manual_oauth_client)
                        .order(kind: :asc, created_at: :desc)
     config_items = ConfigItem.visible_for_project(current_project).pluck(:name)
 

--- a/app/resources/mcp_server_resource.rb
+++ b/app/resources/mcp_server_resource.rb
@@ -131,10 +131,11 @@ class MCPServerResource < ApplicationResource
   end
 
   # Connection status for the CURRENT viewer: nil (non-oauth) | "pending" (no
-  # credential yet) | "active" | "expiring" (near expiry) | "error". For per_user
-  # servers the identity is the viewer (passed as params[:user]); for shared servers
-  # it is the server's scope owner. When no user is supplied a per_user server reads
-  # as "pending" (the viewer must connect).
+  # credential yet) | "active" | "expiring" (near expiry with no refresh token, so
+  # only a manual re-connect can save it) | "error". For per_user servers the
+  # identity is the viewer (passed as params[:user]); for shared servers it is the
+  # server's scope owner. When no user is supplied a per_user server reads as
+  # "pending" (the viewer must connect).
   typelize :string?
   attribute :oauth_status do |server|
     next nil unless server.auth_type_oauth?
@@ -151,6 +152,15 @@ class MCPServerResource < ApplicationResource
                  .max_by(&:updated_at)
     next "pending" if cred.nil?
     next "error" if cred.error?
+
+    # A refreshable credential never needs the viewer's attention: the */5 sweep and
+    # the session-start injection both renew it (Oauth::TokenService), and a refresh
+    # that keeps failing escalates to "error" above. Reporting near-expiry for those
+    # made every 1h-token provider (Railway) read "Connect" for the last ~20 minutes
+    # of each token's life — a healthy connection that looked permanently broken.
+    # "expiring" is reserved for a credential with nothing to refresh from, where the
+    # viewer genuinely must re-connect before the access token lapses.
+    next "active" if cred.refreshable?
 
     cred.expired?(30.minutes) ? "expiring" : "active"
   end

--- a/test/resources/mcp_server_resource_test.rb
+++ b/test/resources/mcp_server_resource_test.rb
@@ -45,6 +45,43 @@ class MCPServerResourceTest < ActiveSupport::TestCase
     assert_equal "pending", without["oauthStatus"]
   end
 
+  # Near-expiry with a refresh token is the sweep's problem, not the viewer's — the
+  # badge stays "active". The old behavior surfaced "expiring" here, which on a
+  # 1h-token provider (Railway) read as a dead connection for the last ~20 minutes
+  # of every token's life.
+  test "oauth_status stays active near expiry while the credential can be refreshed" do
+    server = create(:mcp_server, scope: @project, kind: :custom, transport: :sse,
+                    auth_type: :oauth)
+    OauthCredential.create!(
+      owner: @project, oauth_client: @client, mcp_server: server, provider: "mcp:sentry",
+      status: :active, access_token: "tok", refresh_token: "rt", expires_at: 5.minutes.from_now
+    )
+
+    assert_equal "active", MCPServerResource.new(server, params: { user: @user }).to_h["oauthStatus"]
+  end
+
+  test "oauth_status is expiring near expiry when there is nothing to refresh from" do
+    server = create(:mcp_server, scope: @project, kind: :custom, transport: :sse,
+                    auth_type: :oauth)
+    OauthCredential.create!(
+      owner: @project, oauth_client: @client, mcp_server: server, provider: "mcp:sentry",
+      status: :active, access_token: "tok", expires_at: 5.minutes.from_now
+    )
+
+    assert_equal "expiring", MCPServerResource.new(server, params: { user: @user }).to_h["oauthStatus"]
+  end
+
+  test "oauth_status is error once the credential is escalated" do
+    server = create(:mcp_server, scope: @project, kind: :custom, transport: :sse,
+                    auth_type: :oauth)
+    OauthCredential.create!(
+      owner: @project, oauth_client: @client, mcp_server: server, provider: "mcp:sentry",
+      status: :error, access_token: "tok", refresh_token: "rt", expires_at: 1.hour.ago
+    )
+
+    assert_equal "error", MCPServerResource.new(server, params: { user: @user }).to_h["oauthStatus"]
+  end
+
   test "oauth_status is nil for non-oauth servers" do
     server = create(:mcp_server, scope: @project, kind: :custom, transport: :sse)
     hash = MCPServerResource.new(server, params: { user: @user }).to_h


### PR DESCRIPTION
## Problem

The Connectors page shows a yellow **Connect** badge for OAuth servers whose credential is within 30 minutes of expiry (`oauth_status: "expiring"`), but the refresh sweep (`Oauth::TokenService`, `*/5` schedule) deliberately refreshes only inside a 10-minute skew. On a provider that issues 1-hour access tokens — Railway MCP — this means a perfectly healthy, auto-refreshing connection reads as disconnected for the last ~20 minutes of every token's life, roughly a third of the time. Each earlier fix in this area (#35 authorize-URL query merge, #38 `prompt=consent` for the refresh token) repaired a real breakage underneath, but this cosmetic window kept reporting "still broken" and trained people to re-consent by hand every hour.

## Change

- `MCPServerResource#oauth_status`: a non-errored credential that **can** be refreshed (refresh token + client present) now always reports `"active"` — near-expiry is the sweep's job, not the viewer's. `"expiring"` is reserved for a credential with nothing to refresh from, where a manual re-connect genuinely is the only fix. `"pending"` / `"error"` semantics are unchanged, and a refresh that keeps failing still escalates to `"error"` via the existing `MAX_REFRESH_FAILURES` path.
- `MCPServersController#index`: eager-load extended to `oauth_credentials: :oauth_client` since `refreshable?` touches the client (keeps the list N+1-free).

No frontend changes — the badge map already renders these states; the false-positive state simply no longer occurs.

## Tests

- resource: refreshable credential near expiry → `active`; no refresh token near expiry → `expiring`; escalated credential → `error`
- `docker compose exec -T web make check_all` green (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
