### PR TITLE
build: stop duplicating /app to change its owner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,27 @@ RUN set -eux; \
     rm -rf /tmp/coder-extract /tmp/coder.tar.gz && \
     /usr/local/bin/coder version
 
-RUN mkdir /app
+# The app user (L-22) exists from here on, and everything under /app is written
+# as that user rather than written as root and handed over at the end. A closing
+# `chown -R app:app /app` reads cheap and is not: changing an owner rewrites every
+# file underneath it into a fresh layer, so the image carried a second copy of
+# most of node_modules. Measured on arm64: that one layer was 536 MB and the
+# image 4.04 GB, against 3.50 GB with it gone. Every build wrote those 536 MB,
+# every cache export stored them, and every CI job that materialises the image
+# moves them.
+RUN addgroup -S app && adduser -S app -G app
+
+# Corepack installs globally, so it has to happen while we are still root.
+RUN npm install -g corepack@latest && corepack enable
+
+RUN mkdir /app && chown app:app /app
 WORKDIR /app
+USER app
 
-COPY Gemfile Gemfile.lock .ruby-version ./
+COPY --chown=app:app Gemfile Gemfile.lock .ruby-version ./
 
+# The ruby base image leaves GEM_HOME mode 1777 precisely so unprivileged users
+# can install into it, so both of these work as `app`.
 RUN gem install bundler -v 4.0.11
 RUN bundle config set --local frozen true && \
     bundle install && \
@@ -41,14 +57,12 @@ RUN bundle config set --local frozen true && \
 
 # Yarn is provisioned via Corepack driven by the "packageManager" field in
 # package.json — the Yarn release is NOT vendored into the repo.
-RUN npm install -g corepack@latest && corepack enable
-
-COPY package.json yarn.lock .yarnrc.yml ./
+COPY --chown=app:app package.json yarn.lock .yarnrc.yml ./
 
 RUN corepack install
 RUN yarn install --immutable
 
-COPY . /app
+COPY --chown=app:app . /app
 
 ENV PATH=/app/bin:/app/node_modules/.bin:$PATH
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
@@ -77,7 +91,10 @@ RUN RAILS_SECRET_KEY_BASE=secret \
     VITE_RUBY_ASSET_HOST="${ASSET_HOST}" \
     rails assets:precompile
 
-RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
+# Back to root for the entrypoint: bin/run-as-app fixes ownership on the
+# bundle_cache and app_home volumes, which are root-owned on first mount, before
+# dropping to `app` with su-exec.
+USER root
 
 ENTRYPOINT ["bin/run-as-app"]
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]


### PR DESCRIPTION
## Why

The image ends with

```dockerfile
RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
```

Changing an owner rewrites every file underneath into a fresh layer, so the image carries a second copy of most of `node_modules`. Built both versions on arm64 to measure it rather than guess:

| | layer | image |
|---|---|---|
| `develop` | `chown -R app:app /app` — **536 MB** | 4.04 GB |
| this branch | `USER root` — 0 B | **3.50 GB** |

Every build writes those 536 MB, every cache export stores them, and every CI job that materialises the image moves them — twice per run, once per check job.

## What changed

Create the user before anything lands in `/app`, drop to it for the dependency installs, and let each `COPY` set its own ownership. `npm install -g corepack` stays as root because it installs globally; `gem install bundler` and `bundle install` work as `app` because the ruby base image leaves `GEM_HOME` mode 1777 for exactly this.

The build returns to root at the end. `bin/run-as-app` checks `id -u = 0` and fixes ownership on the `bundle_cache` and `app_home` volumes — root-owned on first mount — before `su-exec`'ing down to `app`.

No stages, no restructuring beyond the reordering. 23 lines added, 7 removed, most of them comments.

## Verification

Built locally and ran the full suite in the resulting image, against its own Postgres in an isolated compose project:

```
=== Summary ===
  [OK]   brakeman
  [OK]   eslint
  [OK]   fe-test
  [OK]   rails-test
  [OK]   rubocop
  [OK]   system-test
  [OK]   typescript
  [OK]   vite-build
```

`system-test` is the one that matters most here — it is the check that actually exercises file permissions under the `app` user end to end. Ownership in the built image:

```
drwxr-xr-x  app app  /app
drwxr-xr-x  app app  /app/node_modules
drwxr-xr-x  app app  /app/public
```

and the container still starts as root, so the entrypoint's `su-exec` path is unchanged.

## Scope

This is also the production image (`images.yml` builds it with no `--target`), so the change ships to the runtime image as well as the test one. The end state is identical — every path under `/app` is owned by `app` either way — it is only reached without writing a duplicate of the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
