### PR TITLE
ci: read the layer cache from GHCR and stop gating the checks on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ on:
 permissions:
   contents: read
 
+env:
+  # Buildx layer cache for the test image. Its own package rather than a tag on
+  # the runtime image's, so the other images published by images.yml can add
+  # their own tags beside `:web` later.
+  BUILD_CACHE: ghcr.io/aixlehq/flow-buildcache:web
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   # Superseding a pull request's run is free — only the tip of a branch under
@@ -26,25 +32,40 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
-  build-image:
-    name: Build Test Image
-    # Builds the test image once per run to populate the buildx layer cache, which
-    # the two check jobs then read instead of each compiling gems and assets from
-    # scratch. Measured on 31041703132, before this job existed: the same image was
-    # built twice in parallel, 638s in the backend job and 473s in the frontend one
-    # — 18 of the run's 24 machine-minutes. Two concurrent builds writing one
-    # `type=gha` scope cannot warm each other, and `mode=max` on an 18-layer,
-    # 1.45 GB image also churns against the repository's 10 GB cache limit.
+  build-cache:
+    name: Refresh Layer Cache
+    # Maintains the layer cache that the check jobs read, and nothing declares
+    # `needs:` on it. That is the point: the check jobs read whatever the last
+    # develop push published and rebuild only the layers below `COPY . /app`,
+    # which is seconds of work. Gating both of them on a fresh build instead
+    # cost 2m36s of pure wall clock on every run (31254450213), to save a
+    # rebuild that was never expensive.
     #
-    # Deliberately not sharing the image itself. Pushing it to GHCR under a
-    # run-scoped tag would be faster, but pull requests from forks get a read-only
-    # token and no package write, so external contributions — the point of a public
-    # repository — would need a second, untested code path. A `docker save`
-    # artifact moves 1.45 GB twice and gives most of the saving back.
+    # Only develop pushes write. A pull request's own layers are read by nothing
+    # else, and two check jobs writing one cache in parallel is what made the
+    # cache useless in the first place.
+    #
+    # The cache lives in GHCR, not the Actions cache. The Actions cache is
+    # capped at 10 GB per repository and this image alone filled it — measured
+    # 10.6 GB across 255 entries on 2026-08-08 — and past the ceiling GitHub
+    # evicts by least-recent use, which reaches entries a running job still
+    # depends on. GHCR is unmetered for public repositories, and a public
+    # package is readable anonymously, so a fork's pull request reads the same
+    # cache we do without holding any token.
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@v7
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -53,7 +74,7 @@ jobs:
             [registry."docker.io"]
               mirrors = ["mirror.gcr.io"]
 
-      - name: Warm the layer cache
+      - name: Publish the layer cache
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -64,12 +85,13 @@ jobs:
             APP_VERSION=ci
             AUTHOR_NAME=github-actions
             AUTHOR_EMAIL=github-actions@users.noreply.github.com
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.BUILD_CACHE }}
+          # image-manifest + oci-mediatypes: GHCR rejects the default cache
+          # manifest shape and only accepts one written as an OCI image manifest.
+          cache-to: type=registry,ref=${{ env.BUILD_CACHE }},mode=max,image-manifest=true,oci-mediatypes=true
 
   be-checks:
     name: Backend Checks
-    needs: build-image
     uses: ./.github/workflows/code-check.yml
     with:
       # rails-test + rubocop + brakeman (Ruby). Needs the DB for the Rails test suite.
@@ -82,7 +104,6 @@ jobs:
 
   fe-checks:
     name: Frontend Checks
-    needs: build-image
     uses: ./.github/workflows/code-check.yml
     with:
       # eslint + tsc, then Vitest on its own (backendless, no DB needed).

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -40,6 +40,9 @@ permissions:
 
 env:
   COMPOSE_FILE: docker-compose.ci.yml
+  # Written by ci.yml's build-cache job on develop pushes; read here, read-only,
+  # by every run including forks'. Kept in step with the ref in that workflow.
+  BUILD_CACHE: ghcr.io/aixlehq/flow-buildcache:web
 
 jobs:
   check:
@@ -95,14 +98,16 @@ jobs:
               mirrors = ["mirror.gcr.io"]
 
       - name: Build test image
-        # Materialised here rather than pulled from a registry: the image must be
-        # available to fork pull requests, which get no registry credentials. The
-        # layers themselves come from the cache that ci.yml's build-image job wrote
-        # earlier in this run, so this is a load rather than a real build.
+        # Materialised here rather than pulled whole from a registry: the image
+        # has to be available to fork pull requests, which get a read-only token
+        # and so cannot be handed a run-scoped tag someone pushed for them. Its
+        # layers do come from a registry — everything up to `COPY . /app` is
+        # imported from the cache the last develop push wrote, leaving this job
+        # to build only the handful of layers that changed with the commit.
         #
