### PR TITLE
fix(sessions): stop a dead agent container from wedging its run

### DIFF
--- a/app/jobs/container_runtime/sweep_orphaned_resources_job.rb
+++ b/app/jobs/container_runtime/sweep_orphaned_resources_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ContainerRuntime
+  # SweepOrphanedResourcesJob — manual-invocation entry point for the runtime
+  # garbage collector, for a Rails console during an incident ("reclaim the
+  # leftovers now" rather than waiting out the cron interval).
+  #
+  # The scheduled path is `Workflows::ContainerSweepOrphanedResourcesWorkflow`
+  # (`app/temporal/schedules.yml`). This job runs the same activity rather than
+  # a second copy of the reconciliation, so the safety guards documented in
+  # `Activities::Container::SweepOrphanedResourcesActivity` — provable owner,
+  # dead owner, minimum age — can never drift between the two entry points.
+  class SweepOrphanedResourcesJob < ApplicationJob
+    queue_as :low
+
+    def perform
+      summary = Activities::Container::SweepOrphanedResourcesActivity.new.run
+      Rails.logger.info("[ContainerRuntime::SweepOrphanedResourcesJob] #{summary}")
+      summary
+    end
+  end
+end

--- a/app/services/container_runtime/base_runtime.rb
+++ b/app/services/container_runtime/base_runtime.rb
@@ -25,6 +25,7 @@ module ContainerRuntime
   # == Introspection
   #   resolve_container(id)                      → container handle
   #   container_identifier(container)            → String
+  #   container_status(id)                       → Symbol (see #container_status)
   #   wait_container(id, timeout=nil)            → Hash { "StatusCode" => int }
   #   container_logs(id, opts={})                → Hash { stdout:, stderr: }
   #
@@ -92,6 +93,23 @@ module ContainerRuntime
 
     def container_identifier(_container)
       raise NotImplementedError, "#{self.class.name} must implement #container_identifier"
+    end
+
+    # Liveness of a container as the runtime sees it *right now*. One of:
+    #
+    #   :running    — the workload is up
+    #   :starting   — accepted by the runtime but not up yet (k8s Pending,
+    #                 docker "created"/"restarting") — NOT a dead container
+    #   :terminated — it ran and is over (k8s Succeeded/Failed, docker exited/dead)
+    #   :missing    — the runtime has no record of it at all
+    #   :unknown    — the runtime could not answer (control-plane error, state
+    #                 string we don't recognize)
+    #
+    # Callers may treat :terminated and :missing as "the agent is gone". They must
+    # NOT treat :unknown that way: an unreachable control plane is not a dead pod,
+    # and a scheduling backlog (:starting) is not one either.
+    def container_status(_id)
+      raise NotImplementedError, "#{self.class.name} must implement #container_status"
     end
 
     def wait_container(_id, _timeout = nil)

--- a/app/services/container_runtime/base_runtime.rb
+++ b/app/services/container_runtime/base_runtime.rb
@@ -17,6 +17,7 @@ module ContainerRuntime
   #
   # == Execution
   #   exec(id, cmd, opts={})                     → [stdout_lines, stderr_lines, exit_code]
+  #   exec!(id, cmd, opts={})                    → same, but raises ContainerUnreachableError
   #
   # == File I/O (tar-based, works on running containers)
   #   write_file(id, path, content, mode:, uid:, gid:) → true/false
@@ -69,6 +70,16 @@ module ContainerRuntime
 
     def exec(_id, _cmd, _opts = {})
       raise NotImplementedError, "#{self.class.name} must implement #exec"
+    end
+
+    # Same as #exec, but a container the runtime could not reach at all raises
+    # ContainerUnreachableError instead of being flattened into an exit code of
+    # 1 that is indistinguishable from a command that ran and failed. Callers
+    # that must tell "the pod is gone" from "the command failed" use this.
+    #
+    # Runtimes that cannot tell the two apart answer exactly like #exec.
+    def exec!(id, cmd, opts = {})
+      exec(id, cmd, opts)
     end
 
     # -- File I/O -------------------------------------------------------------

--- a/app/services/container_runtime/base_runtime.rb
+++ b/app/services/container_runtime/base_runtime.rb
@@ -28,6 +28,10 @@ module ContainerRuntime
   #   wait_container(id, timeout=nil)            → Hash { "StatusCode" => int }
   #   container_logs(id, opts={})                → Hash { stdout:, stderr: }
   #
+  # == Garbage collection
+  #   list_session_resources                     → [ContainerRuntime::SessionResource]
+  #   delete_session_resource(resource)          → true/false
+  #
   class BaseRuntime
     # -- Lifecycle ------------------------------------------------------------
 
@@ -100,6 +104,43 @@ module ContainerRuntime
 
     def container_logs(_id, _opts = {})
       raise NotImplementedError, "#{self.class.name} must implement #container_logs"
+    end
+
+    # -- Garbage collection ---------------------------------------------------
+    #
+    # A session's objects normally die in `remove_container`, which only runs on
+    # the happy path. When the node holding an agent pod dies, that call never
+    # happens and everything the session's routing was made of leaks — for
+    # Kubernetes a Service with zero endpoints and the IngressRoute/Middlewares
+    # pointing at it, which is why a dead session's URL answers with Traefik's
+    # own "no available server" 503 instead of a terminal.
+    #
+    # These two primitives exist so a sweeper can reconcile what the runtime
+    # actually holds against the `TerminalSession` rows that own it, without any
+    # caller reaching into a vendor client (Kubeclient/Docker) itself.
+
+    # Every session-scoped object this runtime currently holds, across every
+    # namespace it manages.
+    #
+    # Implementations MUST return the objects in a safe deletion order — routing
+    # objects before the workload they point at — so a caller can delete the
+    # list front to back without ever leaving traffic aimed at a vanishing
+    # backend. Implementations MUST NOT return shared infrastructure (a
+    # namespace-wide auth middleware, the Traefik deployment, …): only objects
+    # created for one session.
+    #
+    # @return [Array<ContainerRuntime::SessionResource>]
+    def list_session_resources
+      raise NotImplementedError, "#{self.class.name} must implement #list_session_resources"
+    end
+
+    # Deletes one object previously returned by #list_session_resources.
+    # "Already gone" counts as success — the sweeper races real teardown by
+    # design, and a 404 means the goal state was reached.
+    #
+    # @return [Boolean] true when the object is gone
+    def delete_session_resource(_resource)
+      raise NotImplementedError, "#{self.class.name} must implement #delete_session_resource"
     end
 
     private

--- a/app/services/container_runtime/container_unreachable_error.rb
+++ b/app/services/container_runtime/container_unreachable_error.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module ContainerRuntime
+  # Raised when the runtime could not reach the container at all — the pod was
+  # deleted, its node died, or the API refused the exec upgrade.
+  #
+  # This is deliberately distinct from "the command ran and exited non-zero",
+  # which #exec reports as an exit code. Collapsing both into `["", "", 1]` is
+  # what let ScanQuotaErrorsActivity re-exec into destroyed pods forever: it
+  # could not tell a dead container from a command that simply failed.
+  class ContainerUnreachableError < StandardError
+    attr_reader :status_code, :container_identifier
+
+    def initialize(message = nil, status_code: nil, container_identifier: nil)
+      @status_code = status_code
+      @container_identifier = container_identifier
+      super(message.presence || default_message)
+    end
+
+    private
+
+    def default_message
+      target = container_identifier.presence || "container"
+      reason = status_code ? "exec handshake returned HTTP #{status_code}" : "exec handshake failed"
+
+      "#{target} is unreachable (#{reason})"
+    end
+  end
+end

--- a/app/services/container_runtime/docker_runtime.rb
+++ b/app/services/container_runtime/docker_runtime.rb
@@ -182,6 +182,32 @@ module ContainerRuntime
       container.to_s
     end
 
+    # `resolve_container` answers nil for a container the daemon has never heard of
+    # (or has already pruned), which is the docker equivalent of a vanished pod.
+    # A container that ran and stopped stays in the daemon's list as
+    # exited/dead — that is the "agent died, nothing restarted it" case, since
+    # agent containers are never started with a restart policy.
+    def container_status(id)
+      container = resolve_container(id)
+      return :missing if container.nil?
+
+      state = container.json["State"] || {}
+      # Paused containers report Running=true; they have not exited, so they are
+      # not dead.
+      return :running if state["Running"]
+
+      case state["Status"].to_s
+      when "created", "restarting" then :starting
+      when "exited", "dead", "removing" then :terminated
+      else :unknown
+      end
+    rescue Docker::Error::NotFoundError
+      :missing
+    rescue StandardError => e
+      Rails.logger.warn("[DockerRuntime] container_status failed for #{id}: #{e.message}")
+      :unknown
+    end
+
     private
 
     def wait_for_traffic_route(container)

--- a/app/services/container_runtime/docker_runtime.rb
+++ b/app/services/container_runtime/docker_runtime.rb
@@ -14,6 +14,11 @@ module ContainerRuntime
     TRAEFIK_ROUTE_TIMEOUT = 30
     TRAEFIK_ROUTE_INTERVAL = 1
 
+    # Set by ContainerStrategies::AgentBaseStrategy#base_labels on every agent
+    # session's container (and by no tool strategy); its presence is what makes a
+    # container reapable as a session object rather than part of the stack.
+    SESSION_LABEL = "aixle.session_id"
+
     # -- Lifecycle ------------------------------------------------------------
 
     def pull_image(image)
@@ -182,7 +187,64 @@ module ContainerRuntime
       container.to_s
     end
 
+    # -- Garbage collection ---------------------------------------------------
+
+    # Docker has no Service/IngressRoute equivalent — Traefik reads its routes
+    # from the container's own labels — so a session owns exactly one object and
+    # the deletion order is trivially satisfied.
+    #
+    # `all: true` on purpose: an exited container still holds its name and its
+    # Traefik labels, which is precisely the leak this sweeps.
+    def list_session_resources
+      Docker::Container.all(all: true, filters: { label: [ SESSION_LABEL ] }.to_json)
+                       .filter_map { |container| build_session_resource(container) }
+    rescue StandardError => e
+      Rails.logger.warn("[DockerRuntime] Failed to list session containers: #{e.message}")
+      []
+    end
+
+    def delete_session_resource(resource)
+      return false if resource.blank? || resource.name.blank?
+
+      Docker::Container.get(resource.name).remove(force: true)
+      true
+    rescue Docker::Error::NotFoundError
+      # Already gone — the goal state, not a failure.
+      true
+    rescue StandardError => e
+      Rails.logger.warn("[DockerRuntime] Failed to delete #{resource}: #{e.message}")
+      false
+    end
+
     private
+
+    def build_session_resource(container)
+      info = container.info || {}
+      names = Array(info["Names"]).map { |name| name.to_s.delete_prefix("/") }
+      name = names.first.presence || info["Id"].presence || container.id
+      return nil if name.blank?
+
+      created = info["Created"]
+
+      ContainerRuntime::SessionResource.new(
+        kind: "Container",
+        name: name,
+        namespace: nil,
+        # nil for anything not named `terminal-<route_token>` — an unprovable
+        # owner, which the sweeper keeps.
+        route_token: names.filter_map { |candidate| route_token_from_name(candidate) }.first,
+        created_at: created.present? ? Time.zone.at(created.to_i) : nil
+      )
+    rescue StandardError => e
+      Rails.logger.warn("[DockerRuntime] Failed to describe session container: #{e.message}")
+      nil
+    end
+
+    def route_token_from_name(name)
+      return nil unless name.to_s.start_with?("terminal-")
+
+      name.delete_prefix("terminal-").presence
+    end
 
     def wait_for_traffic_route(container)
       route_token = route_token_from_container(container)

--- a/app/services/container_runtime/kubernetes_runtime.rb
+++ b/app/services/container_runtime/kubernetes_runtime.rb
@@ -20,6 +20,30 @@ module ContainerRuntime
     READY_TIMEOUT = 30
     READY_INTERVAL = 1
 
+    RUNTIME_APP_LABEL = "aixle-runtime"
+    # Per-session identity label, carrying the pod name (`terminal-<route_token>`
+    # for agent sessions). Every object a session owns carries it, which is what
+    # makes the set reapable as a unit — and its ABSENCE is what keeps
+    # namespace-wide infrastructure (the shared `terminal-auth` middleware, the
+    # network policies) out of the sweep.
+    CONTAINER_LABEL = "aixle-container"
+
+    # The four object kinds a session owns, in deletion order: routing first, so
+    # traffic stops being aimed at a backend that is about to disappear, then the
+    # Service, then whatever pod is left. #list_session_resources returns them in
+    # this order and callers may delete front to back.
+    SESSION_RESOURCE_KINDS = [
+      [ "IngressRoute", "ingressroutes", :traefik ],
+      [ "Middleware",   "middlewares",   :traefik ],
+      [ "Service",      "services",      :core ],
+      [ "Pod",          "pods",          :core ]
+    ].freeze
+
+    # Cluster-wide selector for "objects belonging to one agent session".
+    # `aixle-container` is a presence check — every session object sets it, no
+    # shared object does.
+    SESSION_RESOURCE_SELECTOR = "app=#{RUNTIME_APP_LABEL},#{CONTAINER_LABEL}"
+
     # -- Lifecycle ------------------------------------------------------------
 
     def pull_image(image)
@@ -163,7 +187,88 @@ module ContainerRuntime
       container.to_s
     end
 
