### PR TITLE
feat(kubernetes): pin agent session pods to a dedicated node group

### DIFF
--- a/app/frontend/pages/Docs/data/pages/config-schema.md
+++ b/app/frontend/pages/Docs/data/pages/config-schema.md
@@ -77,6 +77,7 @@ it's required.
 | `K8S_SA_TOKEN_PATH`               | `/var/run/secrets/kubernetes.io/serviceaccount/token`          | Service account token path.                                |
 | `K8S_SA_CA_PATH`                  | `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`         | Service account CA cert path.                              |
 | `K8S_AGENTS_IMAGE_PULL_SECRETS`   | unset                                                          | Comma-separated image pull secrets.                        |
+| `K8S_AGENTS_NODE_POOL`            | unset                                                          | Pin agent pods to a node group: `key=value[:Effect]`.      |
 | `K8S_IMAGE_PULL_POLICY`           | `IfNotPresent`                                                 | Pod image pull policy.                                     |
 | `K8S_READY_INTERVAL`              | a few seconds                                                  | Poll interval while waiting for a pod to become Ready.     |
 | `K8S_READY_TIMEOUT`               | a few minutes                                                  | Max wait for pod ready before failing.                     |

--- a/app/services/container_runtime/kubernetes_runtime.rb
+++ b/app/services/container_runtime/kubernetes_runtime.rb
@@ -308,6 +308,8 @@ module ContainerRuntime
         pod_spec[:imagePullSecrets] = configured_pull_secrets.map { |name| { name: name } }
       end
 
