### PR TITLE
feat(personal-mcp): add delete_board_task

### DIFF
--- a/app/services/personal_tools/delete_board_task.rb
+++ b/app/services/personal_tools/delete_board_task.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module PersonalTools
+  class DeleteBoardTask < Base
+    tool do
+      display_name "Delete Board Task"
+      description "Permanently delete a board task with its comments, assets and gates. " \
+                  "Irreversible — prefer archive_board_task unless the user asked to delete. " \
+                  "Rejected while the task has active workflow runs."
+      audience :user
+      tags :board
+      param :project_id, type: :integer, description: "Project id.", required: true
+      param :task_id, type: :integer, description: "Board task id.", required: true
+    end
+
+    def execute
+      project = find_project!
+      authorize!(project.board, :destroy?, policy: Web::Company::Projects::Board::TasksPolicy, project: project)
+      task = project.board&.board_tasks&.find_by(id: params[:task_id])
+      return error("Task not found on this project's board") unless task
+      # A run outlives its task (workflow_runs are nullified, not destroyed), so
+      # deleting mid-run would leave a live run with nothing to report back to.
+      return error(active_runs_message(task)) if task.workflow_runs.active.exists?
+
+      title = task.title
+      # Through TaskService, so the board activity feed records the deletion the
+      # same way the UI's delete action does.
+      TaskService.destroy(task: task, actor: user)
+      return error("Failed to delete task: #{task.errors.full_messages.to_sentence}") unless task.destroyed?
+
+      success(deleted_task_id: params[:task_id].to_i, title: title)
+    end
+
+    private
+
+    def active_runs_message(task)
+      "Cannot delete '#{task.title}' — it has active workflow runs; cancel them first (cancel_workflow_run)"
+    end
+  end
+end

--- a/app/services/tools/personal_mcp_guides.rb
+++ b/app/services/tools/personal_mcp_guides.rb
@@ -192,6 +192,10 @@ module Tools
             project-admin). A column with tasks cannot be deleted.
           - `create_board_task` puts work on it; `move_board_task` between
             columns is what a column trigger reacts to.
+          - `archive_board_task` takes a card off the board reversibly (and
+            puts it back with `archived: false`); `delete_board_task` destroys
+            it with its comments, assets and gates. Archive unless the user
+            asked to delete.
 
           ## 8. The workflow
           - Read the `build_workflow` prompt for the full sequence and

--- a/test/integration/personal_mcp_board_test.rb
+++ b/test/integration/personal_mcp_board_test.rb
@@ -168,6 +168,45 @@ class PersonalMCPBoardTest < ActionDispatch::IntegrationTest
     assert_nil @task.reload.archived_at
   end
 
+  test "delete_board_task destroys the task and its comments" do
+    create(:task_comment, board_task: @task, author: @user)
+
+    body = call_tool("delete_board_task", { project_id: @project.id, task_id: @task.id })
+    assert_not tool_error?(body)
+    assert_equal @task.id, payload(body)["deleted_task_id"]
+    assert_not BoardTask.exists?(@task.id)
+    assert_empty TaskComment.where(board_task_id: @task.id)
+  end
+
+  test "delete_board_task is rejected while the task has an active workflow run" do
+    create(:workflow_run, :running, project: @project, board_task: @task, user: @user)
+
+    body = call_tool("delete_board_task", { project_id: @project.id, task_id: @task.id })
+    assert tool_error?(body)
+    assert_match(/active workflow runs/i, body.dig("result", "content").map { |c| c["text"] }.join(" "))
+    assert BoardTask.exists?(@task.id)
+  end
+
+  test "delete_board_task requires write access" do
+    viewer = create(:user, :viewer, company: @company)
+    @project.add_collaborator(viewer)
+    vtoken = viewer.regenerate_mcp_token!
+
+    body = call_tool("delete_board_task", { project_id: @project.id, task_id: @task.id }, token: vtoken)
+    assert tool_error?(body)
+    assert_match(/not allowed/i, body.dig("result", "content").first["text"])
+    assert BoardTask.exists?(@task.id)
+  end
+
+  test "delete_board_task cannot reach another company's task" do
+    other = foreign_task
+
+    body = call_tool("delete_board_task",
+                     { project_id: other.board.project.id, task_id: other.id })
+    assert tool_error?(body)
+    assert BoardTask.exists?(other.id)
+  end
+
   test "list_project_members returns assignable users with roles" do
     member = create(:user, company: @company)
     @project.add_collaborator(member)


### PR DESCRIPTION
## Why

`archive_board_task` shipped in #52, but there is no MCP counterpart for a hard delete — an agent asked to remove a board card had to stop and hand the job back to a human. The UI/API has had `DELETE /tasks/:id` (`TaskService.destroy`) all along.

## What

- `PersonalTools::DeleteBoardTask` — `audience :user`, `tags :board`, params `project_id` + `task_id`. Goes through `TaskService.destroy`, so the board activity feed records `task_deleted` exactly as the UI's delete does, and authorizes with the same `Board::TasksPolicy#destroy?` (project-writable) the controller uses.
- Refuses while the task has active workflow runs (`pending` / `running` / `paused`). `workflow_runs` are nullified rather than destroyed, so deleting mid-run would leave a live run with no card to report back to; the error points at `cancel_workflow_run`.
- The description steers agents to `archive_board_task` unless deletion was actually asked for; the personal-MCP guide's board section now names both.

## Tests

`test/integration/personal_mcp_board_test.rb`: happy path (task and its comments gone), the active-run refusal, viewer denied, and another company's task unreachable.

`docker compose exec -T web make check_all` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
