### PR TITLE
build(deps): declare the peers the root workspace left unmet

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "vitest": "^4.1.10"
   },
   "dependencies": {
+    "@codemirror/view": "^6.0.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
@@ -79,6 +80,7 @@
     "nuqs": "^2.9.4",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
+    "react-is": "^16.13.1",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.12.2",
     "react-syntax-highlighter": "^16.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8185,6 +8185,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
+    "@codemirror/view": "npm:^6.0.0"
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
     "@dnd-kit/utilities": "npm:^3.2.2"
@@ -8251,6 +8252,7 @@ __metadata:
     prettier-plugin-packagejson: "npm:^3.0.0"
     react: "npm:^19.2.8"
     react-dom: "npm:^19.2.8"
+    react-is: "npm:^16.13.1"
     react-markdown: "npm:^10.1.0"
     react-resizable-panels: "npm:^4.12.2"
     react-syntax-highlighter: "npm:^16.1.1"


### PR DESCRIPTION
## What

`@uiw/react-codemirror` and `recharts` each declare a peer dependency that the root
workspace never provided, so **every** `yarn install` — local, Docker build, CI — ends
its post-resolution step with:

```
➤ YN0002: │ root-workspace-0b6124@workspace:. doesn't provide @codemirror/view (p592a29), requested by @uiw/react-codemirror.
➤ YN0002: │ root-workspace-0b6124@workspace:. doesn't provide react-is (pc092df), requested by recharts.
➤ YN0086: │ Some peer dependencies are incorrectly met by your project; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code.
```

Both peers already resolve at runtime purely by hoisting luck. This PR declares them, so
the graph the app actually runs is the graph `package.json` describes.

Those two are the complete set — no third one is hiding behind them. Yarn prints all
unmet root peers in one pass, and `yarn explain peer-requirements` confirms each is the
only peer of its parent not already satisfied by that parent's own `dependencies`:

- `@uiw/react-codemirror` peers on `@babel/runtime`, `@codemirror/state`,
  `@codemirror/theme-one-dark`, `@codemirror/view`, `codemirror`, `react`, `react-dom`.
  All but `@codemirror/view` are either in its own `dependencies` or already declared here.
- `@uiw/codemirror-extensions-langs` peers on `@codemirror/language`, which is in its own
  `dependencies`.
- `recharts` peers on `react`, `react-dom`, `react-is`; only `react-is` was missing.

## Packages added

| package | range added | resolves to | why that range |
| --- | --- | --- | --- |
| `@codemirror/view` | `^6.0.0` | `6.41.0` | merges into the existing `@codemirror/view@npm:^6.0.0` descriptor group, so it keeps deduping with the 17 transitive requesters instead of forking a second copy |
| `react-is` | `^16.13.1` | `16.13.1` | matches the existing `react-is@npm:^16.13.1` descriptor exactly |

`@codemirror/view` deliberately gets `^6.0.0` rather than `^6.41.0`: a fresh `^6.41.0`
descriptor is re-resolved from the registry and pulled in `@codemirror/view@6.43.8` +
`@codemirror/state@6.7.1` as a **second** copy alongside 6.41.0. CodeMirror facets are
identity-based, so two `@codemirror/view` instances in one tree is a real runtime hazard.
`^6.0.0` mirrors what `@uiw/react-codemirror` asks for (`>=6.0.0`) and what every
transitive consumer already requests, and keeps exactly one copy.

## Evidence this changes nothing at runtime

Both versions were already in `yarn.lock` as transitive resolutions before this PR:

```
yarn.lock:621  "@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.17.0, @codemirror/view@npm:^6.23.0, @codemirror/view@npm:^6.27.0, @codemirror/view@npm:^6.35.0, @codemirror/view@npm:^6.37.0":
                 version: 6.41.0
yarn.lock:7703 "react-is@npm:^16.13.1":
                 version: 16.13.1
```

`yarn why` before the change:

```
@codemirror/view  → 6.41.0, requested by 17 packages (@codemirror/{autocomplete,commands,
                    lang-*,language,lint,search,theme-one-dark}, @uiw/codemirror-*, codemirror)
react-is          → 16.13.1 via prop-types@15.8.1 (hoisted to node_modules/react-is)
```

The regenerated lockfile diff is **two lines** — both inside the `root-workspace` entry.
No new resolution block, no checksum change, no version change, and `yarn install`
reported no `YN0085` (nothing added to the project):

```
@@ -8185,6 +8185,7 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
+    "@codemirror/view": "npm:^6.0.0"
@@ -8251,6 +8252,7 @@ __metadata:
     react-dom: "npm:^19.2.8"
+    react-is: "npm:^16.13.1"
```

Installed versions after the change are unchanged: `@codemirror/view 6.41.0`,
`react-is 16.13.1`, single copy of each.

Also worth noting: `app/frontend/shared/resources/tools/ToolFileEditor.tsx` imports
`EditorView` from `@codemirror/view` directly, so this package was a phantom dependency
in the strict sense too — imported by our own source, declared by nobody.

## Verification

- `yarn install --immutable` in the dev container: exit 0, **zero** `YN0002`.
- A from-scratch `docker build --no-cache` mirroring the repo `Dockerfile`'s yarn stage
  (`COPY package.json yarn.lock .yarnrc.yml` → `corepack install` → `yarn install
  --immutable`, empty yarn cache, no `node_modules`) — i.e. exactly the CI "Build Test
  Image" step — succeeds with zero `YN0002`.
- Full `make check_all`, all green:

```
=== Summary ===
  [OK]   brakeman
  [OK]   eslint
  [OK]   fe-test
  [OK]   rails-test
  [OK]   rubocop
  [OK]   system-test
  [OK]   typescript
  [OK]   vite-build

=== Coverage (line %) ===
  backend  (rails / simplecov): 90.96%
  frontend (vitest / v8):       78.39%
```

## Relation to the dependabot PRs

This removes the two peer warnings that head every `yarn install` log, including the
"Build Test Image" logs on #68 (run 31260414101), so those logs stop leading with what
looks like an error.

One correction for whoever triages #68, though: `YN0002` is warning-level and is **not**
what failed that run. `yarn install --immutable` on `develop` exits 0 today with both
`YN0002` lines present. Run 31260414101 died on:

```
➤ YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.
```

because dependabot removed `nanoid: "npm:^6.0.0"` (and the `nanoid@npm:^6.0.0` resolution)
from `yarn.lock` while `package.json` still declares `"nanoid": "^6.0.0"` — a lockfile
inconsistent with its own manifest. #68 needs its lockfile regenerated; this PR does not
fix it on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
