### PR TITLE
fix(coder): stop a failed start from stranding a workspace lock, and make Coder settings editable

### DIFF
--- a/app/controllers/web/company/projects/integrations_controller.rb
+++ b/app/controllers/web/company/projects/integrations_controller.rb
@@ -54,6 +54,28 @@ class Web::Company::Projects::IntegrationsController < Web::Company::Projects::A
     end
   end
 
+  # Edits provider settings on an already-connected integration. Scoped with
+  # `for_project` like #destroy: a company-wide integration is shared by every
+  # project, so it is not editable from one project's page.
+  def update
+    integration = Integration.for_project(current_project).find(params[:id])
+
+    Coder::IntegrationService.new(
+      company: current_company,
+      connected_by: current_user,
+      project: current_project
+    ).update_settings(
+      integration:      integration,
+      default_template: params[:default_template],
+      machine_prefix:   params[:machine_prefix],
+      lock_ttl_minutes: params[:lock_ttl_minutes]
+    )
+
+    redirect_to company_project_integrations_path(current_project), notice: "Integration settings saved"
+  rescue Coder::IntegrationService::ConfigurationError => e
+    redirect_to company_project_integrations_path(current_project), alert: e.message
+  end
+
   def destroy
     integration = Integration.for_project(current_project).find(params[:id])
     integration.destroy

--- a/app/frontend/shared/resources/integrations/IntegrationsContent.test.tsx
+++ b/app/frontend/shared/resources/integrations/IntegrationsContent.test.tsx
@@ -645,4 +645,107 @@ describe('IntegrationsContent', () => {
       expect(screen.getByText('https://coder.aixle.dev')).toBeInTheDocument();
     });
   });