+    # -- Garbage collection ---------------------------------------------------
+
+    # Every session-scoped object in the cluster, in deletion order.
+    #
+    # Cluster-wide on purpose: sessions live in per-project/per-user namespaces
+    # (`aixle-prod-project-27`) whose set is not knowable from the database once
+    # the owning rows are gone, so the label selector is the enumeration. This
+    # needs list/delete on pods, services, ingressroutes and middlewares at
+    # CLUSTER scope in the runtime's RBAC — the same ClusterRole that already
+    # grants namespace creation.
+    #
+    # A listing failure is logged and answered with an empty list for that kind:
+    # the sweeper's job is to delete garbage, and "I could not see" must never
+    # be read as "there is none of it left alive".
+    def list_session_resources
+      SESSION_RESOURCE_KINDS.flat_map do |kind, plural, client_key|
+        list_session_objects(kind, plural, client_key)
+      end
+    end
+
+    def delete_session_resource(resource)
+      return false if resource.blank? || resource.name.blank?
+
+      entry = SESSION_RESOURCE_KINDS.find { |kind, _plural, _client| kind == resource.kind }
+      return false if entry.nil?
+
+      _kind, plural, client_key = entry
+      kube_client(client_key).delete_entity(plural, resource.name, resource.namespace)
+      true
+    rescue Kubeclient::ResourceNotFoundError
+      # Already gone — the goal state, not a failure.
+      true
+    rescue StandardError => e
+      Rails.logger.warn("[KubernetesRuntime] Failed to delete #{resource}: #{e.message}")
+      false
+    end
+
     private
+
+    def list_session_objects(kind, plural, client_key)
+      body = kube_client(client_key).get_entities(
+        kind, plural,
+        label_selector: SESSION_RESOURCE_SELECTOR,
+        as: :raw
+      )
+
+      items = JSON.parse(body.to_s)["items"]
+      Array(items).filter_map { |item| build_session_resource(kind, item) }
+    rescue StandardError => e
+      Rails.logger.warn("[KubernetesRuntime] Failed to list #{kind} objects: #{e.message}")
+      []
+    end
+
+    def build_session_resource(kind, item)
+      metadata = item["metadata"] || {}
+      name = metadata["name"]
+      return nil if name.blank?
+
+      pod_name = (metadata["labels"] || {})[CONTAINER_LABEL]
+
+      SessionResource.new(
+        kind: kind,
+        name: name,
+        namespace: metadata["namespace"],
+        # nil for anything that is not an agent session (an internal-tool pod,
+        # say). A nil token is an unprovable owner, and the sweeper keeps those.
+        route_token: extract_route_token(pod_name),
+        created_at: parse_kube_timestamp(metadata["creationTimestamp"])
+      )
+    end
+
+    def parse_kube_timestamp(value)
+      return nil if value.blank?
+
+      Time.zone.parse(value.to_s)
+    rescue ArgumentError, TypeError
+      nil
+    end
+
+    def kube_client(client_key)
+      client_key == :traefik ? traefik_client : core_client
+    end
 
     def copy_from(id, path)
       return "" if path.blank?
@@ -295,7 +400,7 @@ module ContainerRuntime
       ports = handle.service_ports
       container[:ports] = ports.map { |port| { containerPort: port } } if ports.any?
 