+      apply_agents_node_pool(pod_spec, handle)
+
       Kubeclient::Resource.new(
         apiVersion: "v1",
         kind: "Pod",
@@ -794,6 +796,57 @@ module ContainerRuntime
       end
 
       values.map(&:to_s).map(&:strip).reject(&:blank?).uniq
+    end
+
+    # Pins agent session pods to the dedicated agent node group, when one is
+    # configured (`kubernetes.agents_node_pool`, see config/settings.yml for the
+    # value format). Agent pods only: `route_token` is present exactly for the
+    # `terminal-*` containers an agent session creates, so internal-tool and
+    # custom-tool pods keep scheduling on the general pool.
+    #
+    # Nothing configured => neither key is written, and the pod spec stays byte
+    # for byte what it was before this existed. That default is load-bearing: an
+    # empty `nodeSelector`/`tolerations` pair, or one naming a node group that
+    # does not exist yet, leaves every agent pod Pending.
+    def apply_agents_node_pool(pod_spec, handle)
+      return if handle.route_token.blank?
+
+      entries = agents_node_pool_entries
+      return if entries.empty?
+
+      pod_spec[:nodeSelector] = entries.to_h { |entry| [ entry[:key], entry[:value] ] }
+      pod_spec[:tolerations] = entries.map do |entry|
+        {
+          key: entry[:key],
+          operator: "Equal",
+          value: entry[:value],
+          effect: entry[:effect]
+        }
+      end
+    end
+
+    # Parses `key=value[:Effect]` entries into the node label / taint toleration
+    # pairs above. One entry drives both sides, so the selector and the
+    # toleration can never drift apart. Unparseable entries are dropped rather
+    # than raised on: a typo in a ConfigMap must not take agent scheduling down.
+    def agents_node_pool_entries
+      raw = kube_setting(:agents_node_pool)
+      values = raw.is_a?(Array) ? raw : raw.to_s.split(",")
+
+      values.filter_map do |value|
+        entry = value.to_s.strip
+        next if entry.blank?
+
+        selector, effect = entry.split(":", 2)
+        label_key, label_value = selector.to_s.split("=", 2)
+        next if label_key.blank? || label_value.blank?
+
+        {
+          key: label_key.strip,
+          value: label_value.strip,
+          effect: effect.to_s.strip.presence || "NoSchedule"
+        }
+      end
     end
 
     def service_account_token_path

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -211,6 +211,24 @@ kubernetes:
   runtime_limits_cpu: <%= ENV['K8S_RUNTIME_LIMITS_CPU'] || '1000m' %>
   runtime_limits_memory: <%= ENV['K8S_RUNTIME_LIMITS_MEMORY'] || '1Gi' %>
   agents_image_pull_secrets: <%= (ENV['K8S_AGENTS_IMAGE_PULL_SECRETS'] || '').split(',').map(&:strip).reject(&:empty?) %>
+  # Dedicated node group for agent session pods (the `terminal-*` pods) — a
+  # runaway agent then only starves other agents, never a platform pod.
+  #
+  # FORMAT: comma-separated `key=value[:Effect]` entries. `Effect` is optional
+  # and defaults to NoSchedule (NoSchedule | PreferNoSchedule | NoExecute).
+  # Example ConfigMap value — this is the exact pair the prod agent node group
+  # (`palad-agents-on-demand`) labels and taints its nodes with:
+  #   K8S_AGENTS_NODE_POOL: "aixle.com/workload=agents:NoSchedule"
+  # Each entry becomes BOTH one `nodeSelector` label AND one matching
+  # toleration (operator Equal), so the node group's *label* and its *taint*
+  # must use the same key=value pair. Multiple entries = all labels required
+  # and all taints tolerated.
+  #
+  # EMPTY (the default) emits neither `nodeSelector` nor `tolerations` — not
+  # even empty ones. Any environment without such a node group (dev, staging,
+  # a cluster where the group has not been created yet) must leave it unset,
+  # otherwise every agent pod stays Pending forever.
+  agents_node_pool: <%= (ENV['K8S_AGENTS_NODE_POOL'] || '').split(',').map(&:strip).reject(&:empty?) %>
   kubeconfig_path: <%= ENV['KUBECONFIG'] || File.join(ENV.fetch('HOME', '/root'), '.kube', 'config') %>
   service_account_token_path: <%= ENV['K8S_SA_TOKEN_PATH'] || '/var/run/secrets/kubernetes.io/serviceaccount/token' %>
   service_account_ca_path: <%= ENV['K8S_SA_CA_PATH'] || '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt' %>

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -80,6 +80,7 @@ it's required.
 | `K8S_SA_TOKEN_PATH`               | `/var/run/secrets/kubernetes.io/serviceaccount/token`          | Service account token path.                                |
 | `K8S_SA_CA_PATH`                  | `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`         | Service account CA cert path.                              |
 | `K8S_AGENTS_IMAGE_PULL_SECRETS`   | unset                                                          | Comma-separated image pull secrets.                        |
+| `K8S_AGENTS_NODE_POOL`            | unset                                                          | Pin agent pods to a node group: `key=value[:Effect]`.      |
 | `K8S_IMAGE_PULL_POLICY`           | `IfNotPresent`                                                 | Pod image pull policy.                                     |
 | `K8S_READY_INTERVAL`              | a few seconds                                                  | Poll interval while waiting for a pod to become Ready.     |
 | `K8S_READY_TIMEOUT`               | a few minutes                                                  | Max wait for pod ready before failing.                     |

--- a/test/services/container_runtime/kubernetes_runtime_test.rb
+++ b/test/services/container_runtime/kubernetes_runtime_test.rb
@@ -213,6 +213,62 @@ module ContainerRuntime
       assert_equal "aixle-project-77", result.namespace
     end
 
+    # The agent node group is opt-in. With nothing configured the emitted pod
+    # spec must be exactly what it was before node-pool pinning existed — an
+    # empty nodeSelector/tolerations pair, or one naming a node group a cluster
+    # does not have, leaves every agent pod Pending.
+    test "build_pod emits no nodeSelector or tolerations when no agent node pool is configured" do
+      Settings.kubernetes.stubs(:agents_node_pool).returns([])
+      Settings.kubernetes.stubs(:agents_image_pull_secrets).returns([])
+
+      pod_spec = build_agent_pod_spec
+
+      assert_equal %i[automountServiceAccountToken enableServiceLinks restartPolicy containers],
+                   pod_spec.keys,
+                   "unconfigured agent pod spec gained or lost a key"
+      assert_not pod_spec.key?(:nodeSelector)
+      assert_not pod_spec.key?(:tolerations)
+    end
+
+    test "build_pod pins agent pods to the configured node pool and tolerates its matching taint" do
+      Settings.kubernetes.stubs(:agents_node_pool).returns([ "aixle.com/workload=agent:NoSchedule" ])
+
+      pod_spec = build_agent_pod_spec
+      node_selector = node_selector_from(pod_spec)
+      tolerations = tolerations_from(pod_spec)
+
+      assert_equal({ "aixle.com/workload" => "agent" }, node_selector)
+      assert_equal [ { key: "aixle.com/workload", operator: "Equal", value: "agent", effect: "NoSchedule" } ],
+                   tolerations
+      # The selector and the toleration are two views of the same entry: a pod
+      # that selects a taint it does not tolerate never schedules.
+      assert_equal node_selector, tolerations.to_h { |toleration| [ toleration[:key].to_s, toleration[:value] ] }
+    end
+
+    test "build_pod defaults the toleration effect to NoSchedule and skips unparseable node pool entries" do
+      Settings.kubernetes.stubs(:agents_node_pool).returns([ "aixle.com/workload=agent", "nonsense" ])
+
+      pod_spec = build_agent_pod_spec
+
+      assert_equal({ "aixle.com/workload" => "agent" }, node_selector_from(pod_spec))
+      assert_equal [ { key: "aixle.com/workload", operator: "Equal", value: "agent", effect: "NoSchedule" } ],
+                   tolerations_from(pod_spec)
+    end
+
+    test "build_pod leaves tool pods unpinned even when an agent node pool is configured" do
+      Settings.kubernetes.stubs(:agents_node_pool).returns([ "aixle.com/workload=agent:NoSchedule" ])
+      Settings.kubernetes.stubs(:agents_image_pull_secrets).returns([])
+
+      # Tool containers are created without a container_name, so they get no
+      # route token — the same discriminator the ingress path already uses.
+      pod_spec = build_agent_pod_spec(container_name: nil)
+
+      assert_equal %i[automountServiceAccountToken enableServiceLinks restartPolicy containers],
+                   pod_spec.keys
+      assert_not pod_spec.key?(:nodeSelector)
+      assert_not pod_spec.key?(:tolerations)
+    end
+
     test "stop_container deletes pod" do
       handle = OpenStruct.new(pod_name: "my-pod", namespace: "default")
       core_mock = mock("core_client")
@@ -479,6 +535,38 @@ module ContainerRuntime
     end
 
     private
+
+    # Builds the pod the way create_container does — real handle, real pod-spec
+    # builder — and hands back the pod spec as a plain Hash. No API calls: only
+    # settings are read on this path.
+    def build_agent_pod_spec(container_name: "terminal-abc123")
+      spec = {
+        image: "alpine:latest",
+        env_vars: [],
+        labels: {},
+        host_config: {},
+        container_name: container_name
+      }
+      handle = @runtime.send(:build_handle, spec)
+      pod = @runtime.send(:build_pod, spec, handle)
+
+      pod.spec.respond_to?(:to_h) ? pod.spec.to_h : pod.spec
+    end
+
+    # Kubeclient::Resource symbolizes keys on the way in; normalize back so the
+    # assertions read as the YAML Kubernetes actually receives.
+    def node_selector_from(pod_spec)
+      selector = pod_spec[:nodeSelector]
+      selector = selector.to_h if selector.respond_to?(:to_h)
+      selector.transform_keys(&:to_s)
+    end
+
+    def tolerations_from(pod_spec)
+      Array(pod_spec[:tolerations]).map do |toleration|
+        hash = toleration.respond_to?(:to_h) ? toleration.to_h : toleration
+        hash.transform_keys(&:to_sym)
+      end
+    end
 
     def build_test_tar(filename, content)
       io = StringIO.new


### PR DESCRIPTION
## Why

On 2026-08-09 a prod node ran out of memory. Agent session pods took the node down and killed a `worker-ruby` pod along with themselves — platform and agent workloads share one node group, so a runaway agent can starve the control plane.

The requests fix (palad-ai/aixle-infra#24) stops the overcommit. This is the isolation half: agent pods get their own tainted node group (`m6a.xlarge`), platform pods stay on `t3.large`, and a runaway agent can then only starve other agents.

Terraform for the node group is palad-ai/aixle-infra (branch `feat/prod-agent-node-group`).

## What this adds

One setting, `K8S_AGENTS_NODE_POOL`, parsed into a `nodeSelector` **and** a matching toleration on agent session pods.

```yaml
K8S_AGENTS_NODE_POOL: "aixle.com/workload=agents:NoSchedule"
```

emits, on `terminal-*` pods only:

```yaml
nodeSelector:
  aixle.com/workload: agents
tolerations:
  - key: aixle.com/workload
    operator: Equal
    value: agents
    effect: NoSchedule
```

One config entry drives both sides, so the selector and the toleration cannot drift apart — there is no way to configure half of this. Format is `key=value[:Effect]`, comma-separated, `Effect` defaulting to `NoSchedule`. Unparseable entries are dropped rather than raised on: a ConfigMap typo must not take pod creation down.

Scoping is by `route_token`, which `extract_route_token` sets only for containers named `terminal-*`. Internal-tool and custom-tool pods keep scheduling on the general pool.

## Safe to merge and deploy before the node group exists

**The default is unset, and unset emits nothing** — not empty `nodeSelector: {}` / `tolerations: []`, but no keys at all. This is the load-bearing property, not a detail: this change ships before the node group exists, and staging will never have one. A non-empty default would leave every agent pod `Pending` — the same outage this work exists to prevent.

The test asserting it compares the pod spec's **complete key list** for exact equality, so it fails on any added key, not only these two.

`DockerRuntime` is untouched — node scheduling is a Kubernetes concept and `BaseRuntime`'s interface is unchanged, so the fake needs nothing either.

## Rollout order

1. **Phase 1** — apply the terraform. Creates capacity only; the taint keeps agent pods off, since they carry no toleration yet. Prod behaviour unchanged.
2. **Phase 2** — set `K8S_AGENTS_NODE_POOL` in the prod ConfigMap and restart the deployments that launch agent pods.

Reversed, phase 2 alone is an outage: a `nodeSelector` for a label no node carries means no session can start. Merging this PR is not phase 2 — the setting stays unset until someone adds the ConfigMap key.

## Verification

`make check_all` green — `rails-test`, `rubocop`, `brakeman`, `system-test`, `eslint`, `typescript`, `vitest`, `vite-build`. Backend line coverage 91.0%, frontend 78.36%.

Tests cover: unconfigured → spec unchanged and both keys absent; configured → both present and mutually consistent; missing `:Effect` → `NoSchedule`; garbage entries dropped; a tool pod stays unpinned even with the pool configured.

Merges cleanly with #73 — verified, no conflicts.

## Note

`AgentAuthStrategy` and `WorkflowStepStrategy` pods are pinned too: they inherit `AgentBaseStrategy` and so carry `terminal-*` names. That is intended — they are agent workloads — but worth knowing when sizing the node group, since it is not only interactive sessions landing there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