+
+  describe('Coder settings', () => {
+    const coderIntegration = (overrides: Partial<Integration> = {}) =>
+      makeIntegration({
+        id: 9,
+        name: 'Acme Coder',
+        provider: 'coder',
+        scopeIndicator: 'project',
+        coderUrl: 'https://coder.aixle.dev',
+        coderDefaultTemplate: 'aws-ec2-spot-v1',
+        coderMachinePrefix: 'aixle-prod',
+        coderLockTtlMinutes: 120,
+        ...overrides,
+      });
+
+    it('shows the allocator settings on the row', () => {
+      renderPage(
+        <IntegrationsContent
+          title="Project Integrations"
+          basePath="/projects/42/integrations"
+          integrations={[coderIntegration()]}
+        />,
+        { props: settingsProps },
+      );
+
+      expect(screen.getByText('template aws-ec2-spot-v1 · prefix aixle-prod · lock 120m')).toBeInTheDocument();
+    });
+
+    it('calls out a missing default template, which is what stops the pool from growing', () => {
+      renderPage(
+        <IntegrationsContent
+          title="Project Integrations"
+          basePath="/projects/42/integrations"
+          integrations={[coderIntegration({ coderDefaultTemplate: null, coderMachinePrefix: null })]}
+        />,
+        { props: settingsProps },
+      );
+
+      expect(screen.getByText('no default template · no prefix · lock 120m')).toBeInTheDocument();
+    });
+
+    it('saving the edit form patches the integration with the changed settings', async () => {
+      renderPage(
+        <IntegrationsContent
+          title="Project Integrations"
+          basePath="/projects/42/integrations"
+          integrations={[coderIntegration({ coderDefaultTemplate: null })]}
+        />,
+        { props: settingsProps },
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Edit settings for Acme Coder' }));
+      const dialog = await screen.findByRole('dialog', { name: /Coder settings/i });
+
+      // Prefilled from the row, so an edit never silently drops the other fields.
+      expect(within(dialog).getByLabelText('Machine name prefix')).toHaveValue('aixle-prod');
+
+      await userEvent.type(within(dialog).getByLabelText('Default template'), 'aws-ec2-spot-v1');
+      await userEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+      expect(router.patch).toHaveBeenCalledWith(
+        '/projects/42/integrations/9',
+        { defaultTemplate: 'aws-ec2-spot-v1', machinePrefix: 'aixle-prod', lockTtlMinutes: 120 },
+        expect.objectContaining({ preserveScroll: true }),
+      );
+    });
+
+    it('sends a blank template when it is cleared, so the pool can be capped', async () => {
+      renderPage(
+        <IntegrationsContent
+          title="Project Integrations"
+          basePath="/projects/42/integrations"
+          integrations={[coderIntegration()]}
+        />,
+        { props: settingsProps },
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Edit settings for Acme Coder' }));
+      const dialog = await screen.findByRole('dialog', { name: /Coder settings/i });
+
+      await userEvent.clear(within(dialog).getByLabelText('Default template'));
+      await userEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+      expect(router.patch).toHaveBeenCalledWith(
+        '/projects/42/integrations/9',
+        expect.objectContaining({ defaultTemplate: '' }),
+        expect.any(Object),
+      );
+    });
+
+    it('hides the edit action for a company-wide integration in a project context', () => {
+      renderPage(
+        <IntegrationsContent
+          title="Project Integrations"
+          basePath="/projects/42/integrations"
+          integrations={[coderIntegration({ scopeIndicator: 'company' })]}
+        />,
+        { props: settingsProps },
+      );
+
+      expect(screen.queryByRole('button', { name: /Edit settings/i })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/app/frontend/shared/resources/integrations/IntegrationsContent.tsx
+++ b/app/frontend/shared/resources/integrations/IntegrationsContent.tsx
@@ -28,6 +28,7 @@ import {
   IconChevronRight,
   IconCopy,
   IconLink,
+  IconPencil,
   IconPlus,
   IconSearch,
   IconSettings,
@@ -90,6 +91,9 @@ const SCOPE_COLORS: Record<string, string> = {
   project: 'green',
 };
 
+// Mirrors the server-side fallback in Coder::LockService#ttl_minutes.
+const DEFAULT_CODER_LOCK_TTL = 120;
+
 const formatDate = (d: string) =>
   new Date(d).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
 
@@ -109,17 +113,23 @@ export const IntegrationsContent = ({ integrations, basePath, title }: Integrati
   const [coderToken, setCoderToken] = useState('');
   const [coderDefaultTemplate, setCoderDefaultTemplate] = useState('');
   const [coderMachinePrefix, setCoderMachinePrefix] = useState('');
-  const [coderLockTtlMinutes, setCoderLockTtlMinutes] = useState<number | string>(120);
+  const [coderLockTtlMinutes, setCoderLockTtlMinutes] = useState<number | string>(DEFAULT_CODER_LOCK_TTL);
   const [coderAdvancedOpen, setCoderAdvancedOpen] = useState(false);
   const [coderLoading, setCoderLoading] = useState(false);
   const [coderError, setCoderError] = useState<string | null>(null);
+
+  const [coderEditTarget, setCoderEditTarget] = useState<Integration | null>(null);
+  const [coderEditTemplate, setCoderEditTemplate] = useState('');
+  const [coderEditPrefix, setCoderEditPrefix] = useState('');
+  const [coderEditTtl, setCoderEditTtl] = useState<number | string>(DEFAULT_CODER_LOCK_TTL);
+  const [coderEditLoading, setCoderEditLoading] = useState(false);
 
   const resetCoderForm = useCallback(() => {
     setCoderUrl('');
     setCoderToken('');
     setCoderDefaultTemplate('');
     setCoderMachinePrefix('');
-    setCoderLockTtlMinutes(60);
+    setCoderLockTtlMinutes(DEFAULT_CODER_LOCK_TTL);
     setCoderAdvancedOpen(false);
     setCoderError(null);
   }, []);
@@ -260,6 +270,33 @@ export const IntegrationsContent = ({ integrations, basePath, title }: Integrati
       onFinish: () => setCoderLoading(false),
     });
   }, [basePath, closeCoderModal, coderDefaultTemplate, coderLockTtlMinutes, coderMachinePrefix, coderToken, coderUrl]);
+
+  const openCoderSettings = useCallback((integration: Integration) => {
+    setCoderEditTarget(integration);
+    setCoderEditTemplate(integration.coderDefaultTemplate ?? '');
+    setCoderEditPrefix(integration.coderMachinePrefix ?? '');
+    setCoderEditTtl(integration.coderLockTtlMinutes ?? DEFAULT_CODER_LOCK_TTL);
+  }, []);
+
+  const handleSaveCoderSettings = useCallback(() => {
+    if (!coderEditTarget) return;
+    const ttl = typeof coderEditTtl === 'number' ? coderEditTtl : Number(coderEditTtl);
+    if (Number.isNaN(ttl) || ttl <= 0) return;
+
+    setCoderEditLoading(true);
+    // Template and prefix go out even when empty — a blank value clears the
+    // setting, which is how you stop the allocator from creating machines.
+    router.patch(
+      `${basePath}/${coderEditTarget.id}`,
+      { defaultTemplate: coderEditTemplate.trim(), machinePrefix: coderEditPrefix.trim(), lockTtlMinutes: ttl },
+      {
+        preserveScroll: true,
+        onSuccess: () => setCoderEditTarget(null),
+        onError: () => notifications.show({ message: 'Failed to save Coder settings', color: 'red' }),
+        onFinish: () => setCoderEditLoading(false),
+      },
+    );
+  }, [basePath, coderEditPrefix, coderEditTarget, coderEditTemplate, coderEditTtl]);
 
   // Slack connects via OAuth: redirect to the project-scoped start action, which
   // bounces to Slack's consent screen. The install binds to this project.
@@ -461,6 +498,21 @@ export const IntegrationsContent = ({ integrations, basePath, title }: Integrati
                               {integration.coderUrl}
                             </Text>
                           )}
+                          {/* The allocator reads these three, and a missing template is
+                              why it can never create a machine — so show them here
+                              instead of only inside the connect form. */}
+                          {integration.provider === 'coder' && (
+                            <Text fz={11} c="dimmed" truncate maw={260}>
+                              {integration.coderDefaultTemplate
+                                ? `template ${integration.coderDefaultTemplate}`
+                                : 'no default template'}
+                              {' · '}
+                              {integration.coderMachinePrefix
+                                ? `prefix ${integration.coderMachinePrefix}`
+                                : 'no prefix'}
+                              {` · lock ${integration.coderLockTtlMinutes ?? DEFAULT_CODER_LOCK_TTL}m`}
+                            </Text>
+                          )}
                         </Box>
                       </Group>
                     </Table.Td>
@@ -509,6 +561,18 @@ export const IntegrationsContent = ({ integrations, basePath, title }: Integrati
                               target="_blank"
                             >
                               <IconSettings size={16} />
+                            </ActionIcon>
+                          </Tooltip>
+                        )}
+                        {integration.provider === 'coder' && canExecute && !readOnly && (
+                          <Tooltip label="Edit settings">
+                            <ActionIcon
+                              aria-label={`Edit settings for ${integration.name}`}
+                              variant="subtle"
+                              size="sm"
+                              onClick={() => openCoderSettings(integration)}
+                            >
+                              <IconPencil size={16} />
                             </ActionIcon>
                           </Tooltip>
                         )}
@@ -651,6 +715,54 @@ export const IntegrationsContent = ({ integrations, basePath, title }: Integrati
               }
             >
               Connect
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+
+      <Modal
+        opened={!!coderEditTarget}
+        onClose={() => setCoderEditTarget(null)}
+        title="Coder settings"
+        centered
+        size="sm"
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            Without a default template the allocator can only hand out workspaces that already exist — it never creates
+            one. Leave it blank to cap the pool at its current size.
+          </Text>
+          <TextInput
+            label="Default template"
+            placeholder="aws-ec2-spot-v1"
+            value={coderEditTemplate}
+            onChange={(e) => setCoderEditTemplate(e.currentTarget.value)}
+            autoFocus
+          />
+          <TextInput
+            label="Machine name prefix"
+            placeholder="aixle-prod"
+            value={coderEditPrefix}
+            onChange={(e) => setCoderEditPrefix(e.currentTarget.value)}
+          />
+          <NumberInput
+            label="Lock TTL (minutes)"
+            min={1}
+            max={1440}
+            value={coderEditTtl}
+            onChange={(value) => setCoderEditTtl(value)}
+            error={typeof coderEditTtl === 'number' && coderEditTtl > 0 ? undefined : 'Required'}
+          />
+          <Group justify="flex-end">
+            <Button variant="default" onClick={() => setCoderEditTarget(null)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSaveCoderSettings}
+              loading={coderEditLoading}
+              disabled={!(typeof coderEditTtl === 'number' && coderEditTtl > 0)}
+            >
+              Save
             </Button>
           </Group>
         </Stack>

--- a/app/policies/web/company/projects/integrations_policy.rb
+++ b/app/policies/web/company/projects/integrations_policy.rb
@@ -6,6 +6,7 @@ module Web
       class IntegrationsPolicy < Web::Company::ApplicationPolicy
         def index? = project_accessible?
         def create? = manage_integrations?
+        def update? = manage_integrations?
         def destroy? = manage_integrations?
         def slack_oauth_start? = manage_integrations?
         def github_app_install? = manage_integrations?

--- a/app/services/coder/allocator.rb
+++ b/app/services/coder/allocator.rb
@@ -35,6 +35,9 @@ module Coder
         [ status, w["name"].to_s ]
       end
 
+      held           = []
+      start_failures = []
+
       candidates.each do |ws|
         ws_name = ws["name"].to_s
         ws_id   = ws["id"].to_s
@@ -49,10 +52,26 @@ module Coder
             acquired_by:         acquired_by
           )
         rescue Coder::LockService::LockNotAcquired
+          held << ws_name
           next
         end
 
-        status = ensure_started(ws)
+        begin
+          status = ensure_started(ws)
+        rescue Coder::WorkspaceService::OperationError => e
+          # A lock is only worth holding while the workspace is usable. Handing
+          # it back keeps a failed start (spot capacity, build timeout) from
+          # stranding the machine for the whole lock TTL, which is what turned
+          # a transient EC2 hiccup into an exhausted pool. Holder-scoped, so a
+          # session that reclaimed an expired lock underneath us keeps it.
+          @lock_service.release_owned(
+            workspace_name:      ws_name,
+            terminal_session_id: @terminal_session.id
+          )
+          start_failures << "#{ws_name} (#{e.message})"
+          next
+        end
+
         return build_result(workspace_id: ws_id, workspace_name: ws_name, status: status, lock: lock)
       end
 
@@ -70,10 +89,31 @@ module Coder
         return build_result(workspace_id: ws_id, workspace_name: ws_name, status: "starting", lock: lock)
       end
 
-      raise ExhaustedError, "no Coder workspaces available and no default template configured"
+      raise ExhaustedError, exhausted_message(
+        candidates: candidates, held: held, start_failures: start_failures
+      )
     end
 
     private
+
+    # Reaching this point means every candidate was unusable AND no default
+    # template is configured (a configured one either returns a workspace or
+    # raises its own `OperationError`). The old single sentence claimed "no
+    # workspaces available" for all of those, which read as an empty pool even
+    # when the pool was full and merely locked — so spell out which it was.
+    def exhausted_message(candidates:, held:, start_failures:)
+      pool =
+        if candidates.empty?
+          prefix ? "no workspaces match prefix #{prefix.inspect}" : "the Coder account has no workspaces"
+        else
+          reasons = []
+          reasons << "#{held.size} held by other sessions (#{held.join(', ')})" if held.any?
+          reasons << "#{start_failures.size} failed to start: #{start_failures.join('; ')}" if start_failures.any?
+          "none of the #{candidates.size} workspaces in the pool could be allocated — #{reasons.join('; ')}"
+        end
+
+      "#{pool}; no default_template configured on the integration, so the pool cannot grow"
+    end
 
     def prefix
       @integration.coder_machine_prefix.presence

--- a/app/services/coder/api.rb
+++ b/app/services/coder/api.rb
@@ -60,13 +60,11 @@ module Coder
         )
       end
 
+      # Raises like every other call here. Collapsing failures to `[]` made an
+      # expired token or a 403 indistinguishable from "the template isn't
+      # there", and callers reported the latter.
       def list_templates(coder_url:, session_token:)
-        response = request(:get, "/api/v2/templates", coder_url: coder_url, session_token: session_token)
-        return [] unless response.status == 200
-
-        Array(parse_json(response, op: "list_templates"))
-      rescue ApiError
-        []
+        Array(json_get("/api/v2/templates", coder_url: coder_url, session_token: session_token, op: "list_templates"))
       end
 
       def create_workspace(coder_url:, session_token:, user_id:, name:, template_id:)

--- a/app/services/coder/integration_service.rb
+++ b/app/services/coder/integration_service.rb
@@ -77,6 +77,31 @@ module Coder
       integration
     end
 
+    # Edit the operational settings of a connected integration in place. Only
+    # these three are editable: they change how the allocator behaves, carry no
+    # secret, and need no round-trip to Coder to validate. URL and token are
+    # deliberately excluded — replacing credentials has to re-verify them, which
+    # is what `create` (reconnect) already does.
+    #
+    # A blank `default_template` or `machine_prefix` clears the setting; blank
+    # or non-positive `lock_ttl_minutes` is rejected, since the lock TTL has no
+    # sane "unset" (the allocator would silently fall back to its own default).
+    def update_settings(integration:, default_template: nil, machine_prefix: nil, lock_ttl_minutes: nil)
+      raise ConfigurationError, "Only Coder integrations have editable settings" unless integration.coder?
+
+      ttl_value = parse_positive_int(lock_ttl_minutes)
+      raise ConfigurationError, "Lock TTL minutes must be a positive number" if ttl_value.nil?
+
+      integration.update!(
+        settings: (integration.settings || {}).merge(
+          "default_template" => default_template.presence,
+          "machine_prefix"   => machine_prefix.presence,
+          "lock_ttl_minutes" => ttl_value
+        ).compact
+      )
+      integration
+    end
+
     private
 
     def build_integration

--- a/app/services/coder/lock_service.rb
+++ b/app/services/coder/lock_service.rb
@@ -85,11 +85,24 @@ module Coder
       row
     end
 
-    # Idempotent — deletes the lock row if present.
+    # Idempotent — deletes the lock row if present. Not scoped to a holder:
+    # callers that act on behalf of a session must use `release_owned`.
     def release(workspace_name:)
       @integration.integration_data
                   .where(key: lock_key(workspace_name))
                   .delete_all
+    end
+
+    # Holder-scoped release. Deletes the row only while `terminal_session_id`
+    # still owns it, in a single statement — so a lock that expired mid-flight
+    # and was reclaimed by another session is left alone (a read-then-delete
+    # pair would race that reclaim). Returns whether a row was deleted.
+    def release_owned(workspace_name:, terminal_session_id:)
+      @integration.integration_data
+                  .where(key: lock_key(workspace_name))
+                  .where("value ->> 'terminal_session_id' = ?", terminal_session_id.to_s)
+                  .delete_all
+                  .positive?
     end
 
     # Release every live lock currently held by the given terminal session,

--- a/app/services/internal_tools/coder_release_machine.rb
+++ b/app/services/internal_tools/coder_release_machine.rb
@@ -31,20 +31,17 @@ module InternalTools
       workspace_name = params[:workspace_name].to_s
       return error("workspace_name is required") if workspace_name.empty?
 
-      lock_service = Coder::LockService.new(coder_integration)
-      held_by_self = lock_service.held_by_session?(
+      # DD-13: only the lock holder may release. The ownership check lives in
+      # the delete statement itself, so a lock that expired and was reclaimed
+      # by another session between check and delete cannot be dropped here.
+      released = Coder::LockService.new(coder_integration).release_owned(
         workspace_name:      workspace_name,
         terminal_session_id: session.id
       )
 
-      # DD-13: only the lock holder may release. Without this gate any session
-      # could delete another session's row (LockService#release is a scoped
-      # delete_all on the workspace key).
-      lock_service.release(workspace_name: workspace_name) if held_by_self
-
       success({
         workspace_name: workspace_name,
-        released:       held_by_self
+        released:       released
       }.to_json)
     rescue Concerns::CoderResolver::NotConfiguredError => e
       error(e.message)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -305,7 +305,10 @@ Rails.application.routes.draw do
           resources :assets, only: %i[index]
           resources :analytics, only: :index
           resources :repositories, only: %i[index create update destroy]
-          resources :integrations, only: %i[index create destroy] do
+          # `update` edits provider settings only (Coder's template / prefix /
+          # lock TTL) — credentials are replaced by reconnecting, which has to
+          # re-verify them against the provider.
+          resources :integrations, only: %i[index create update destroy] do
             collection do
               get :slack_oauth_start
               get :github_app_install

--- a/test/integration/web/company/projects/integrations_authorization_test.rb
+++ b/test/integration/web/company/projects/integrations_authorization_test.rb
@@ -62,6 +62,15 @@ class Web::Company::Projects::IntegrationsAuthorizationTest < ActionDispatch::In
     end
   end
 
+  # update carries a non-authz alert for a provider without editable settings
+  # (the seeded integration is a GitHub one), which proves the allowed role got
+  # past the policy — same shape as the #create case above.
+  test "update is admin-or-owner (collaborator/viewer denied)" do
+    assert_role_matrix(MANAGE, transport: :web, allowed_status: :redirect) do
+      patch company_project_integration_path(@project, @integration), params: { lockTtlMinutes: "120" }
+    end
+  end
+
   # destroy mutates, so build a throwaway integration per allowed-role iteration.
   test "destroy is admin-or-owner (collaborator/viewer denied)" do
     assert_role_matrix(MANAGE, transport: :web) do

--- a/test/integration/web/company/projects/integrations_controller_test.rb
+++ b/test/integration/web/company/projects/integrations_controller_test.rb
@@ -134,4 +134,71 @@ class Web::Company::Projects::IntegrationsControllerTest < ActionDispatch::Integ
     assert_equal "http://coder.example.com", integration.credentials_data["coder_url"]
     assert_response :redirect
   end
+
+  # The :coder factory trait rewrites `settings` in an after(:build) hook, so a
+  # test that needs specific settings has to merge them after create.
+  def create_coder_integration(project: @project, **settings)
+    integration = create(:integration, :coder, :active, company: @company, project: project, connected_by: @user)
+    integration.update!(settings: integration.settings.merge(settings)) if settings.any?
+    integration
+  end
+
+  test "update saves coder settings without touching credentials" do
+    integration = create_coder_integration("machine_prefix" => "old-prefix")
+    credentials_before = integration.credentials_data
+
+    patch company_project_integration_path(@project, integration), params: {
+      defaultTemplate: "aws-ec2-spot-v1",
+      machinePrefix:   "aixle-prod",
+      lockTtlMinutes:  "120"
+    }
+
+    assert_response :redirect
+    integration.reload
+    assert_equal "aws-ec2-spot-v1", integration.coder_default_template
+    assert_equal "aixle-prod", integration.coder_machine_prefix
+    assert_equal 120, integration.coder_lock_ttl_minutes
+    assert_equal credentials_before, integration.credentials_data
+  end
+
+  test "update clears a blank template so the pool stops growing" do
+    integration = create_coder_integration("default_template" => "aws-ec2-spot-v1")
+
+    patch company_project_integration_path(@project, integration), params: {
+      defaultTemplate: "", machinePrefix: "", lockTtlMinutes: "120"
+    }
+
+    assert_response :redirect
+    assert_nil integration.reload.coder_default_template
+  end
+
+  test "update rejects a non-positive lock TTL and keeps the stored settings" do
+    integration = create_coder_integration("machine_prefix" => "aixle-prod")
+
+    patch company_project_integration_path(@project, integration), params: {
+      machinePrefix: "changed", lockTtlMinutes: "0"
+    }
+
+    assert_response :redirect
+    assert_match(/Lock TTL minutes must be a positive number/, flash[:alert])
+    assert_equal "aixle-prod", integration.reload.coder_machine_prefix
+  end
+
+  test "update refuses a provider that has no editable settings" do
+    integration = create(:integration, company: @company, project: @project, connected_by: @user)
+
+    patch company_project_integration_path(@project, integration), params: { lockTtlMinutes: "120" }
+
+    assert_response :redirect
+    assert_match(/Only Coder integrations have editable settings/, flash[:alert])
+  end
+
+  test "update does not reach a company-wide integration from a project page" do
+    integration = create_coder_integration(project: nil)
+
+    patch company_project_integration_path(@project, integration), params: { lockTtlMinutes: "5" }
+
+    assert_response :not_found
+    assert_equal 60, integration.reload.coder_lock_ttl_minutes
+  end
 end

--- a/test/services/coder/allocator_test.rb
+++ b/test/services/coder/allocator_test.rb
@@ -7,11 +7,12 @@ module Coder
     class FakeWorkspaceService
       attr_accessor :workspaces, :started_ids, :awaited_ids, :created
 
-      def initialize(workspaces: [], created: nil)
-        @workspaces  = workspaces
-        @started_ids = []
-        @awaited_ids = []
-        @created     = created
+      def initialize(workspaces: [], created: nil, failing_start_ids: [])
+        @workspaces        = workspaces
+        @started_ids       = []
+        @awaited_ids       = []
+        @created           = created
+        @failing_start_ids = failing_start_ids
       end
 
       def list(prefix: nil)
@@ -21,6 +22,11 @@ module Coder
 
       def start(workspace_id)
         @started_ids << workspace_id
+        if @failing_start_ids.include?(workspace_id)
+          raise Coder::WorkspaceService::OperationError,
+                "build (start) failed: HTTP 500 spot capacity unavailable"
+        end
+
         { "id" => "build-#{workspace_id}", "job" => { "status" => "succeeded" } }
       end
 
@@ -152,13 +158,68 @@ module Coder
       assert_equal "starting", result[:status]
     end
 
+    test "hands the lock back when a workspace fails to start and tries the next candidate" do
+      ws = FakeWorkspaceService.new(
+        workspaces: [
+          { "id" => "u1", "name" => "aixle-prod-1",
+            "latest_build" => { "transition" => "stop", "job" => { "status" => "succeeded" } } },
+          { "id" => "u2", "name" => "aixle-prod-2",
+            "latest_build" => { "transition" => "stop", "job" => { "status" => "succeeded" } } }
+        ],
+        failing_start_ids: [ "u1" ]
+      )
+
+      result = build_allocator(workspace_service: ws).allocate
+
+      assert_equal "aixle-prod-2", result[:workspace_name]
+      assert_nil @integration.integration_data.find_by(key: "coder:workspace_lock:aixle-prod-1"),
+                 "a workspace that failed to start must not stay locked for the whole TTL"
+      assert @integration.integration_data.find_by(key: "coder:workspace_lock:aixle-prod-2")
+    end
+
     test "raises ExhaustedError when pool is empty and no default template configured" do
       ws = FakeWorkspaceService.new(workspaces: [])
       @integration.update!(settings: (@integration.settings || {}).merge("default_template" => nil))
 
-      assert_raises(Coder::Allocator::ExhaustedError) do
+      error = assert_raises(Coder::Allocator::ExhaustedError) do
         build_allocator(workspace_service: ws).allocate
       end
+      assert_match(/no workspaces match prefix "aixle-prod"/, error.message)
+      assert_match(/no default_template configured/, error.message)
+    end
+
+    test "ExhaustedError names the sessions-held workspaces instead of claiming the pool is empty" do
+      ws = FakeWorkspaceService.new(workspaces: [
+        { "id" => "u1", "name" => "aixle-prod-1",
+          "latest_build" => { "transition" => "start", "job" => { "status" => "succeeded" } } },
+        { "id" => "u2", "name" => "aixle-prod-2",
+          "latest_build" => { "transition" => "start", "job" => { "status" => "succeeded" } } }
+      ])
+      lock_service = Coder::LockService.new(@integration)
+      lock_service.acquire(workspace_name: "aixle-prod-1", workspace_id: "u1", terminal_session_id: "sess-OTHER")
+      lock_service.acquire(workspace_name: "aixle-prod-2", workspace_id: "u2", terminal_session_id: "sess-OTHER")
+
+      error = assert_raises(Coder::Allocator::ExhaustedError) do
+        build_allocator(workspace_service: ws).allocate
+      end
+      assert_match(/none of the 2 workspaces in the pool could be allocated/, error.message)
+      assert_match(/2 held by other sessions \(aixle-prod-1, aixle-prod-2\)/, error.message)
+    end
+
+    test "ExhaustedError carries the reason a workspace failed to start" do
+      ws = FakeWorkspaceService.new(
+        workspaces: [
+          { "id" => "u1", "name" => "aixle-prod-1",
+            "latest_build" => { "transition" => "stop", "job" => { "status" => "succeeded" } } }
+        ],
+        failing_start_ids: [ "u1" ]
+      )
+
+      error = assert_raises(Coder::Allocator::ExhaustedError) do
+        build_allocator(workspace_service: ws).allocate
+      end
+      assert_match(/1 failed to start: aixle-prod-1 \(build \(start\) failed: HTTP 500 spot capacity unavailable\)/,
+                   error.message)
     end
 
     test "lock value records terminal_session_id and never task_id / step_run_id" do

--- a/test/services/coder/api_test.rb
+++ b/test/services/coder/api_test.rb
@@ -55,9 +55,25 @@ module Coder
       assert_equal "build-1", build["id"]
     end
 
-    test "list_templates returns [] on non-200 without raising" do
-      stub_request(:get, "#{BASE}/api/v2/templates").to_return(status: 500)
-      assert_equal [], Coder::Api.list_templates(coder_url: BASE, session_token: TOKEN)
+    test "list_templates returns the parsed template list" do
+      stub_request(:get, "#{BASE}/api/v2/templates").to_return(
+        status: 200,
+        body: [ { id: "t1", name: "aws-ec2-spot-v1" } ].to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+      templates = Coder::Api.list_templates(coder_url: BASE, session_token: TOKEN)
+      assert_equal [ "aws-ec2-spot-v1" ], templates.map { |t| t["name"] }
+    end
+
+    test "list_templates raises on non-200 instead of reporting an empty catalog" do
+      stub_request(:get, "#{BASE}/api/v2/templates").to_return(status: 401)
+
+      error = assert_raises(Coder::Api::HTTPError) do
+        Coder::Api.list_templates(coder_url: BASE, session_token: TOKEN)
+      end
+      assert_equal 401, error.status
+      assert_match(/list_templates failed: HTTP 401/, error.message)
     end
 
     test "ParseError raised on invalid JSON" do

--- a/test/services/coder/integration_service_test.rb
+++ b/test/services/coder/integration_service_test.rb
@@ -191,5 +191,63 @@ module Coder
       assert second.persisted?
       assert_not_equal first.id, second.id
     end
+
+    test "update_settings edits the allocator settings and leaves credentials alone" do
+      integration = create(:integration, :coder, :active, company: @company, connected_by: @user)
+      credentials_before = integration.credentials_data
+
+      Coder::IntegrationService.new(company: @company, connected_by: @user).update_settings(
+        integration: integration, default_template: "aws-ec2-spot-v1",
+        machine_prefix: "aixle-prod", lock_ttl_minutes: "90"
+      )
+
+      integration.reload
+      assert_equal "aws-ec2-spot-v1", integration.coder_default_template
+      assert_equal "aixle-prod", integration.coder_machine_prefix
+      assert_equal 90, integration.coder_lock_ttl_minutes
+      assert_equal credentials_before, integration.credentials_data
+      # Identity written at connect time survives an edit.
+      assert_equal "test-user", integration.settings["coder_username"]
+    end
+
+    test "update_settings treats a blank template or prefix as a removal" do
+      integration = create(:integration, :coder, :active, company: @company, connected_by: @user)
+      integration.update!(
+        settings: integration.settings.merge("default_template" => "tpl", "machine_prefix" => "aixle-prod")
+      )
+
+      Coder::IntegrationService.new(company: @company, connected_by: @user).update_settings(
+        integration: integration, default_template: "  ", machine_prefix: nil, lock_ttl_minutes: 120
+      )
+
+      integration.reload
+      assert_nil integration.coder_default_template
+      assert_nil integration.coder_machine_prefix
+    end
+
+    test "update_settings rejects a non-positive or missing lock TTL" do
+      integration = create(:integration, :coder, :active, company: @company, connected_by: @user)
+      service = Coder::IntegrationService.new(company: @company, connected_by: @user)
+
+      [ "0", "-5", "abc", nil, "" ].each do |bad|
+        error = assert_raises(Coder::IntegrationService::ConfigurationError) do
+          service.update_settings(integration: integration, lock_ttl_minutes: bad)
+        end
+        assert_match(/Lock TTL minutes must be a positive number/, error.message)
+      end
+
+      assert_equal 60, integration.reload.coder_lock_ttl_minutes
+    end
+
+    test "update_settings refuses a non-Coder integration" do
+      integration = create(:integration, :gitlab, company: @company, connected_by: @user)
+
+      error = assert_raises(Coder::IntegrationService::ConfigurationError) do
+        Coder::IntegrationService.new(company: @company, connected_by: @user).update_settings(
+          integration: integration, lock_ttl_minutes: 120
+        )
+      end
+      assert_match(/Only Coder integrations have editable settings/, error.message)
+    end
   end
 end

--- a/test/services/coder/lock_service_test.rb
+++ b/test/services/coder/lock_service_test.rb
@@ -73,6 +73,33 @@ module Coder
       assert     @service.held?(workspace_name: "ws-3")
     end
 
+    test "release_owned deletes the row only for the holding session" do
+      @service.acquire(**lock_args(terminal_session_id: "sess-A"))
+
+      assert_not @service.release_owned(workspace_name: "ws-1", terminal_session_id: "sess-B")
+      assert @service.held?(workspace_name: "ws-1"), "another session must not be able to release the lock"
+
+      assert @service.release_owned(workspace_name: "ws-1", terminal_session_id: "sess-A")
+      assert_not @service.held?(workspace_name: "ws-1")
+    end
+
+    test "release_owned keeps a lock that another session reclaimed after expiry" do
+      create(
+        :integration_data, :expired,
+        integration: @integration,
+        key:         "coder:workspace_lock:ws-1",
+        value:       { terminal_session_id: "sess-A", workspace_id: "u1" }
+      )
+      @service.acquire(**lock_args(terminal_session_id: "sess-B"))
+
+      assert_not @service.release_owned(workspace_name: "ws-1", terminal_session_id: "sess-A")
+      assert @service.held_by_session?(workspace_name: "ws-1", terminal_session_id: "sess-B")
+    end
+
+    test "release_owned is idempotent on missing rows" do
+      assert_not @service.release_owned(workspace_name: "missing", terminal_session_id: "sess-A")
+    end
+
     test "held_by_session? returns true only for the holder" do
       @service.acquire(**lock_args(terminal_session_id: "sess-A"))
 


### PR DESCRIPTION
## Why

Allocation on staging started failing with `ExhaustedError: no Coder workspaces available and no default template configured`, on a pool that visibly had two running workspaces. Two separate problems combined to produce that:

1. **The lock leaked on a failed start.** `Allocator` locked a workspace *before* starting it, and a start failure (spot capacity, failed build, the 240s `await_build` budget) propagated out with the lock still held — so the machine stayed locked for the whole TTL, two hours by default. On a two-machine pool a couple of transient EC2 hiccups take the pool to zero.
2. **The pool could not grow, and nothing said so.** `default_template` was empty, which is the only gate that lets the allocator create a workspace. It was empty because there was no update action: settings could only be set at connect time, the fields sit in a collapsed "Advanced" section that only submits non-empty values, and the stored values were never rendered anywhere. A token rotation with that section closed clears the template silently.

## What changed

**Allocation**
- A failed start hands the lock back and the allocator tries the next candidate.
- New `LockService#release_owned` checks ownership *inside* the `DELETE`, so a lock that expired mid-flight and was reclaimed by another session is never dropped. `coder_release_machine` moves onto it too, closing its check-then-delete race.
- `ExhaustedError` now distinguishes: a prefix matching nothing, workspaces held by other sessions (named), workspaces that failed to start (with the reason), and the no-default-template gate.
- `Api.list_templates` no longer collapses API errors to `[]` — an expired token used to surface as "template not found".

**Settings**
- `PATCH /…/integrations/:id` edits `default_template` / `machine_prefix` / `lock_ttl_minutes`. `update?` is `manage_integrations?`, same as create/destroy. Credentials are out of scope — replacing them has to re-verify against Coder, which the connect path already does. Company-wide integrations are not editable from a project page, matching `#destroy`.
- The row shows `template … · prefix … · lock …m`, with a missing template called out, and a pencil action opens an edit form.
- Fixed `resetCoderForm` resetting the TTL to 60 while the initial state was 120.

## Testing

`docker compose exec -T web make check_all` green: rails-test, rubocop, brakeman, system-test, eslint, typescript, fe-test, vite-build. Backend line coverage 90.99%, frontend 78.38%.

New coverage: holder-scoped release (including the expired-then-reclaimed case), lock handback on a failed start, each `ExhaustedError` shape, `list_templates` raising, the update action (happy path, blank-clears-template, non-positive TTL rejected, non-Coder provider refused, company-wide not reachable), the authorization matrix row, and the UI (row summary, prefilled edit form, blank template submitted, action hidden for company-wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)