-      labels = { "app" => "aixle-runtime", "aixle-container" => handle.pod_name }
+      labels = session_labels(handle)
       pod_spec = {
         automountServiceAccountToken: false,
         enableServiceLinks: false,
@@ -321,8 +426,6 @@ module ContainerRuntime
     end
 
     def create_service(handle)
-      labels = { "app" => "aixle-runtime", "aixle-container" => handle.pod_name }
-
       ports = handle.service_ports.map do |port|
         {
           name: "port-#{port}",
@@ -337,10 +440,14 @@ module ContainerRuntime
         kind: "Service",
         metadata: {
           name: handle.service_name,
-          namespace: handle.namespace
+          namespace: handle.namespace,
+          labels: session_labels(handle)
         },
         spec: {
-          selector: labels,
+          # Deliberately narrower than the metadata labels: the selector must
+          # keep matching pods created by older builds, so it stays the two
+          # identity labels and never grows.
+          selector: pod_selector_labels(handle),
           ports: ports
         }
       )
@@ -366,7 +473,7 @@ module ContainerRuntime
         metadata: {
           name: handle.ingress_name,
           namespace: handle.namespace,
-          labels: resource_labels(namespace: handle.namespace)
+          labels: session_labels(handle)
         },
         spec: {
           entryPoints: [ traefik_entrypoint ],
@@ -663,7 +770,7 @@ module ContainerRuntime
         metadata: {
           name: "#{handle.pod_name}-#{suffix}-strip",
           namespace: handle.namespace,
-          labels: resource_labels(namespace: handle.namespace)
+          labels: session_labels(handle)
         },
         spec: {
           stripPrefix: {
@@ -739,6 +846,22 @@ module ContainerRuntime
       {
         "aixle.com/runtime-origin" => runtime_namespace,
         "aixle.com/runtime-namespace" => namespace
+      }
+    end
+
+    # The identity every object of one session carries. Applied uniformly to the
+    # Pod, the Service, the IngressRoute and both strip Middlewares so the whole
+    # set can be found (and reaped) from the pod name alone — before this was
+    # uniform, only pods were labelled and a dead node's Service/IngressRoute
+    # could not be attributed to anything.
+    def session_labels(handle)
+      resource_labels(namespace: handle.namespace).merge(pod_selector_labels(handle))
+    end
+
+    def pod_selector_labels(handle)
+      {
+        "app" => RUNTIME_APP_LABEL,
+        CONTAINER_LABEL => handle.pod_name
       }
     end
 

--- a/app/services/container_runtime/kubernetes_runtime.rb
+++ b/app/services/container_runtime/kubernetes_runtime.rb
@@ -163,6 +163,30 @@ module ContainerRuntime
       container.to_s
     end
 
+    # Pods are created with `restartPolicy: Never` (see #build_pod), so a container
+    # that dies is NOT restarted: the pod leaves the Running phase and stays around
+    # as Succeeded/Failed. When the node itself dies the pod object is eventually
+    # garbage-collected instead and the lookup 404s. Both mean the agent is gone.
+    #
+    # Pending is deliberately :starting — a pod waiting on scheduling or an image
+    # pull has simply not run yet.
+    def container_status(id)
+      handle = resolve_handle(id)
+      pod = core_client.get_pod(handle.pod_name, handle.namespace)
+
+      case pod&.status&.phase.to_s
+      when "Running" then :running
+      when "Pending" then :starting
+      when "Succeeded", "Failed" then :terminated
+      else :unknown
+      end
+    rescue Kubeclient::ResourceNotFoundError
+      :missing
+    rescue StandardError => e
+      Rails.logger.warn("[KubernetesRuntime] container_status failed for #{id}: #{e.message}")
+      :unknown
+    end
+
     private
 
     def copy_from(id, path)

--- a/app/services/container_runtime/kubernetes_runtime.rb
+++ b/app/services/container_runtime/kubernetes_runtime.rb
@@ -19,6 +19,7 @@ module ContainerRuntime
     DEFAULT_TRAEFIK_PORTS = [ 7681, 4040, 8443 ].freeze
     READY_TIMEOUT = 30
     READY_INTERVAL = 1
+    HANDSHAKE_STATUS_LINE = %r{\AHTTP/\d(?:\.\d)?\s+(\d{3})}
 
     # -- Lifecycle ------------------------------------------------------------
 
@@ -65,6 +66,13 @@ module ContainerRuntime
       stderr_lines = stderr.empty? ? [] : stderr.split("\n").map { |line| "#{line}\n" }
 
       [ stdout_lines, stderr_lines, exit_code ]
+    end
+
+    # See BaseRuntime#exec!. A pod that no longer exists answers the exec
+    # upgrade with a non-101 status (404 for a deleted pod); that surfaces as
+    # ContainerUnreachableError instead of a generic [[], [], 1].
+    def exec!(id, cmd, opts = {})
+      exec(id, cmd, opts.merge(raise_on_unreachable: true))
     end
 
     # -- File I/O -------------------------------------------------------------
@@ -451,85 +459,119 @@ module ContainerRuntime
       exit_code = 0
       done = false
       error = nil
+      error_reported = false
+      unreachable = nil
       mutex = Mutex.new
       cv = ConditionVariable.new
       ws_state = { closed: false }
       runtime = self
 
-      ws = WebSocket::Client::Simple.connect(url.to_s, headers: headers)
       exit_code_parser = method(:exit_code_from_status_payload)
 
-      ws.on(:open) do
-        next unless stdin_io
+      # Register the callbacks inside the connect block: the gem yields the
+      # client *before* it opens the socket and starts its reader thread.
+      # Registering them on the returned client instead is a race the API server
+      # wins whenever it answers fast — the :error/:close events then land on a
+      # client with no listeners and the exec sits until its timeout expires.
+      ws = WebSocket::Client::Simple.connect(url.to_s, headers: headers) do |client|
+        client.on(:open) do
+          next unless stdin_io
 
-        Thread.new do
-          begin
-            stdin_io.rewind if stdin_io.respond_to?(:rewind)
-            while (chunk = stdin_io.read(16_384))
-              break if runtime.send(:websocket_closed?, ws, ws_state)
-              ws.send([ 0 ].pack("C") + chunk)
+          Thread.new do
+            begin
+              stdin_io.rewind if stdin_io.respond_to?(:rewind)
+              while (chunk = stdin_io.read(16_384))
+                break if runtime.send(:websocket_closed?, client, ws_state)
+                client.send([ 0 ].pack("C") + chunk)
+              end
+              client.close if close_on_stdin_eof && !runtime.send(:websocket_closed?, client, ws_state)
+            rescue StandardError => e
+              mutex.synchronize do
+                error = e
+                exit_code = 1
+                done = true
+                cv.broadcast
+              end
             end
-            ws.close if close_on_stdin_eof && !runtime.send(:websocket_closed?, ws, ws_state)
-          rescue StandardError => e
+          end
+        end
+
+        client.on(:message) do |msg|
+          next if msg.data.to_s.empty?
+
+          data = msg.data.bytes
+          channel = data.shift
+          payload = data.pack("C*")
+          payload.force_encoding("utf-8") unless binary
+
+          case channel
+          when 1
+            if stdout_io
+              stdout_io.write(payload)
+            else
+              stdout << payload
+            end
+          when 2
+            if stderr_io
+              stderr_io.write(payload)
+            else
+              stderr << payload
+            end
+          when 3
             mutex.synchronize do
-              error = e
-              exit_code = 1
+              exit_code = exit_code_parser.call(payload)
               done = true
               cv.broadcast
             end
           end
         end
-      end
 
-      ws.on(:message) do |msg|
-        next if msg.data.to_s.empty?
-
-        data = msg.data.bytes
-        channel = data.shift
-        payload = data.pack("C*")
-        payload.force_encoding("utf-8") unless binary
-
-        case channel
-        when 1
-          if stdout_io
-            stdout_io.write(payload)
-          else
-            stdout << payload
+        # websocket-client-simple re-raises a failed handshake once per byte
+        # still sitting in the HTTP response, so a single 404 from a deleted pod
+        # emitted ~100 :error events — all of them logged, all of them redoing
+        # the same bookkeeping. Handle only the first and tear the connection
+        # down from inside the callback so the reader loop stops immediately.
+        client.on(:error) do |msg|
+          first_error = mutex.synchronize do
+            if error_reported || runtime.send(:websocket_closed?, client, ws_state)
+              false
+            else
+              error_reported = true
+              error = msg
+              exit_code = 1
+              done = true
+              unreachable = runtime.send(:build_unreachable_error, handle, client) if runtime.send(:handshake_error?, msg)
+              cv.broadcast
+              true
+            end
           end
-        when 2
-          if stderr_io
-            stderr_io.write(payload)
+          next unless first_error
+
+          if unreachable
+            Rails.logger.warn("[KubernetesRuntime] WebSocket handshake failed: #{unreachable.message}")
           else
-            stderr << payload
+            Rails.logger.warn("[KubernetesRuntime] WebSocket error: #{msg.inspect}")
           end
-        when 3
+
+          # #close runs on this (reader) thread and ends in Thread.kill(self),
+          # so nothing may follow it here — and the mutex must already be
+          # released, because closing emits :close, whose handler takes it.
+          begin
+            client.close
+          rescue StandardError
+            nil
+          end
+        end
+
+        client.on(:close) do |_msg|
           mutex.synchronize do
-            exit_code = exit_code_parser.call(payload)
+            ws_state[:closed] = true
             done = true
             cv.broadcast
           end
         end
       end
 
-      ws.on(:error) do |msg|
-        next if runtime.send(:websocket_closed?, ws, ws_state)
-
-        Rails.logger.warn("[KubernetesRuntime] WebSocket error: #{msg.inspect}")
-        mutex.synchronize do
-          error = msg
-          exit_code = 1
-          done = true
-          cv.broadcast
-        end
-      end
-
-      ws.on(:close) do |_msg|
-        mutex.synchronize do
-          ws_state[:closed] = true
-          done = true
-          cv.broadcast
-        end
-      end
       mutex.synchronize do
         cv.wait(mutex, timeout) unless done
         unless done
@@ -544,7 +586,9 @@ module ContainerRuntime
         Rails.logger.warn("[KubernetesRuntime] Failed to close WebSocket: #{e.message}")
       end
 
-      if error.is_a?(StandardError)
+      if unreachable
+        raise unreachable
+      elsif error.is_a?(StandardError)
         raise error
       elsif error
         Rails.logger.warn("[KubernetesRuntime] Exec error: #{error}")
@@ -552,8 +596,47 @@ module ContainerRuntime
 
       [ stdout, stderr, exit_code ]
     rescue StandardError => e
-      Rails.logger.warn("[KubernetesRuntime] Exec failed: #{e.message}")
+      # Tearing the connection down from the reader thread can also break a
+      # write still in flight on this one (IOError: stream closed in another
+      # thread). The callback already recorded — and logged — the real cause, so
+      # report that and stay quiet about the fallout.
+      unreachable ||= e if e.is_a?(ContainerUnreachableError)
+
+      if unreachable
+        raise unreachable if opts[:raise_on_unreachable]
+      else
+        Rails.logger.warn("[KubernetesRuntime] Exec failed: #{e.message}")
+      end
+
       [ "", "", 1 ]
+    end
+
+    def handshake_error?(error)
+      error.is_a?(::WebSocket::Error::Handshake)
+    end
+
+    def build_unreachable_error(handle, ws)
+      handshake = ws.respond_to?(:handshake) ? ws.handshake : nil
+
+      ContainerUnreachableError.new(
+        status_code: handshake_status_code(handshake),
+        container_identifier: "#{handle.namespace}/#{handle.pod_name}"
+      )
+    end
+
+    # websocket-client-simple hands us a bare
+    # WebSocket::Error::Handshake::InvalidStatusCode with no status attached,
+    # and WebSocket::Handshake::Client raises out of #<< before it records the
+    # response (its #headers still hold *our* request headers). The raw response
+    # text it accumulated is the only place the status survives, so read it
+    # defensively and fall back to "no status" rather than fighting the gem.
+    def handshake_status_code(handshake)
+      return nil if handshake.nil?
+
+      raw = handshake.instance_variable_get(:@data).to_s
+      raw[HANDSHAKE_STATUS_LINE, 1]&.to_i
+    rescue StandardError
+      nil
     end
 
     def build_exec_params(handle, cmd, opts)

--- a/app/services/container_runtime/session_resource.rb
+++ b/app/services/container_runtime/session_resource.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ContainerRuntime
+  # One reapable object a runtime created on behalf of an agent session.
+  #
+  # `route_token` is the reconciliation key — it is what ties the object back to
+  # the `TerminalSession` that owns it (`terminal_sessions.route_token`, uniquely
+  # indexed). A resource whose `route_token` is blank has no provable owner and
+  # must therefore never be a garbage-collection candidate.
+  #
+  # `created_at` is the object's own creation time as the runtime reports it
+  # (Kubernetes `metadata.creationTimestamp`, Docker's `Created`), not the
+  # session's — it is what the sweeper's minimum-age guard is measured against,
+  # so an object that came into existence seconds ago cannot be reaped no matter
+  # what the database says.
+  SessionResource = Struct.new(:kind, :name, :namespace, :route_token, :created_at, keyword_init: true) do
+    def to_s
+      namespace.present? ? "#{kind} #{namespace}/#{name}" : "#{kind} #{name}"
+    end
+  end
+end

--- a/app/services/session_service.rb
+++ b/app/services/session_service.rb
@@ -63,6 +63,33 @@ class SessionService
       session.fail! if session.may_fail?
     end
 
+    # Fail a session AND wake its container workflow, so the container's cleanup
+    # phase actually runs. THE blessed way to fail a session from outside the
+    # container workflow (watchdogs, scanners) — do not hand-roll
+    # `update!(error_message:) + fail!`.
+    #
+    # Why the signal is not optional: `TerminalSession#on_failed` only notifies the
+    # PARENT workflow run ("workflow-execution-<id>", via WorkflowService), which
+    # completes the step. The session's own container workflow is a different
+    # execution ("agent-session-<id>") and it is parked in its `exec` phase
+    # awaiting `container_finished` with a 23-hour signal timeout (see
+    # WorkflowStepStrategy#phase_config). Failing the row without signalling that
+    # execution leaves it spinning until the timeout, and its cleanup phase — the
+    # only thing that deletes the pod, Service, IngressRoute and Middlewares —
+    # never runs. Every such failure leaked its Kubernetes objects for a day.
+    #
+    # Ordering mirrors `finish`: transition first, signal second. The cleanup phase
+    # decides the step's outcome from `session.state` (CompleteStepActivity), so it
+    # must already read `failed`. Clearing `container_id` in `on_failed` is safe —
+    # the cleanup phase takes its container reference from the workflow's own
+    # accumulated state, not from the row.
+    def fail_session(session:, error_message: nil)
+      session.update!(error_message: error_message) if error_message.present?
+      session.fail! if session.may_fail?
+      signal_container_finished(session) if session.temporal_workflow_id.present?
+      session
+    end
+
     def create_for_workflow_step(step_run:)
       workflow_run = step_run.workflow_run
       step = step_run.step

--- a/app/temporal/activities/container/sweep_orphaned_resources_activity.rb
+++ b/app/temporal/activities/container/sweep_orphaned_resources_activity.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+# Activities::Container::SweepOrphanedResourcesActivity
+# Deletes the runtime objects of agent sessions that are over — the garbage
+# collector behind `Workflows::ContainerSweepOrphanedResourcesWorkflow`
+# (`app/temporal/schedules.yml`, every 10 minutes).
+#
+# WHY IT EXISTS
+# A session's Pod, Service, IngressRoute and Middlewares are torn down in
+# `ContainerRuntime#remove_container`, which only runs on the happy path. When a
+# node dies and takes its agent pods with it, nothing tears anything down: the
+# routing objects survive, the Service keeps zero endpoints, and the session URL
+# starts answering with Traefik's own "no available server" 503 instead of a
+# terminal. Prod reached 22 IngressRoutes against 7 live pods, the oldest orphan
+# 16 hours old. Nothing reclaimed them, because nothing was looking.
+#
+# SAFETY
+# The sweep may only delete what it can PROVE nobody is using. Three independent
+# guards have to agree before an object is touched:
+#
+#   1. Provable owner. Reconciliation is by `route_token`, which the runtime
+#      stamps on every object of a session (`aixle-container` label → pod name
+#      `terminal-<route_token>`) and which is uniquely indexed on
+#      `terminal_sessions`. An object whose token is missing or unparseable —
+#      an internal-tool pod, a hand-made object — has no provable owner and is
+#      always kept.
+#   2. Dead owner. The owning session must be in a terminal state (`finished`,
+#      `failed`) or absent from the database entirely. Every live state —
+#      `not_started`, `running`, `ready`, `finishing` — is kept, so a session
+#      that is merely slow (a long `not_started` while an image pulls, a
+#      long-running agent, a hung finalization) is never a candidate. Note the
+#      ordering that makes this hold: the session row is created, and its
+#      route_token generated, BEFORE any container is asked for — so an object
+#      can never exist ahead of the row that would protect it.
+#   3. Minimum age, twice. The OBJECT must itself be older than MIN_AGE
+#      (measured from the runtime's own creation timestamp, so an object created
+#      seconds ago during session startup can never qualify), and a
+#      terminal-state session's finalization must ALSO be older than MIN_AGE, so
+#      an in-flight `remove_container` is never raced. An object whose age the
+#      runtime cannot report is kept.
+#
+# The asymmetry is deliberate: keeping garbage costs a Service with no
+# endpoints until the next run, while deleting a live session's IngressRoute
+# kills someone's terminal mid-task. Every ambiguous case therefore resolves to
+# "keep".
+#
+# SCOPE
+# Only objects the runtime labelled as belonging to a session are enumerated
+# (see `KubernetesRuntime::SESSION_RESOURCE_SELECTOR`). Objects created before
+# that labelling was uniform — in particular Services, which carried no metadata
+# labels at all — are invisible here and remain a one-off operator cleanup.
+
+module Activities
+  module Container
+    class SweepOrphanedResourcesActivity < ::Activities::Base
+      # A session in any of these states may still be using its objects.
+      LIVE_STATES = %w[not_started running ready finishing].freeze
+
+      # Startup takes tens of seconds (pod schedule + image pull + readiness +
+      # Traefik route propagation), and teardown is a handful of API calls. Fifteen
+      # minutes is an order of magnitude clear of both, which is the point: the
+      # guard is not a tuned deadline, it is a margin wide enough that no normal
+      # timing can land inside it.
+      MIN_AGE = 15.minutes
+
+      def run(_input = nil)
+        cutoff = MIN_AGE.ago
+        resources = Array(runtime.list_session_resources)
+
+        aged, young = resources.partition { |resource| aged?(resource, cutoff) }
+        owned, unowned = aged.partition { |resource| resource.route_token.present? }
+        sessions = sessions_for(owned)
+
+        reapable, kept = owned.partition { |resource| reapable?(sessions[resource.route_token], cutoff) }
+        # Everything in `kept` has a session row — a missing one is reapable —
+        # so the split below is safe to index without a nil guard.
+        live, finalizing = kept.partition { |resource| LIVE_STATES.include?(sessions[resource.route_token].state) }
+
+        deleted, failed = reap(reapable, sessions)
+
+        summary = {
+          reaped: deleted.values.sum,
+          by_kind: deleted,
+          sessions: reapable.map(&:route_token).uniq.size,
+          kept_live: live.size,
+          kept_finalizing: finalizing.size,
+          kept_recent: young.size,
+          kept_unowned: unowned.size,
+          failed: failed
+        }
+
+        log(:info, "orphan sweep: #{format_summary(summary)}")
+        summary
+      end
+
+      private
+
+      # One grep-able line per run, so the next incident starts from "what did
+      # the sweep think" instead of from a cluster diff.
+      def format_summary(summary)
+        counts = summary.except(:by_kind).map { |key, value| "#{key}=#{value}" }
+        kinds = summary[:by_kind].sort.map { |kind, count| "#{kind}:#{count}" }
+        counts << "kinds=#{kinds.join(',')}" if kinds.any?
+        counts.join(" ")
+      end
+
+      # Guard 3a: the object's own age, as the runtime reports it. A resource
+      # whose creation time is unknown is not aged — it is unprovable, so kept.
+      def aged?(resource, cutoff)
+        resource.created_at.present? && resource.created_at < cutoff
+      end
+
+      # Guards 2 + 3b. `nil` means no row owns these objects any more, which is
+      # the node-died case the sweep exists for.
+      def reapable?(session, cutoff)
+        return true if session.nil?
+        return false if LIVE_STATES.include?(session.state)
+
+        finalized_at = session.finished_at || session.updated_at
+        finalized_at.present? && finalized_at < cutoff
+      end
+
+      def sessions_for(resources)
+        tokens = resources.map(&:route_token).uniq
+        return {} if tokens.empty?
+
+        TerminalSession
+          .where(route_token: tokens)
+          .select(:id, :route_token, :state, :finished_at, :updated_at)
+          .index_by(&:route_token)
+      end
+
+      # `resources` arrives in the runtime's promised deletion order — routing
+      # objects before the workload they point at — so it is deleted front to
+      # back without re-sorting.
+      def reap(resources, sessions)
+        deleted = Hash.new(0)
+        failed = 0
+
+        resources.each do |resource|
+          reason = sessions[resource.route_token] ? "session #{sessions[resource.route_token].id} over" : "no session row"
+
+          if runtime.delete_session_resource(resource)
+            deleted[resource.kind] += 1
+            log(:info, "reaped #{resource} for #{resource.route_token} (#{reason})")
+          else
+            failed += 1
+            log(:warn, "failed to reap #{resource} for #{resource.route_token} (#{reason})")
+          end
+        rescue StandardError => e
+          failed += 1
+          log(:warn, "failed to reap #{resource}: #{e.class}: #{e.message}")
+        end
+
+        [ deleted, failed ]
+      end
+
+      def runtime
+        @runtime ||= ContainerRuntime.build
+      end
+    end
+  end
+end

--- a/app/temporal/activities/session/scan_dead_containers_activity.rb
+++ b/app/temporal/activities/session/scan_dead_containers_activity.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+# ScanDeadContainersActivity
+# Watchdog for agent containers that died without telling anyone.
+#
+# Agent pods are bare pods with `restartPolicy: Never` and no owning controller
+# (ContainerRuntime::KubernetesRuntime#build_pod), so when their node dies the pods
+# die with it — and nothing in the app notices. The session stays `ready` forever,
+# its container workflow keeps awaiting `container_finished` (23-hour signal
+# timeout), and the linked StepRun stays `running` with a frozen `updated_at`. In
+# production a single node OOM stranded ten sessions this way, the oldest for 16
+# hours.
+#
+# This sweep closes the loop: it asks the runtime whether each active session's
+# container is still there, and drives the ones that are not through the existing
+# `fail` path (SessionService.fail_session → container_finished → cleanup phase →
+# CompleteStepActivity), which is what fails the step and reclaims the pod,
+# Service, IngressRoute and Middlewares.
+#
+# Two guards keep it from firing on healthy sessions:
+#
+#   MIN_AGE            — a pod that has not been created yet is not a dead pod.
+#   CONFIRMATION_DELAY — one look is not enough. The normal teardown path
+#                        (ContainerStrategies::BaseStrategy#cleanup) stops and
+#                        removes the container while the session is still `ready`
+#                        and only transitions it afterwards, so for a few seconds a
+#                        perfectly healthy completion is indistinguishable from a
+#                        dead node. A session is only failed when it looked dead
+#                        twice, CONFIRMATION_DELAY apart.
+module Activities
+  module Session
+    class ScanDeadContainersActivity < Base
+      ACTIVE_STATES = %w[running ready].freeze
+
+      # Runtime answers that mean "the agent is gone". `:starting` (pod Pending,
+      # docker "created") and `:unknown` (control plane unreachable) never qualify —
+      # see ContainerRuntime::BaseRuntime#container_status.
+      DEAD_STATUSES = %i[missing terminated].freeze
+      ALIVE_STATUSES = %i[running starting].freeze
+
+      # A pod can sit Pending for a while (scheduling, image pull) and reports
+      # `:starting` while it does, so this is belt-and-braces rather than the main
+      # defence: it only has to cover the moment between persisting `container_id`
+      # and the runtime being able to answer for it at all.
+      MIN_AGE = 2.minutes
+
+      # Comfortably longer than a normal teardown (stop with a 5s grace, remove,
+      # transition — seconds), and short enough that a genuinely dead session is
+      # failed within ~3 minutes instead of hanging for a day.
+      CONFIRMATION_DELAY = 2.minutes
+
+      MARKER_KEY = "container_dead_since"
+
+      MESSAGES = {
+        missing: "Agent container vanished: the container runtime no longer knows this container. " \
+                 "Its node most likely died or the pod was evicted.",
+        terminated: "Agent container is no longer running: it exited before the session finished. " \
+                    "Its node most likely died, or the container was killed (out of memory, eviction)."
+      }.freeze
+
+      def run(_input = nil)
+        checked = 0
+        failed = 0
+
+        candidate_sessions.find_each do |session|
+          checked += 1
+          status = runtime.container_status(session.container_id)
+
+          if DEAD_STATUSES.include?(status)
+            failed += 1 if confirm_or_mark(session, status)
+          elsif ALIVE_STATUSES.include?(status)
+            clear_marker(session)
+          end
+        rescue StandardError => e
+          log(:warn, "Failed to check session #{session.id}: #{e.message}")
+        end
+
+        { checked: checked, failed: failed }
+      end
+
+      private
+
+      def candidate_sessions
+        TerminalSession
+          .where(state: ACTIVE_STATES)
+          .where.not(container_id: [ nil, "" ])
+          .where("COALESCE(started_at, created_at) < ?", MIN_AGE.ago)
+      end
+
+      # First sighting only records the time; the session is failed on a later
+      # sighting, once CONFIRMATION_DELAY has passed and it is still both dead and
+      # active. Returns true when the session was failed.
+      def confirm_or_mark(session, status)
+        first_seen = marker_at(session)
+
+        if first_seen.nil?
+          mark_dead(session)
+          return false
+        end
+
+        return false if first_seen > CONFIRMATION_DELAY.ago
+        return false unless ACTIVE_STATES.include?(session.reload.state)
+
+        SessionService.fail_session(session: session, error_message: MESSAGES.fetch(status))
+        log(:info, "Failed session #{session.id}: container #{status}")
+        true
+      end
+
+      def marker_at(session)
+        raw = session.metadata&.dig(MARKER_KEY)
+        return nil if raw.blank?
+
+        Time.zone.parse(raw.to_s)
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+      def mark_dead(session)
+        session.update!(metadata: (session.metadata || {}).merge(MARKER_KEY => Time.current.iso8601))
+        log(:info, "Session #{session.id} looks dead; re-checking in #{CONFIRMATION_DELAY.inspect}")
+      end
+
+      # A container that came back (or was never really gone — a flapping API read)
+      # drops its marker, so confirmation always means two dead sightings with
+      # nothing alive in between.
+      def clear_marker(session)
+        return unless session.metadata.is_a?(Hash) && session.metadata.key?(MARKER_KEY)
+
+        session.update!(metadata: session.metadata.except(MARKER_KEY))
+      end
+
+      def runtime
+        @runtime ||= ContainerRuntime.build
+      end
+    end
+  end
+end

--- a/app/temporal/activities/workflow/scan_quota_errors_activity.rb
+++ b/app/temporal/activities/workflow/scan_quota_errors_activity.rb
@@ -2,8 +2,10 @@
 
 # ScanQuotaErrorsActivity
 # Finds active workflow_step sessions and checks for quota error patterns in
-# error_message and live terminal output. When detected, transitions the session
-# to "failed" which triggers container_finished → CompleteStepActivity.
+# error_message and live terminal output. When detected, fails the session through
+# SessionService.fail_session, which both completes the step (container_finished →
+# CompleteStepActivity) and lets the session's own container workflow reach its
+# cleanup phase instead of waiting out its 23-hour signal timeout.
 module Activities
   module Workflow
     class ScanQuotaErrorsActivity < ::Activities::Base
@@ -18,8 +20,12 @@ module Activities
           detection = QuotaErrorDetector.detect(detection_text_for(session))
           next unless detection.quota_error?
 
-          session.update!(error_message: detection.message)
-          session.fail! if session.may_fail?
+          # Through SessionService, not `fail!` directly: failing the row alone
+          # leaves this session's own container workflow parked on its
+          # `container_finished` await for 23 hours, so its cleanup phase never
+          # runs and the pod/Service/IngressRoute leak. See
+          # SessionService.fail_session.
+          SessionService.fail_session(session: session, error_message: detection.message)
           cleaned += 1
         rescue StandardError => e
           log(:warn, "Failed to process session #{session.id}: #{e.message}")

--- a/app/temporal/activities/workflow/scan_quota_errors_activity.rb
+++ b/app/temporal/activities/workflow/scan_quota_errors_activity.rb
@@ -13,6 +13,7 @@ module Activities
 
       def run(_input = nil)
         cleaned = 0
+        unreachable = 0
 
         candidate_sessions.find_each do |session|
           detection = QuotaErrorDetector.detect(detection_text_for(session))
@@ -21,11 +22,19 @@ module Activities
           session.update!(error_message: detection.message)
           session.fail! if session.may_fail?
           cleaned += 1
+        rescue ContainerRuntime::ContainerUnreachableError => e
+          # The pod behind this session is gone (node died, pod evicted). Its
+          # tmux is not coming back, so re-running capture-pane against it every
+          # sweep only burns CPU — that spin is what pinned worker-ruby to its
+          # HPA ceiling. Skip the session and leave its fate to the session
+          # watchdog; one line per session, not one per exec attempt.
+          log(:warn, "Skipping session #{session.id}: #{e.message}")
+          unreachable += 1
         rescue StandardError => e
           log(:warn, "Failed to process session #{session.id}: #{e.message}")
         end
 
-        { cleaned: cleaned }
+        { cleaned: cleaned, unreachable: unreachable }
       end
 
       private
@@ -48,11 +57,15 @@ module Activities
         container = runtime.resolve_container(session.container_id)
         return "" unless container
 
-        runtime.exec(
+        # exec! (not exec) so a destroyed pod arrives as ContainerUnreachableError
+        # instead of an exit code of 1 that looks like an ordinary command failure.
+        runtime.exec!(
           container,
           [ "sh", "-c", "tmux capture-pane -t agent -p -S -1000 2>/dev/null || true" ],
           stdout: true, stderr: true
         ).then { |stdout, _stderr, status| status.zero? ? stdout.join("\n") : "" }
+      rescue ContainerRuntime::ContainerUnreachableError
+        raise
       rescue StandardError => e
         log(:warn, "Failed to read terminal for session #{session.id}: #{e.message}")
         ""

--- a/app/temporal/schedules.yml
+++ b/app/temporal/schedules.yml
@@ -27,6 +27,20 @@ schedules:
     cron: "0 * * * *"
     enabled: true
 
+  # Reclaims the Kubernetes objects of agent sessions that ended without the
+  # happy-path teardown running — the node-died case, which otherwise leaves an
+  # IngressRoute and an endpoint-less Service answering 503 on the session URL
+  # forever.
+  #
+  # Every 10 minutes against a 15-minute minimum object age: an orphan is gone
+  # within ~25 minutes, while nothing created inside the last quarter hour can
+  # be looked at. SKIP overlap: two sweeps would enumerate the same objects and
+  # race each other's deletes, turning a benign 404 into log noise.
+  - workflow: container_sweep_orphaned_resources_workflow
+    cron: "*/10 * * * *"
+    overlap: skip
+    enabled: true
+
   # Mirrors the Official MCP Registry into the local connector catalog.
   #
   # Weekly, not the hourly cadence the registry suggests to aggregators. What

--- a/app/temporal/schedules.yml
+++ b/app/temporal/schedules.yml
@@ -14,6 +14,24 @@ schedules:
     cron: "* * * * *"
     enabled: true
 
+  # Watchdog for agent containers that died without telling anyone (node failure,
+  # eviction, OOM kill). The pods are bare pods with restartPolicy: Never, so
+  # nothing else notices: the session stays `ready` and its container workflow
+  # waits 23 hours for a signal that will never arrive.
+  #
+  # Every minute, because the cost of a miss is a workflow step wedged for a day,
+  # while the scan is one runtime lookup per active session. Nothing is failed on a
+  # single sighting — the activity requires two, two minutes apart — so the cadence
+  # sets detection latency (~3 minutes), not sensitivity.
+  #
+  # SKIP overlap: a slow sweep must not be joined by the next one re-checking the
+  # same sessions, which would confirm a session dead against its own first
+  # sighting.
+  - workflow: dead_container_scan_workflow
+    cron: "* * * * *"
+    overlap: skip
+    enabled: true
+
   # Transactional-outbox safety net: re-dispatches trigger events a producer
   # committed but crashed before dispatching. Every minute is the finest cron
   # granularity; the happy path dispatches inline, so this only recovers crashes.

--- a/app/temporal/workflows.yml
+++ b/app/temporal/workflows.yml
@@ -23,6 +23,12 @@ workflows:
       - name: session_cleanup_stale_activity
         task_queue: aixle_ruby
 
+  - name: dead_container_scan_workflow
+    owner: aixle_ruby
+    activities:
+      - name: session_scan_dead_containers_activity
+        task_queue: aixle_ruby
+
   - name: dismissed_asset_cleanup_workflow
     owner: aixle_ruby
     activities:

--- a/app/temporal/workflows.yml
+++ b/app/temporal/workflows.yml
@@ -47,6 +47,12 @@ workflows:
       - name: coder_sweep_expired_locks_activity
         task_queue: aixle_ruby
 
+  - name: container_sweep_orphaned_resources_workflow
+    owner: aixle_ruby
+    activities:
+      - name: container_sweep_orphaned_resources_activity
+        task_queue: aixle_ruby
+
   - name: mcp_connector_catalog_sync_workflow
     owner: aixle_ruby
     activities:

--- a/app/temporal/workflows/container_sweep_orphaned_resources_workflow.rb
+++ b/app/temporal/workflows/container_sweep_orphaned_resources_workflow.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Workflows
+  # ContainerSweepOrphanedResourcesWorkflow — garbage-collects the runtime
+  # objects (Pod, Service, IngressRoute, Middlewares) of agent sessions that are
+  # finished, failed, or gone from the database. Wired into
+  # `app/temporal/schedules.yml` so the project's existing Temporal cron drives
+  # it.
+  #
+  # Correctness does not depend on the cadence: the happy path still tears its
+  # own objects down in `ContainerRuntime#remove_container`, and the sweep is
+  # idempotent — a missed run leaves the same garbage for the next one, a doubled
+  # run finds nothing the first already deleted. The cadence only decides how
+  # long a dead node's leftovers keep answering 503 on a session URL.
+  class ContainerSweepOrphanedResourcesWorkflow < Base
+    def run(_input = nil)
+      execute_activity(
+        activities.container_sweep_orphaned_resources_activity, {},
+        start_to_close_timeout: 300,
+        retry_policy: Temporalio::RetryPolicy.new(max_attempts: 2)
+      )
+    end
+  end
+end

--- a/app/temporal/workflows/dead_container_scan_workflow.rb
+++ b/app/temporal/workflows/dead_container_scan_workflow.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Workflows
+  class DeadContainerScanWorkflow < Base
+    def run(_input = nil)
+      execute_activity(
+        activities.session_scan_dead_containers_activity, {},
+        start_to_close_timeout: 300,
+        retry_policy: Temporalio::RetryPolicy.new(max_attempts: 2)
+      )
+    end
+  end
+end

--- a/test/jobs/container_runtime/sweep_orphaned_resources_job_test.rb
+++ b/test/jobs/container_runtime/sweep_orphaned_resources_job_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ContainerRuntime
+  class SweepOrphanedResourcesJobTest < ActiveSupport::TestCase
+    setup do
+      @company = create(:company)
+      @user = create(:user, :admin, company: @company)
+      @runtime = stub_container_runtime
+    end
+
+    teardown do
+      cleanup_runtime_overrides
+    end
+
+    test "reaps the same objects the scheduled sweep would, and returns its summary" do
+      dead = create(:terminal_session, :failed, user: @user, finished_at: 3.hours.ago)
+      live = create(:terminal_session, :running, user: @user, started_at: 20.hours.ago)
+      @runtime.seed_session_resources(route_token: dead.route_token, created_at: 3.hours.ago)
+      live_resources = @runtime.seed_session_resources(route_token: live.route_token, created_at: 20.hours.ago)
+
+      summary = ContainerRuntime::SweepOrphanedResourcesJob.new.perform
+
+      assert_equal 4, summary[:reaped]
+      assert_equal 4, summary[:kept_live]
+      assert_equal live_resources, @runtime.list_session_resources
+    end
+  end
+end

--- a/test/services/container_runtime/base_runtime_test.rb
+++ b/test/services/container_runtime/base_runtime_test.rb
@@ -64,6 +64,10 @@ module ContainerRuntime
       assert_raises(NotImplementedError) { @runtime.container_identifier("container") }
     end
 
+    test "container_status raises NotImplementedError" do
+      assert_raises(NotImplementedError) { @runtime.container_status("id") }
+    end
+
     test "wait_container raises NotImplementedError" do
       assert_raises(NotImplementedError) { @runtime.wait_container("id") }
     end

--- a/test/services/container_runtime/docker_runtime_test.rb
+++ b/test/services/container_runtime/docker_runtime_test.rb
@@ -107,6 +107,42 @@ module ContainerRuntime
       assert_nil result
     end
 
+    # -- container_status: is this container still alive? --
+
+    test "container_status reports a live container as running" do
+      stub_container_state("Running" => true, "Status" => "running")
+
+      assert_equal :running, @runtime.container_status("cid")
+    end
+
+    test "container_status reports a container that has not started yet as starting" do
+      stub_container_state("Running" => false, "Status" => "created")
+
+      assert_equal :starting, @runtime.container_status("cid")
+    end
+
+    test "container_status reports an exited container as terminated" do
+      stub_container_state("Running" => false, "Status" => "exited", "ExitCode" => 137)
+
+      assert_equal :terminated, @runtime.container_status("cid")
+    end
+
+    test "container_status reports a container the daemon has never heard of as missing" do
+      Docker::Container.stubs(:get).with("gone").raises(Docker::Error::NotFoundError)
+
+      assert_equal :missing, @runtime.container_status("gone")
+    end
+
+    test "container_status reports unknown rather than dead when the daemon errors" do
+      # A daemon that cannot answer is not evidence a container died — callers key
+      # session failure off :missing/:terminated only.
+      container_mock = mock("container")
+      container_mock.stubs(:json).raises(Docker::Error::ServerError.new("boom"))
+      Docker::Container.stubs(:get).with("cid").returns(container_mock)
+
+      assert_equal :unknown, @runtime.container_status("cid")
+    end
+
     test "container_identifier returns nil for blank" do
       assert_nil @runtime.container_identifier(nil)
       assert_nil @runtime.container_identifier("")
@@ -307,6 +343,13 @@ module ContainerRuntime
     end
 
     private
+
+    def stub_container_state(state)
+      container_mock = mock("container")
+      container_mock.stubs(:json).returns("State" => state)
+      Docker::Container.stubs(:get).with("cid").returns(container_mock)
+      container_mock
+    end
 
     def build_test_tar(filename, content)
       io = StringIO.new

--- a/test/services/container_runtime/docker_runtime_test.rb
+++ b/test/services/container_runtime/docker_runtime_test.rb
@@ -306,7 +306,60 @@ module ContainerRuntime
       assert_equal "Custom#123", @runtime.container_identifier(container_mock)
     end
 
+    # == Garbage-collection primitives ==
+
+    test "list_session_resources describes session containers, exited ones included" do
+      Docker::Container.expects(:all)
+        .with(all: true, filters: { label: [ "aixle.session_id" ] }.to_json)
+        .returns([
+          session_container("terminal-abc123", created: 1_764_000_000),
+          session_container("aixle-tool-xyz", created: 1_764_000_500)
+        ])
+
+      resources = @runtime.list_session_resources
+
+      assert_equal [ "Container", "Container" ], resources.map(&:kind)
+      assert_equal [ "terminal-abc123", "aixle-tool-xyz" ], resources.map(&:name)
+      # A tool container has no route token, so it has no provable owner and the
+      # sweeper keeps it.
+      assert_equal [ "abc123", nil ], resources.map(&:route_token)
+      assert_equal Time.zone.at(1_764_000_000), resources.first.created_at
+    end
+
+    test "list_session_resources reports nothing when the daemon is unreachable" do
+      Docker::Container.stubs(:all).raises(StandardError.new("connection refused"))
+
+      assert_empty @runtime.list_session_resources
+    end
+
+    test "delete_session_resource removes the container and treats an already-gone one as success" do
+      container_mock = mock("container")
+      container_mock.expects(:remove).with(force: true)
+      Docker::Container.expects(:get).with("terminal-abc123").returns(container_mock)
+      Docker::Container.expects(:get).with("terminal-gone").raises(Docker::Error::NotFoundError)
+
+      assert @runtime.delete_session_resource(session_resource("terminal-abc123"))
+      assert @runtime.delete_session_resource(session_resource("terminal-gone"))
+      assert_not @runtime.delete_session_resource(session_resource(""))
+    end
+
+    test "delete_session_resource reports false when removal fails" do
+      Docker::Container.stubs(:get).with("terminal-stuck").raises(Docker::Error::ServerError)
+
+      assert_not @runtime.delete_session_resource(session_resource("terminal-stuck"))
+    end
+
     private
+
+    def session_container(name, created:)
+      container = mock("container")
+      container.stubs(:info).returns("Names" => [ "/#{name}" ], "Id" => "abcdef0123456789", "Created" => created)
+      container
+    end
+
+    def session_resource(name)
+      ContainerRuntime::SessionResource.new(kind: "Container", name: name, route_token: "abc123")
+    end
 
     def build_test_tar(filename, content)
       io = StringIO.new

--- a/test/services/container_runtime/kubernetes_runtime_test.rb
+++ b/test/services/container_runtime/kubernetes_runtime_test.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require "rubygems/package"
+require "socket"
 
 module ContainerRuntime
   class KubernetesRuntimeTest < ActiveSupport::TestCase
@@ -478,7 +479,142 @@ module ContainerRuntime
       assert_equal :pod_deleted, result
     end
 
+    # -- Refused exec upgrade (pod gone) --------------------------------------
+
+    test "handshake_status_code reads the HTTP status out of a refused upgrade" do
+      handshake = ::WebSocket::Handshake::Client.new(url: "http://127.0.0.1:1/api/v1/pods/x/exec")
+
+      begin
+        handshake << "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\n\r\n#{POD_NOT_FOUND_BODY}"
+      rescue ::WebSocket::Error::Handshake::InvalidStatusCode
+        # Whether the gem raises here depends on the global WebSocket.should_raise
+        # flag; either way the raw response is now buffered on the handshake,
+        # which is the only place the status code survives.
+      end
+
+      assert_equal 404, @runtime.send(:handshake_status_code, handshake)
+    end
+
+    test "handshake_status_code returns nil when there is nothing to read" do
+      assert_nil @runtime.send(:handshake_status_code, nil)
+
+      handshake = ::WebSocket::Handshake::Client.new(url: "http://127.0.0.1:1/api/v1/pods/x/exec")
+      assert_nil @runtime.send(:handshake_status_code, handshake)
+    end
+
+    test "handshake_error? separates a refused upgrade from a mid-stream failure" do
+      assert @runtime.send(:handshake_error?, ::WebSocket::Error::Handshake::InvalidStatusCode.new)
+      assert_not @runtime.send(:handshake_error?, IOError.new("closed stream"))
+      assert_not @runtime.send(:handshake_error?, "exec timeout after 30s")
+    end
+
+    test "exec logs the refused upgrade exactly once and reports a generic failure" do
+      handle = OpenStruct.new(pod_name: "terminal-gone", namespace: "aixle-user-1", container_name: "main")
+
+      logs = with_refused_exec_endpoint("404 Not Found") do
+        stdout, stderr, exit_code = @runtime.exec(handle, [ "sh", "-c", "true" ], timeout: 5)
+
+        assert_equal [], stdout
+        assert_equal [], stderr
+        assert_equal 1, exit_code
+      end
+
+      # The gem re-raises a failed handshake once per byte left in the HTTP
+      # response (~190 lines for this body before the fix); the connection must
+      # now be torn down after the first one.
+      assert_equal 1, logs.scan("WebSocket handshake failed").size
+      assert_equal 0, logs.scan("WebSocket error:").size
+      assert_match(%r{aixle-user-1/terminal-gone is unreachable \(exec handshake returned HTTP 404\)}, logs)
+    end
+
+    test "exec! raises ContainerUnreachableError carrying the handshake status" do
+      handle = OpenStruct.new(pod_name: "terminal-gone", namespace: "aixle-user-1", container_name: "main")
+
+      error = nil
+      logs = with_refused_exec_endpoint("404 Not Found") do
+        error = assert_raises(ContainerRuntime::ContainerUnreachableError) do
+          @runtime.exec!(handle, [ "sh", "-c", "true" ], timeout: 5)
+        end
+      end
+
+      assert_equal 404, error.status_code
+      assert_equal "aixle-user-1/terminal-gone", error.container_identifier
+      assert_match(/unreachable/, error.message)
+      assert_equal 1, logs.scan("WebSocket handshake failed").size
+    end
+
+    test "exec! reports the status of any refused upgrade, not just 404" do
+      handle = OpenStruct.new(pod_name: "terminal-gone", namespace: "aixle-user-1", container_name: "main")
+
+      error = nil
+      with_refused_exec_endpoint("503 Service Unavailable") do
+        error = assert_raises(ContainerRuntime::ContainerUnreachableError) do
+          @runtime.exec!(handle, [ "sh", "-c", "true" ], timeout: 5)
+        end
+      end
+
+      assert_equal 503, error.status_code
+    end
+
     private
+
+    POD_NOT_FOUND_BODY = {
+      kind: "Status",
+      apiVersion: "v1",
+      metadata: {},
+      status: "Failure",
+      message: 'pods "terminal-gone" not found',
+      reason: "NotFound",
+      details: { name: "terminal-gone", kind: "pods" },
+      code: 404
+    }.to_json.freeze
+
+    # Stands in for the Kubernetes API server refusing the exec upgrade: a real
+    # TCP listener answering with a non-101 status, driven through the real
+    # websocket gem. Nothing vendor-owned is stubbed (docs/testing.md R2) — the
+    # runtime's own k8s client is pointed at the listener instead.
+    def with_refused_exec_endpoint(status_line)
+      server = TCPServer.new("127.0.0.1", 0)
+      port = server.addr[1]
+
+      acceptor = Thread.new do
+        Thread.current.report_on_exception = false
+        socket = server.accept
+        loop do
+          line = socket.gets
+          break if line.nil? || line == "\r\n"
+        end
+        socket.write(
+          "HTTP/1.1 #{status_line}\r\n" \
+          "Content-Type: application/json\r\n" \
+          "Content-Length: #{POD_NOT_FOUND_BODY.bytesize}\r\n" \
+          "\r\n#{POD_NOT_FOUND_BODY}"
+        )
+        socket.flush
+        # Hold the connection open so the client, not the server, decides when
+        # the exchange ends — that is the behaviour under test.
+        socket.read
+      rescue StandardError
+        nil # the client hung up; nothing left for this listener to do
+      end
+
+      @runtime.stubs(:core_client).returns(Kubeclient::Client.new("http://127.0.0.1:#{port}/api", "v1"))
+
+      capture_rails_log { yield }
+    ensure
+      acceptor&.kill
+      server&.close
+    end
+
+    def capture_rails_log
+      buffer = StringIO.new
+      previous = Rails.logger
+      Rails.logger = ActiveSupport::Logger.new(buffer)
+      yield
+      buffer.string
+    ensure
+      Rails.logger = previous
+    end
 
     def build_test_tar(filename, content)
       io = StringIO.new

--- a/test/services/container_runtime/kubernetes_runtime_test.rb
+++ b/test/services/container_runtime/kubernetes_runtime_test.rb
@@ -213,6 +213,51 @@ module ContainerRuntime
       assert_equal "aixle-project-77", result.namespace
     end
 
+    # -- container_status: is this pod still alive? --
+    #
+    # Pods run with restartPolicy: Never and no owning controller, so a dead agent
+    # either leaves a terminated pod behind or — when its node is gone — no pod at
+    # all. Both must read as "gone"; a pod that has simply not been scheduled yet
+    # must not.
+
+    test "container_status reports a running pod as running" do
+      stub_pod_phase("Running")
+
+      assert_equal :running, @runtime.container_status(pod_handle)
+    end
+
+    test "container_status reports a pending pod as starting" do
+      stub_pod_phase("Pending")
+
+      assert_equal :starting, @runtime.container_status(pod_handle)
+    end
+
+    test "container_status reports a pod that left the Running phase as terminated" do
+      stub_pod_phase("Failed")
+      assert_equal :terminated, @runtime.container_status(pod_handle)
+
+      stub_pod_phase("Succeeded")
+      assert_equal :terminated, @runtime.container_status(pod_handle)
+    end
+
+    test "container_status reports a pod the API no longer knows as missing" do
+      core_mock = mock("core_client")
+      core_mock.stubs(:get_pod).raises(Kubeclient::ResourceNotFoundError.new(404, "pods 'my-pod' not found", nil))
+      @runtime.stubs(:core_client).returns(core_mock)
+
+      assert_equal :missing, @runtime.container_status(pod_handle)
+    end
+
+    test "container_status reports unknown rather than dead when the API cannot answer" do
+      # An unreachable control plane is not a dead pod: callers only fail sessions
+      # on :missing/:terminated.
+      core_mock = mock("core_client")
+      core_mock.stubs(:get_pod).raises(StandardError.new("connection refused"))
+      @runtime.stubs(:core_client).returns(core_mock)
+
+      assert_equal :unknown, @runtime.container_status(pod_handle)
+    end
+
     test "stop_container deletes pod" do
       handle = OpenStruct.new(pod_name: "my-pod", namespace: "default")
       core_mock = mock("core_client")
@@ -479,6 +524,20 @@ module ContainerRuntime
     end
 
     private
+
+    # A resolved handle, so the status lookup is the only API call under test.
+    def pod_handle
+      OpenStruct.new(pod_name: "my-pod", namespace: "default")
+    end
+
+    def stub_pod_phase(phase)
+      core_mock = mock("core_client")
+      core_mock.stubs(:get_pod).with("my-pod", "default").returns(
+        OpenStruct.new(status: OpenStruct.new(phase: phase))
+      )
+      @runtime.stubs(:core_client).returns(core_mock)
+      core_mock
+    end
 
     def build_test_tar(filename, content)
       io = StringIO.new

--- a/test/services/container_runtime/kubernetes_runtime_test.rb
+++ b/test/services/container_runtime/kubernetes_runtime_test.rb
@@ -478,7 +478,195 @@ module ContainerRuntime
       assert_equal :pod_deleted, result
     end
 
+    # == Session-object identity labels ==
+    #
+    # The garbage collector finds a dead session's objects by label, so every
+    # object one session owns has to carry the same identity. Before this was
+    # uniform only the Pod did, and a dead node's Service/IngressRoute could not
+    # be attributed to anything.
+
+    test "every object a session owns carries the same identity labels" do
+      handle = OpenStruct.new(
+        pod_name: "terminal-abc123",
+        namespace: "aixle-project-7",
+        container_name: "main",
+        service_name: "terminal-abc123",
+        ingress_name: "terminal-abc123-ingress",
+        middleware_names: [ "terminal-abc123-tty-strip", "terminal-abc123-fs-strip" ],
+        route_token: "abc123",
+        service_ports: [ 7681, 4040 ]
+      )
+
+      created = []
+      core_mock = mock("core_client")
+      core_mock.expects(:create_service).with { |service| created << service }.returns(true)
+      traefik_mock = mock("traefik_client")
+      traefik_mock.expects(:get_entity).with("middlewares", "terminal-auth", "aixle-project-7").returns(true)
+      traefik_mock.expects(:create_entity).times(3).with { |_kind, _plural, resource| created << resource }.returns(true)
+
+      @runtime.stubs(:core_client).returns(core_mock)
+      @runtime.stubs(:traefik_client).returns(traefik_mock)
+
+      @runtime.start_container(handle)
+      created << @runtime.send(:build_pod, { image: "alpine", env_vars: [] }, handle)
+
+      assert_equal 5, created.size
+      created.each do |resource|
+        labels = labels_of(resource)
+        assert_equal "aixle-runtime", labels["app"],
+                     "#{resource.kind} is missing the runtime app label"
+        assert_equal "terminal-abc123", labels["aixle-container"],
+                     "#{resource.kind} is missing the per-session identity label"
+      end
+    end
+
+    test "service selector stays the two pod identity labels so it keeps matching older pods" do
+      handle = OpenStruct.new(
+        pod_name: "terminal-abc123",
+        namespace: "default",
+        service_name: "terminal-abc123",
+        route_token: nil,
+        service_ports: [ 7681 ]
+      )
+
+      created_service = nil
+      core_mock = mock("core_client")
+      core_mock.expects(:create_service).with { |service| created_service = service }.returns(true)
+      @runtime.stubs(:core_client).returns(core_mock)
+
+      @runtime.start_container(handle)
+
+      selector = created_service.spec.to_h[:selector].to_h.transform_keys(&:to_s)
+      assert_equal({ "app" => "aixle-runtime", "aixle-container" => "terminal-abc123" }, selector)
+    end
+
+    test "the shared terminal-auth middleware carries no per-session label, so a sweep cannot select it" do
+      middleware = @runtime.send(:build_terminal_auth_middleware, "aixle-project-7")
+
+      labels = labels_of(middleware)
+      assert_equal "aixle", labels["aixle.com/runtime-origin"]
+      assert_not labels.key?("aixle-container")
+    end
+
+    # == Garbage-collection primitives ==
+
+    test "list_session_resources maps labelled objects to session resources in deletion order" do
+      core_mock = mock("core_client")
+      traefik_mock = mock("traefik_client")
+
+      traefik_mock.expects(:get_entities)
+        .with("IngressRoute", "ingressroutes", label_selector: KubernetesRuntime::SESSION_RESOURCE_SELECTOR, as: :raw)
+        .returns(items_json([ kube_item("terminal-abc123-ingress", "aixle-project-7", "terminal-abc123") ]))
+      traefik_mock.expects(:get_entities)
+        .with("Middleware", "middlewares", label_selector: KubernetesRuntime::SESSION_RESOURCE_SELECTOR, as: :raw)
+        .returns(items_json([ kube_item("terminal-abc123-tty-strip", "aixle-project-7", "terminal-abc123") ]))
+      core_mock.expects(:get_entities)
+        .with("Service", "services", label_selector: KubernetesRuntime::SESSION_RESOURCE_SELECTOR, as: :raw)
+        .returns(items_json([ kube_item("terminal-abc123", "aixle-project-7", "terminal-abc123") ]))
+      core_mock.expects(:get_entities)
+        .with("Pod", "pods", label_selector: KubernetesRuntime::SESSION_RESOURCE_SELECTOR, as: :raw)
+        .returns(items_json([ kube_item("terminal-abc123", "aixle-project-7", "terminal-abc123") ]))
+
+      @runtime.stubs(:core_client).returns(core_mock)
+      @runtime.stubs(:traefik_client).returns(traefik_mock)
+
+      resources = @runtime.list_session_resources
+
+      assert_equal %w[IngressRoute Middleware Service Pod], resources.map(&:kind)
+      assert_equal [ "abc123" ], resources.map(&:route_token).uniq
+      assert_equal [ "aixle-project-7" ], resources.map(&:namespace).uniq
+      assert_equal Time.zone.parse("2026-08-09T10:00:00Z"), resources.first.created_at
+      assert_equal "terminal-abc123-ingress", resources.first.name
+    end
+
+    test "list_session_resources leaves the route token nil for a pod that is not an agent session" do
+      resources = stub_listing([ kube_item("aixle-tool-xyz", "aixle", "aixle-tool-xyz") ])
+
+      assert_nil resources.first.route_token
+      assert_equal "aixle-tool-xyz", resources.first.name
+    end
+
+    test "list_session_resources reports nothing for a kind the API refuses to list" do
+      core_mock = mock("core_client")
+      traefik_mock = mock("traefik_client")
+      traefik_mock.stubs(:get_entities).raises(StandardError.new("forbidden"))
+      core_mock.stubs(:get_entities).raises(StandardError.new("forbidden"))
+      @runtime.stubs(:core_client).returns(core_mock)
+      @runtime.stubs(:traefik_client).returns(traefik_mock)
+
+      assert_empty @runtime.list_session_resources
+    end
+
+    test "delete_session_resource routes each kind to its client and plural" do
+      core_mock = mock("core_client")
+      traefik_mock = mock("traefik_client")
+      traefik_mock.expects(:delete_entity).with("ingressroutes", "terminal-abc123-ingress", "aixle-project-7")
+      traefik_mock.expects(:delete_entity).with("middlewares", "terminal-abc123-tty-strip", "aixle-project-7")
+      core_mock.expects(:delete_entity).with("services", "terminal-abc123", "aixle-project-7")
+      core_mock.expects(:delete_entity).with("pods", "terminal-abc123", "aixle-project-7")
+      @runtime.stubs(:core_client).returns(core_mock)
+      @runtime.stubs(:traefik_client).returns(traefik_mock)
+
+      names = {
+        "IngressRoute" => "terminal-abc123-ingress",
+        "Middleware" => "terminal-abc123-tty-strip",
+        "Service" => "terminal-abc123",
+        "Pod" => "terminal-abc123"
+      }
+
+      names.each do |kind, name|
+        resource = SessionResource.new(kind: kind, name: name, namespace: "aixle-project-7", route_token: "abc123")
+        assert @runtime.delete_session_resource(resource), "#{kind} should report deleted"
+      end
+    end
+
+    test "delete_session_resource treats an already-gone object as success and a failure as false" do
+      core_mock = mock("core_client")
+      core_mock.expects(:delete_entity).with("pods", "gone", nil)
+        .raises(Kubeclient::ResourceNotFoundError.new(404, "Not Found", nil))
+      core_mock.expects(:delete_entity).with("pods", "broken", nil).raises(StandardError.new("boom"))
+      @runtime.stubs(:core_client).returns(core_mock)
+
+      assert @runtime.delete_session_resource(SessionResource.new(kind: "Pod", name: "gone"))
+      assert_not @runtime.delete_session_resource(SessionResource.new(kind: "Pod", name: "broken"))
+      assert_not @runtime.delete_session_resource(SessionResource.new(kind: "Pod", name: ""))
+      assert_not @runtime.delete_session_resource(SessionResource.new(kind: "Namespace", name: "aixle"))
+    end
+
     private
+
+    def labels_of(resource)
+      (resource.metadata.to_h[:labels] || {}).to_h.transform_keys(&:to_s)
+    end
+
+    def stub_listing(items)
+      core_mock = mock("core_client")
+      traefik_mock = mock("traefik_client")
+      traefik_mock.stubs(:get_entities).returns(items_json([]))
+      core_mock.stubs(:get_entities).returns(items_json([]))
+      core_mock.stubs(:get_entities)
+        .with("Pod", "pods", label_selector: KubernetesRuntime::SESSION_RESOURCE_SELECTOR, as: :raw)
+        .returns(items_json(items))
+      @runtime.stubs(:core_client).returns(core_mock)
+      @runtime.stubs(:traefik_client).returns(traefik_mock)
+
+      @runtime.list_session_resources
+    end
+
+    def items_json(items)
+      { "items" => items }.to_json
+    end
+
+    def kube_item(name, namespace, container_label)
+      {
+        "metadata" => {
+          "name" => name,
+          "namespace" => namespace,
+          "creationTimestamp" => "2026-08-09T10:00:00Z",
+          "labels" => { "app" => "aixle-runtime", "aixle-container" => container_label }
+        }
+      }
+    end
 
     def build_test_tar(filename, content)
       io = StringIO.new

--- a/test/services/session_service_test.rb
+++ b/test/services/session_service_test.rb
@@ -320,6 +320,71 @@ class SessionServiceTest < ActiveSupport::TestCase
     assert_equal "failed", session.state
   end
 
+  # == fail_session ==
+
+  test "fail_session records the error, fails the session and signals its container workflow" do
+    session = create(:terminal_session, :running, user: @user, temporal_workflow_id: "wf-dead")
+
+    # The container workflow ("agent-session-<id>") is the execution that owns the
+    # pod: without this signal it waits out its 23-hour `container_finished`
+    # timeout, its cleanup phase never runs, and the pod, Service, IngressRoute and
+    # Middlewares leak for a day.
+    TemporalService.expects(:send_signal).with(session.workflow_id, :container_finished, nil).once
+
+    SessionService.fail_session(session: session, error_message: "Agent container vanished")
+
+    session.reload
+    assert_equal "failed", session.state
+    assert_equal "Agent container vanished", session.error_message
+    assert_not_nil session.finished_at
+  end
+
+  test "fail_session signals the container workflow as well as the parent workflow run" do
+    workflow_run = create(:workflow_run, project: @project, user: @user)
+    step = create(:step, workflow: workflow_run.workflow)
+    step_run = create(:step_run, workflow_run: workflow_run, step: step)
+    session = create(:terminal_session, :running, user: @user, session_type: "workflow_step",
+                     project: @project, temporal_workflow_id: "wf-step")
+    step_run.update!(terminal_session: session)
+
+    # TerminalSession#on_failed only reaches the parent run, which completes the
+    # step. That is not enough on its own — both executions must hear about it.
+    TemporalService.expects(:send_signal)
+      .with("workflow-execution-#{workflow_run.id}", :container_finished, step_run.id).once
+    TemporalService.expects(:send_signal)
+      .with(session.workflow_id, :container_finished, step_run.id).once
+
+    SessionService.fail_session(session: session, error_message: "Agent container vanished")
+
+    assert_equal "failed", session.reload.state
+  end
+
+  test "fail_session fails a session that has no temporal workflow without signalling" do
+    session = create(:terminal_session, :running, user: @user, temporal_workflow_id: nil)
+
+    TemporalService.expects(:send_signal).never
+
+    SessionService.fail_session(session: session, error_message: "Agent container vanished")
+
+    session.reload
+    assert_equal "failed", session.state
+    assert_equal "Agent container vanished", session.error_message
+  end
+
+  test "fail_session on an already failed session keeps its original error and still signals" do
+    session = create(:terminal_session, :failed, user: @user, temporal_workflow_id: "wf-dead")
+
+    # A second sweep must still be able to nudge a container workflow that is
+    # somehow still running — the state transition is what is idempotent here.
+    TemporalService.expects(:send_signal).with(session.workflow_id, :container_finished, nil).once
+
+    SessionService.fail_session(session: session)
+
+    session.reload
+    assert_equal "failed", session.state
+    assert_equal "Container failed to start", session.error_message
+  end
+
   # == create_for_workflow_step ==
 
   test "create_for_workflow_step creates session bound to step_run" do

--- a/test/support/fakes/fake_runtime.rb
+++ b/test/support/fakes/fake_runtime.rb
@@ -16,6 +16,11 @@ module ContainerRuntime
   class FakeRuntime < BaseRuntime
     FULL_ID = "abcdef1234567890abcdef"
 
+    # Mirrors ContainerRuntime::KubernetesRuntime::SESSION_RESOURCE_KINDS — the
+    # object kinds one session owns, in the deletion order the BaseRuntime
+    # garbage-collection contract promises.
+    SESSION_RESOURCE_KINDS = %w[IngressRoute Middleware Service Pod].freeze
+
     # Lightweight container handle: create_container returns this; the runtime's
     # own methods key off the in-memory FS, not the handle, so it only carries id.
     Handle = Struct.new(:id) do
@@ -24,13 +29,16 @@ module ContainerRuntime
       end
     end
 
-    attr_reader :fs, :execs, :agent_type
+    attr_reader :fs, :execs, :agent_type, :deleted_session_resources
 
     def initialize(agent_type: "claude_code", filesystem: nil)
       @agent_type = agent_type
       @fs = filesystem || build_filesystem(agent_type)
       @execs = []
       @exec_failures = []
+      @session_resources = []
+      @deleted_session_resources = []
+      @undeletable_resource_names = []
     end
 
     # Command failure injection: register a substring of the command line and
@@ -116,6 +124,46 @@ module ContainerRuntime
 
     def container_logs(_id, stdout: true, stderr: true)
       { stdout: "", stderr: "" }
+    end
+
+    # -- Garbage collection ---------------------------------------------------
+
+    # Seed the objects the runtime is holding. `route_token:` is the key the
+    # sweeper reconciles against TerminalSession; `created_at:` is what its
+    # minimum-age guard reads. Kinds are handed back in the deletion order the
+    # BaseRuntime contract promises.
+    def seed_session_resources(route_token:, created_at:, kinds: SESSION_RESOURCE_KINDS, namespace: "aixle-project-1", name_prefix: nil)
+      prefix = name_prefix || (route_token.present? ? "terminal-#{route_token}" : "aixle-tool")
+
+      Array(kinds).map do |kind|
+        resource = ContainerRuntime::SessionResource.new(
+          kind: kind,
+          name: "#{prefix}-#{kind.downcase}",
+          namespace: namespace,
+          route_token: route_token,
+          created_at: created_at
+        )
+        @session_resources << resource
+        resource
+      end
+    end
+
+    # Make one object refuse to be deleted, so callers can exercise the
+    # failure-counting path without stubbing the runtime.
+    def fail_session_resource_delete(name)
+      @undeletable_resource_names << name
+    end
+
+    def list_session_resources
+      @session_resources.dup
+    end
+
+    def delete_session_resource(resource)
+      return false if @undeletable_resource_names.include?(resource.name)
+
+      @session_resources.delete(resource)
+      @deleted_session_resources << resource
+      true
     end
 
     private

--- a/test/support/fakes/fake_runtime.rb
+++ b/test/support/fakes/fake_runtime.rb
@@ -31,6 +31,22 @@ module ContainerRuntime
       @fs = filesystem || build_filesystem(agent_type)
       @execs = []
       @exec_failures = []
+      @default_container_status = :running
+      @container_statuses = {}
+    end
+
+    # Liveness injection: answer #container_status with `status` for one container
+    # id, or for every container when `container_id:` is omitted. Mirrors the
+    # vocabulary documented on BaseRuntime#container_status. Passing an exception
+    # instance makes the lookup raise instead (both real runtimes swallow control
+    # plane errors into :unknown, so this models a caller-visible failure).
+    def set_container_status(status, container_id: nil)
+      if container_id.nil?
+        @default_container_status = status
+      else
+        @container_statuses[container_id.to_s] = status
+      end
+      self
     end
 
     # Command failure injection: register a substring of the command line and
@@ -108,6 +124,14 @@ module ContainerRuntime
       return container if container.is_a?(String)
 
       container.respond_to?(:id) ? container.id.to_s[0..11] : container.to_s
+    end
+
+    def container_status(id)
+      key = id.respond_to?(:id) ? id.id.to_s : id.to_s
+      status = @container_statuses.fetch(key, @default_container_status)
+      raise status if status.is_a?(Exception)
+
+      status
     end
 
     def wait_container(_id, _timeout = nil)

--- a/test/temporal/activities/container/sweep_orphaned_resources_activity_test.rb
+++ b/test/temporal/activities/container/sweep_orphaned_resources_activity_test.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Activities
+  module Container
+    class SweepOrphanedResourcesActivityTest < ActiveSupport::TestCase
+      OLD = 3.hours
+      FRESH = 1.minute
+
+      setup do
+        @company = create(:company)
+        @user = create(:user, :admin, company: @company)
+        @runtime = stub_container_runtime
+      end
+
+      teardown do
+        cleanup_runtime_overrides
+      end
+
+      # == The leak this exists for ==
+
+      test "reaps every object of a session that no longer has a row" do
+        resources = @runtime.seed_session_resources(route_token: SecureRandom.hex(16), created_at: OLD.ago)
+
+        result = run_activity(SweepOrphanedResourcesActivity)
+
+        assert_equal 4, result[:reaped]
+        assert_equal 1, result[:sessions]
+        assert_equal 0, result[:failed]
+        assert_equal({ "IngressRoute" => 1, "Middleware" => 1, "Service" => 1, "Pod" => 1 }, result[:by_kind])
+        assert_equal resources, @runtime.deleted_session_resources
+        assert_empty @runtime.list_session_resources
+      end
+
+      test "reaps objects in routing-first order so traffic never points at a vanishing backend" do
+        @runtime.seed_session_resources(route_token: SecureRandom.hex(16), created_at: OLD.ago)
+
+        run_activity(SweepOrphanedResourcesActivity)
+
+        assert_equal %w[IngressRoute Middleware Service Pod],
+                     @runtime.deleted_session_resources.map(&:kind)
+      end
+
+      test "reaps objects of a session that failed long ago" do
+        session = create(:terminal_session, :failed, user: @user, finished_at: OLD.ago)
+        @runtime.seed_session_resources(route_token: session.route_token, created_at: OLD.ago)
+
+        result = run_activity(SweepOrphanedResourcesActivity)
+
+        assert_equal 4, result[:reaped]
+        assert_equal 0, result[:kept_live]
+      end
+
+      test "reaps objects of a session that finished long ago" do
+        session = create(:terminal_session, user: @user, state: "finished", finished_at: OLD.ago)
+        @runtime.seed_session_resources(route_token: session.route_token, created_at: OLD.ago)
+
+        result = run_activity(SweepOrphanedResourcesActivity)
+
+        assert_equal 4, result[:reaped]
+      end
+
+      # == Safety: a live session is never touched ==
+
+      test "never reaps the objects of a live session, however old they are" do
+        %w[not_started running ready finishing].each do |state|
+          session = create(:terminal_session, user: @user, state: state, started_at: 20.hours.ago)
+          @runtime.seed_session_resources(route_token: session.route_token, created_at: 20.hours.ago)
+        end
+
+        result = run_activity(SweepOrphanedResourcesActivity)
+
+        assert_equal 0, result[:reaped]
+        assert_equal 16, result[:kept_live]
+        assert_empty @runtime.deleted_session_resources
+        assert_equal 16, @runtime.list_session_resources.size
+      end
+
+      test "never reaps objects created inside the minimum-age window" do
+        @runtime.seed_session_resources(route_token: SecureRandom.hex(16), created_at: FRESH.ago)
+
+        result = run_activity(SweepOrphanedResourcesActivity)
+
+        assert_equal 0, result[:reaped]
+        assert_equal 4, result[:kept_recent]
+        assert_empty @runtime.deleted_session_resources
+      end
+
+      test "never reaps objects of a session that finished inside the minimum-age window" do
+        session = create(:terminal_session, user: @user, state: "finished", finished_at: FRESH.ago)
+        @runtime.seed_session_resources(route_token: session.route_token, created_at: OLD.ago)
+
+        result = run_activity(SweepOrphanedResourcesActivity)
+
+        assert_equal 0, result[:reaped]
+        assert_equal 4, result[:kept_finalizing]
+        assert_equal 0, result[:kept_live]
+        assert_empty @runtime.deleted_session_resources
+      end
+
+      test "never reaps an object whose owner cannot be established" do
+        @runtime.seed_session_resources(route_token: nil, created_at: OLD.ago, kinds: %w[Pod])
+
+        result = run_activity(SweepOrphanedResourcesActivity)
+
+        assert_equal 0, result[:reaped]
+        assert_equal 1, result[:kept_unowned]
+        assert_empty @runtime.deleted_session_resources
+      end
+
+      test "never reaps an object whose age the runtime cannot report" do
+        @runtime.seed_session_resources(route_token: SecureRandom.hex(16), created_at: nil)
+
+        result = run_activity(SweepOrphanedResourcesActivity)
+
+        assert_equal 0, result[:reaped]
+        assert_equal 4, result[:kept_recent]
+        assert_empty @runtime.deleted_session_resources
+      end
+
+      test "reaps the dead session's objects while leaving the live one's alone" do
+        live = create(:terminal_session, :running, user: @user, started_at: 20.hours.ago)
+        dead = create(:terminal_session, :failed, user: @user, finished_at: OLD.ago)
+        live_resources = @runtime.seed_session_resources(route_token: live.route_token, created_at: 20.hours.ago)
+        @runtime.seed_session_resources(route_token: dead.route_token, created_at: OLD.ago)
+
+        result = run_activity(SweepOrphanedResourcesActivity)
+
+        assert_equal 4, result[:reaped]
+        assert_equal 4, result[:kept_live]
+        assert_equal [ dead.route_token ], @runtime.deleted_session_resources.map(&:route_token).uniq
+        assert_equal live_resources, @runtime.list_session_resources
+      end
+
+      # == Diagnosability ==
+
+      test "counts objects the runtime refused to delete instead of reporting them reaped" do
+        resources = @runtime.seed_session_resources(route_token: SecureRandom.hex(16), created_at: OLD.ago)
+        @runtime.fail_session_resource_delete(resources.first.name)
+
+        result = run_activity(SweepOrphanedResourcesActivity)
+
+        assert_equal 3, result[:reaped]
+        assert_equal 1, result[:failed]
+        assert_equal [ resources.first ], @runtime.list_session_resources
+      end
+
+      test "reports an all-zero summary when the runtime holds nothing" do
+        result = run_activity(SweepOrphanedResourcesActivity)
+
+        assert_equal 0, result[:reaped]
+        assert_equal 0, result[:sessions]
+        assert_equal 0, result[:kept_live]
+        assert_equal 0, result[:kept_finalizing]
+        assert_equal 0, result[:kept_recent]
+        assert_equal 0, result[:kept_unowned]
+        assert_equal 0, result[:failed]
+        assert_empty result[:by_kind]
+      end
+    end
+  end
+end

--- a/test/temporal/activities/scan_dead_containers_activity_test.rb
+++ b/test/temporal/activities/scan_dead_containers_activity_test.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Activities
+  module Session
+    class ScanDeadContainersActivityTest < ActiveSupport::TestCase
+      setup do
+        @company = create(:company)
+        @user = create(:user, :admin, company: @company)
+        @runtime = stub_container_runtime
+
+        # Sessions here carry a temporal_workflow_id, so the fail path signals the
+        # container workflow. TemporalService is the app-owned seam (docs/testing.md
+        # §4); the signalling tests replace this with an expectation.
+        TemporalService.stubs(:send_signal).returns({ ok: true })
+      end
+
+      teardown do
+        cleanup_runtime_overrides
+      end
+
+      def ready_session(status: nil, **overrides)
+        session = create(:terminal_session, :running,
+          user: @user,
+          state: "ready",
+          session_type: "agent_session",
+          started_at: 10.minutes.ago,
+          temporal_workflow_id: "wf-#{SecureRandom.hex(4)}",
+          **overrides)
+        @runtime.set_container_status(status, container_id: session.container_id) if status
+        session
+      end
+
+      # == First sighting is never fatal ==
+
+      test "records a first sighting instead of failing the session" do
+        session = ready_session(status: :missing)
+
+        result = run_activity(ScanDeadContainersActivity)
+
+        assert_equal 1, result[:checked]
+        assert_equal 0, result[:failed]
+        session.reload
+        assert_equal "ready", session.state
+        assert session.metadata["container_dead_since"].present?,
+               "first sighting must be recorded so the next sweep can confirm it"
+      end
+
+      test "fails a session whose container is still gone after the confirmation delay" do
+        session = ready_session(status: :missing)
+
+        run_activity(ScanDeadContainersActivity)
+
+        travel ScanDeadContainersActivity::CONFIRMATION_DELAY + 1.minute do
+          result = run_activity(ScanDeadContainersActivity)
+
+          assert_equal 1, result[:failed]
+        end
+
+        session.reload
+        assert_equal "failed", session.state
+        assert_match(/vanished/, session.error_message)
+        assert_not_nil session.finished_at
+      end
+
+      test "fails a session whose pod left the Running phase" do
+        # restartPolicy: Never — a killed agent leaves a terminated pod behind
+        # rather than disappearing.
+        session = ready_session(status: :terminated)
+
+        run_activity(ScanDeadContainersActivity)
+        travel(ScanDeadContainersActivity::CONFIRMATION_DELAY + 1.minute) { run_activity(ScanDeadContainersActivity) }
+
+        session.reload
+        assert_equal "failed", session.state
+        assert_match(/no longer running/, session.error_message)
+      end
+
+      # == The signal that reclaims the container ==
+
+      test "signals the session's own container workflow, not only the parent workflow run" do
+        project = create(:project, owner: @user, company: @company)
+        workflow_run = create(:workflow_run, project: project, user: @user)
+        step = create(:step, workflow: workflow_run.workflow)
+        step_run = create(:step_run, workflow_run: workflow_run, step: step)
+        session = ready_session(status: :missing, session_type: "workflow_step")
+        step_run.update!(terminal_session: session)
+
+        # The parent run's execution completes the step...
+        TemporalService.expects(:send_signal)
+          .with("workflow-execution-#{workflow_run.id}", :container_finished, step_run.id).once
+        # ...and the session's OWN container workflow gets woken up, which is what
+        # runs its cleanup phase and deletes the pod, Service and IngressRoute.
+        # Without it that execution waits out a 23-hour signal timeout and the
+        # Kubernetes objects leak.
+        TemporalService.expects(:send_signal)
+          .with(session.workflow_id, :container_finished, step_run.id).once
+
+        run_activity(ScanDeadContainersActivity)
+        travel(ScanDeadContainersActivity::CONFIRMATION_DELAY + 1.minute) { run_activity(ScanDeadContainersActivity) }
+
+        assert_equal "failed", session.reload.state
+      end
+
+      # == Healthy sessions are left alone ==
+
+      test "leaves a running container alone and never records a sighting" do
+        session = ready_session(status: :running)
+
+        result = run_activity(ScanDeadContainersActivity)
+
+        assert_equal 0, result[:failed]
+        session.reload
+        assert_equal "ready", session.state
+        assert_nil session.metadata["container_dead_since"]
+      end
+
+      test "treats a container that has not started yet as alive" do
+        session = ready_session(status: :starting)
+
+        travel(ScanDeadContainersActivity::CONFIRMATION_DELAY + 1.minute) { run_activity(ScanDeadContainersActivity) }
+        travel(2 * ScanDeadContainersActivity::CONFIRMATION_DELAY) { run_activity(ScanDeadContainersActivity) }
+
+        assert_equal "ready", session.reload.state
+      end
+
+      test "clears the sighting when the container turns out to be alive" do
+        session = ready_session(status: :missing)
+
+        run_activity(ScanDeadContainersActivity)
+        @runtime.set_container_status(:running, container_id: session.container_id)
+
+        travel(ScanDeadContainersActivity::CONFIRMATION_DELAY + 1.minute) do
+          run_activity(ScanDeadContainersActivity)
+        end
+
+        session.reload
+        assert_equal "ready", session.state
+        assert_nil session.metadata["container_dead_since"],
+               "an alive sighting must reset confirmation, so two dead sightings are never split by a live one"
+      end
+
+      test "does not fail a session when the runtime cannot answer" do
+        session = ready_session(status: :missing)
+
+        run_activity(ScanDeadContainersActivity)
+        # Control plane unreachable: :unknown is not evidence of death.
+        @runtime.set_container_status(:unknown, container_id: session.container_id)
+
+        travel(ScanDeadContainersActivity::CONFIRMATION_DELAY + 1.minute) do
+          result = run_activity(ScanDeadContainersActivity)
+
+          assert_equal 0, result[:failed]
+        end
+
+        assert_equal "ready", session.reload.state
+      end
+
+      # == Scope ==
+
+      test "ignores sessions younger than MIN_AGE" do
+        session = ready_session(status: :missing, started_at: 30.seconds.ago)
+
+        result = run_activity(ScanDeadContainersActivity)
+
+        assert_equal 0, result[:checked]
+        session.reload
+        assert_equal "ready", session.state
+        assert_nil session.metadata["container_dead_since"]
+      end
+
+      test "ignores sessions without a container_id" do
+        session = ready_session(status: :missing, container_id: nil)
+
+        result = run_activity(ScanDeadContainersActivity)
+
+        assert_equal 0, result[:checked]
+        assert_equal "ready", session.reload.state
+      end
+
+      test "ignores sessions that already reached a terminal state" do
+        finished = create(:terminal_session, user: @user, state: "finished",
+          container_id: "container-finished", started_at: 1.hour.ago)
+        finishing = create(:terminal_session, :finishing, user: @user,
+          started_at: 1.hour.ago, finishing_at: 30.minutes.ago)
+        @runtime.set_container_status(:missing)
+
+        result = run_activity(ScanDeadContainersActivity)
+
+        assert_equal 0, result[:checked]
+        assert_equal "finished", finished.reload.state
+        assert_equal "finishing", finishing.reload.state
+      end
+
+      test "keeps sweeping after one session's lookup blows up" do
+        ready_session(status: StandardError.new("control plane unreachable"))
+        dead = ready_session(status: :missing)
+
+        result = run_activity(ScanDeadContainersActivity)
+
+        assert_equal 2, result[:checked]
+        assert dead.reload.metadata["container_dead_since"].present?,
+               "a failure on one session must not abandon the rest of the sweep"
+      end
+    end
+  end
+end

--- a/test/temporal/activities/scan_quota_errors_activity_test.rb
+++ b/test/temporal/activities/scan_quota_errors_activity_test.rb
@@ -119,6 +119,27 @@ module Activities
         assert_equal "Error: You've reached your normal usage limit.", session.error_message
       end
 
+      test "signals the failed session's own container workflow so its cleanup runs" do
+        session = create(:terminal_session,
+          user: @user,
+          session_type: :workflow_step,
+          state: "ready",
+          container_id: "container-quota",
+          started_at: 3.minutes.ago,
+          temporal_workflow_id: "wf-quota",
+          error_message: "Credit balance too low · Add funds: https://platform.claude.com/settings/billing")
+
+        # Failing the row alone left this execution parked on its `container_finished`
+        # await for 23 hours, so the pod, Service and IngressRoute were never
+        # reclaimed. It is the same leak the dead-container watchdog had to avoid.
+        TemporalService.expects(:send_signal).with(session.workflow_id, :container_finished, nil).once
+
+        result = run_activity(ScanQuotaErrorsActivity)
+
+        assert_equal 1, result[:cleaned]
+        assert_equal "failed", session.reload.state
+      end
+
       test "does not touch sessions without quota error text" do
         session = create(:terminal_session, :running,
           user: @user,

--- a/test/temporal/activities/scan_quota_errors_activity_test.rb
+++ b/test/temporal/activities/scan_quota_errors_activity_test.rb
@@ -11,7 +11,7 @@ module Activities
         @runtime_mock = mock("runtime")
         ContainerRuntime.stubs(:build).returns(@runtime_mock)
         @runtime_mock.stubs(:resolve_container).returns(nil)
-        @runtime_mock.stubs(:exec).returns([ [], [], 0 ])
+        @runtime_mock.stubs(:exec!).returns([ [], [], 0 ])
 
         Rails.logger.stubs(:info)
         Rails.logger.stubs(:warn)
@@ -47,7 +47,7 @@ module Activities
 
         container = mock("container")
         @runtime_mock.stubs(:resolve_container).with("container-live").returns(container)
-        @runtime_mock.stubs(:exec).returns([
+        @runtime_mock.stubs(:exec!).returns([
           [ "Credit balance too low · Add funds: https://platform.claude.com/settings/billing\n" ],
           [],
           0
@@ -73,7 +73,7 @@ module Activities
 
         container = mock("container")
         @runtime_mock.stubs(:resolve_container).with("container-noisy").returns(container)
-        @runtime_mock.stubs(:exec).returns([
+        @runtime_mock.stubs(:exec!).returns([
           [
             "claude@d683c38e063a:/workspace$",
             "claude \"$AGENT_PROMPT\"",
@@ -102,7 +102,7 @@ module Activities
 
         container = mock("container")
         @runtime_mock.stubs(:resolve_container).with("container-cursor").returns(container)
-        @runtime_mock.stubs(:exec).returns([
+        @runtime_mock.stubs(:exec!).returns([
           [
             "Error: You've reached your normal usage limit.\n",
             "You're out of usage. Ask your admin to increase your limit to continue.\n"
@@ -117,6 +117,53 @@ module Activities
         session.reload
         assert_equal "failed", session.state
         assert_equal "Error: You've reached your normal usage limit.", session.error_message
+      end
+
+      test "skips a session whose container is unreachable instead of scanning it" do
+        session = create(:terminal_session,
+          user: @user,
+          session_type: :workflow_step,
+          state: "ready",
+          container_id: "container-gone",
+          started_at: 3.minutes.ago,
+          error_message: nil)
+
+        container = mock("container")
+        @runtime_mock.stubs(:resolve_container).with("container-gone").returns(container)
+        @runtime_mock.stubs(:exec!).raises(
+          ContainerRuntime::ContainerUnreachableError.new(
+            status_code: 404, container_identifier: "aixle/terminal-gone"
+          )
+        )
+
+        result = run_activity(ScanQuotaErrorsActivity)
+
+        assert_equal 0, result[:cleaned]
+        assert_equal 1, result[:unreachable]
+        session.reload
+        assert_equal "ready", session.state
+        assert_nil session.error_message
+      end
+
+      test "still fails a session when the command runs and merely exits non-zero" do
+        session = create(:terminal_session,
+          user: @user,
+          session_type: :workflow_step,
+          state: "ready",
+          container_id: "container-busy",
+          started_at: 3.minutes.ago,
+          error_message: "Credit balance too low")
+
+        container = mock("container")
+        @runtime_mock.stubs(:resolve_container).with("container-busy").returns(container)
+        @runtime_mock.stubs(:exec!).returns([ [], [ "no server running on /tmp/tmux-0/default\n" ], 1 ])
+
+        result = run_activity(ScanQuotaErrorsActivity)
+
+        assert_equal 1, result[:cleaned]
+        assert_equal 0, result[:unreachable]
+        session.reload
+        assert_equal "failed", session.state
       end
 
       test "does not touch sessions without quota error text" do

--- a/test/temporal/workflows/container_sweep_orphaned_resources_workflow_test.rb
+++ b/test/temporal/workflows/container_sweep_orphaned_resources_workflow_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Workflows
+  # Runs the real workflow end to end through the SDK time-skipping
+  # WorkflowEnvironment (docs/testing.md §2 Temporal-workflow target) with a fake
+  # activity registered on the worker.
+  class ContainerSweepOrphanedResourcesWorkflowTest < ActiveSupport::TestCase
+    TASK_QUEUE = "container-orphan-sweep-test"
+
+    # Stands in for Activities::Container::SweepOrphanedResourcesActivity, under
+    # the real activity name the workflow dispatches to.
+    class FakeSweepActivity < Temporalio::Activity::Definition
+      activity_name "container_sweep_orphaned_resources_activity"
+      def execute(_input = nil)
+        { reaped: 4, sessions: 1, kept_live: 2, failed: 0 }
+      end
+    end
+
+    # Fails on the first attempt, succeeds on the second — proves the retry policy.
+    class FlakySweepActivity < Temporalio::Activity::Definition
+      activity_name "container_sweep_orphaned_resources_activity"
+      @attempts = 0
+      class << self
+        attr_accessor :attempts
+      end
+      def execute(_input = nil)
+        self.class.attempts += 1
+        raise "transient failure" if self.class.attempts < 2
+
+        { reaped: 0, sessions: 0, kept_live: 0, failed: 0 }
+      end
+    end
+
+    setup do
+      proxy = Object.new
+      proxy.define_singleton_method(:container_sweep_orphaned_resources_activity) do
+        TemporalWorkflowHelper::ActivityRef.new("container_sweep_orphaned_resources_activity", TASK_QUEUE)
+      end
+      ContainerSweepOrphanedResourcesWorkflow.stubs(:_preloaded_activities).returns(proxy)
+    end
+
+    test "executes the sweep activity and returns its summary" do
+      result = run_workflow(ContainerSweepOrphanedResourcesWorkflow,
+                            activities: [ FakeSweepActivity.new ], task_queue: TASK_QUEUE)
+
+      assert_equal 4, result["reaped"]
+      assert_equal 1, result["sessions"]
+      assert_equal 2, result["kept_live"]
+    end
+
+    test "retries the activity under the max_attempts:2 policy (time-skips the backoff)" do
+      FlakySweepActivity.attempts = 0
+
+      result = run_workflow(ContainerSweepOrphanedResourcesWorkflow,
+                            activities: [ FlakySweepActivity.new ], task_queue: TASK_QUEUE)
+
+      assert_equal 2, FlakySweepActivity.attempts, "activity should be retried exactly once"
+      assert_equal 0, result["reaped"]
+    end
+  end
+end


### PR DESCRIPTION
## Incident

A prod workflow run sat `RUNNING` for hours with its step output showing `no available server`. That string is Traefik's 503 body — it appears when a session's IngressRoute survives but its Service has zero endpoints.

Chain, established from prod telemetry:

1. Agent runtime pods requested `512Mi`/`100m` but really used 0.8–1.5 GB and 0.33–0.49 cores.
2. The scheduler packs by requests, so ~11 agent pods landed on one `t3.large` (8 GiB). Real working set reached 12.9 GB.
3. Node `ip-10-10-1-163` ran out of memory (available 2.9 GB → 0.45 GB between 11:00 and 11:10 UTC) and died with every agent pod on it. Pods are bare, `restartPolicy: Never`, no controller — nothing recreates them.
4. cluster-autoscaler also evaluates requests, saw ~81% ("normal"), never scaled up, then removed the dead node 20 minutes later. It was the janitor, not the culprit.
5. Sessions stayed `ready` forever. `agent-session-*` workflows parked on `TimerStarted` awaiting `container_finished` with a 23-hour timeout. Ten sessions were stuck this way, the oldest for 16 hours.

The requests fix lives in the infra repo. This PR is the application half.

## What this changes

**A vanished container now fails its session.** New `container_status` primitive on `BaseRuntime` with a documented vocabulary (`:running`, `:starting`, `:terminated`, `:missing`, `:unknown`), implemented for both Kubernetes and Docker so no activity reaches into a client directly. A new `dead_container_scan_workflow` sweeps `ready`/`running` sessions and fails those whose container is gone. `:unknown` never counts as dead — an unreachable control plane is not a dead pod.

Two guards, because one is not enough. `BaseStrategy#cleanup` removes the container while the session is still `ready` and transitions it only in `after_cleanup`, so for ~5–15 s a healthy completion is indistinguishable from a dead node. A session is failed only on a second dead sighting ≥2 min after the first. Detection latency ~3 min, against the 16 h observed.

**Failing a session now signals its own workflow.** This is a pre-existing leak the incident exposed. `TerminalSession#on_failed` only notified the parent run (`workflow-execution-<id>`); the session's container workflow is a different execution (`agent-session-<id>`) and nothing woke it. Its cleanup phase — the only thing that deletes the Pod, Service, IngressRoute and Middlewares — never ran. **Every failed session leaked its Kubernetes objects and hung a workflow for 23 hours**, including the quota-error path. New `SessionService.fail_session` is the one blessed entry point; `ScanQuotaErrorsActivity` now routes through it.

**A refused exec upgrade no longer spins the worker.** `websocket-client-simple`'s reader loop raises `InvalidStatusCode` for every remaining byte of the response, so one 192-byte `Status` body produced 192 `emit :error` calls. One prod worker logged **48 824 handshake errors in 7 hours** across 482 attempts, and the CPU burned drove the `worker-ruby` HPA from 1 replica to its max of 4. Now the first error tears the connection down and logs once, with the HTTP status extracted (`… returned HTTP 404`). Callbacks moved inside the `connect { |client| … }` block — the gem yields before starting the reader thread, and registering afterwards lost the events whenever the API server answered fast, which is almost certainly the `exec timeout after Ns` lines in the same logs.

New `exec!` raises `ContainerUnreachableError` so callers can tell "container is gone" from "command exited 1"; `exec` is unchanged.

**Orphaned objects get reclaimed.** A sweep reconciles cluster objects against `TerminalSession` rows by `route_token` and deletes those whose session is terminal or absent, routing-first. Three independent guards must all agree: provable owner, dead owner, and a 15-minute minimum age on both the object and the session's `finished_at`. Every ambiguity resolves to keep — a listing error yields an empty list, never "nothing is alive".

This also fixes label coverage: only Pods carried identity labels. Services had **none at all**, so a dead node's Service could not be attributed to anything. All five object kinds now carry the same identity; the Service selector deliberately stays narrow so it keeps matching pods from older builds.

## Verification

`make check_all` green on the merged branch — `rails-test`, `rubocop`, `brakeman`, `system-test`, `eslint`, `typescript`, `vitest`, `vite-build`. Backend line coverage 91.34%, frontend 78.36%.

RBAC verified against the prod cluster: `aixle-worker` already holds cluster-scope list/delete on pods, services, ingressroutes and middlewares, which the sweep needs.

## Follow-ups, not in this PR

- The infra-side requests bump (`2Gi` / `500m`) ships separately and needs a `rollout restart` — the ConfigMap has no checksum annotation, so applying it alone restarts nothing.
- Ten IngressRoutes already orphaned in prod carry no labels and predate this change, so the sweep cannot see them. They need a one-off operator deletion.
- `CLAUDE.md` claims test parallelization is off; `test/test_helper.rb:64` calls `parallelize(workers: :number_of_processors)`. Worth correcting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