-        # Read-only on purpose — no cache-to. Two check jobs writing the same
-        # `type=gha` scope in parallel is what made the cache useless before, and it
-        # churns the repository's 10 GB cache budget for no gain.
+        # Read-only on purpose, no cache-to. Two check jobs writing one cache in
+        # parallel cannot warm each other, and ci.yml's build-cache job already
+        # owns the write.
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -112,7 +117,11 @@ jobs:
             APP_VERSION=ci
             AUTHOR_NAME=github-actions
             AUTHOR_EMAIL=github-actions@users.noreply.github.com
-          cache-from: type=gha
+          # No login step: the package is public, so this reads anonymously and
+          # a fork's run gets the same cache. Until the package is made public
+          # after its first push, or if it is ever unreachable, buildx warns and
+          # builds from scratch — a cache miss here is slow, never fatal.
+          cache-from: type=registry,ref=${{ env.BUILD_CACHE }}
 
       - name: Start database
         if: ${{ inputs.needs-db }}


### PR DESCRIPTION
## Why

Both check jobs declared `needs: build-image`, so every run spent 2m36s waiting on a job whose only product was a warm `type=gha` cache ([31254450213](https://github.com/AixleHQ/flow/actions/runs/31254450213)). What that bought was a rebuild of the three layers below `COPY . /app` — `COPY` 3.1s, `assets:precompile` 11.7s, the user setup 34.5s. Seconds of work, gated behind minutes of waiting.

The gate existed because both check jobs used to write the same `type=gha` scope in parallel, and two concurrent writers cannot warm each other. Only the *writing* had to be centralised, though — the reading never did.

Two further problems with keeping it in the Actions cache:

- **It does not fit.** The cache is capped at 10 GB per repository; measured 10.6 GB across 255 entries on 2026-08-08, this image alone. Past the ceiling GitHub evicts by least-recent use, which reaches entries a running job still depends on. #64 reclaims the dead half; this stops the live half from going there at all.
- **It is slow.** The `Build test image` step spent most of its time moving cached bytes, not building.

## What changed

`build-cache` replaces `build-image`: it writes `ghcr.io/aixlehq/flow-buildcache:web` and **nothing declares `needs:` on it**. It runs only on develop pushes — a pull request's own layers are read by nothing else.

The check jobs start with the run and import from that ref read-only, rebuilding only what the commit changed.

```
before:  build-image (2m36s) ──> be-checks
                             └─> fe-checks

after:   be-checks       (immediately)
         fe-checks       (immediately)
         build-cache     (develop pushes only, gates nothing)
```

The cache gets its own package rather than a tag on `flow-web`, so the other images in `images.yml` can add tags beside `:web` later.

## Forks

The comment this replaces ruled out a registry because "pull requests from forks get a read-only token and no package write". That is true of *pushing* and irrelevant to *pulling* — a public GHCR package is readable with no credentials at all:

```
$ curl -s "https://ghcr.io/token?scope=repository:aixlehq/flow-web:pull&service=ghcr.io" | jq -r .token
$ curl -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" \
      https://ghcr.io/v2/aixlehq/flow-web/manifests/latest
200
```

So there is one code path, and a fork's run reads the same cache we do. There is no login step in `code-check.yml` on purpose.

## Activation

`flow-buildcache` does not exist yet. GHCR creates a package private on first push, so the sequence is:

1. Merge this. **The run on this pull request itself will be slow** — the ref 404s, both check jobs build cold in parallel, which is the pre-`build-image` behaviour and takes ~10 minutes. It should still be green; a cache miss makes buildx warn and build from scratch, never fail.
2. The first develop push after the merge creates `flow-buildcache`, private.
3. Flip it to public.

Until step 3, **no run gets the cache — ours included**, not just forks'. There is no login step anywhere in the read path, so every run reads anonymously and a private package is unreachable to all of them. That is deliberate: it means our own runs exercise exactly the path a fork takes, rather than us testing an authenticated path and forks silently getting a cold build nobody notices. Nothing is broken while step 3 is pending, only uniformly slow.

One thing this trades away: cache reads now go out as anonymous GHCR pulls from runner IPs that every GitHub-hosted runner shares. That is the same shape of exposure that made this repository route Docker Hub through `mirror.gcr.io`. GHCR's anonymous limits are more generous and these pulls stay inside GitHub's own network, but I have not confirmed the policy. If it ever bites, the fix is a login step gated to non-fork runs — at the cost of the uniformity above.

## Measurement

Numbers to compare after step 3, against 31254450213 (`Build test image`: backend 1m41s, frontend 1m47s, plus the 2m36s gate). Worth reading alongside #63, which cut the same step's export path, and #65, which takes 536 MB out of the image being moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
