### PR TITLE
feat(coder): bootstrap the product repository on a workspace

### DIFF
--- a/app/services/coder/repo_bootstrap.rb
+++ b/app/services/coder/repo_bootstrap.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+module Coder
+  # RepoBootstrap — put a usable clone of a project repository on a Coder
+  # workspace, and repair one that is already there.
+  #
+  # This cannot live in the workspace template: cloning a private repository
+  # needs a short-lived GitHub App installation token, which the platform mints
+  # and the workspace's EC2 instance profile has no way to obtain. So the boxes
+  # in the field carry whatever an earlier manual session left behind, and every
+  # session pays for it again:
+  #
+  #   * the clone is `--filter=blob:none` and its promisor remote has no
+  #     credentials, so a fetch spawns a second fetch that hangs forever on the
+  #     auth helper rather than failing;
+  #   * it is shallow and single-branch, so feature branch refs do not exist
+  #     locally and each session re-derives `--unshallow` plus a wider refspec.
+  #
+  # Both are repaired in place here, and a workspace with no clone at all (every
+  # box created from a fixed template) gets a full one.
+  #
+  # The credential never touches the workspace's disk. It travels in the
+  # detached launcher's environment (see `SshRunner#exec_detached`) and is read
+  # by a `credential.helper` shell function, so it is neither written into
+  # `remote.origin.url` nor into the job's command file — both of which outlive
+  # the session on a box that is shared and long-lived.
+  class RepoBootstrap
+    class Error < StandardError; end
+
+    DEFAULT_ROOT = "/root"
+
+    def initialize(integration, ssh_runner: nil)
+      @integration = integration
+      @ssh_runner  = ssh_runner || Coder::SshRunner.new(integration)
+    end
+
+    # Starts detached: a cold clone of a real product repository takes longer
+    # than any single MCP call can stay open. Returns the job handle for
+    # `coder_job_status`.
+    def prepare(workspace_name:, repository:, path: nil)
+      target = path.presence || default_path_for(repository)
+      raise Error, "path must be absolute" unless target.start_with?("/")
+
+      token = token_for(repository)
+
+      started = @ssh_runner.exec_detached(
+        workspace_name: workspace_name,
+        command:        script(repository: repository, path: target, authenticated: token.present?),
+        env:            token.present? ? { "AIXLE_GH_TOKEN" => token } : {}
+      )
+
+      started.merge(
+        repository: repository.full_name,
+        path:       target,
+        branch:     repository.source_branch
+      )
+    end
+
+    private
+
+    def default_path_for(repository)
+      File.join(DEFAULT_ROOT, repository.repo_name.to_s)
+    end
+
+    # Scoped to the one repository, like the refresh path: an installation that
+    # can no longer reach some other repo does not take this one down with it.
+    def token_for(repository)
+      return nil if repository.public_source?
+
+      integration = repository.integration
+      raise Error, "repository #{repository.full_name} has no active integration" unless integration&.active?
+
+      unless integration.github?
+        raise Error, "#{integration.provider} repositories are not supported yet — only GitHub and public clones"
+      end
+
+      Github::TokenService.new(integration).generate_installation_token(repositories: [ repository.repo_name ])
+    end
+
+    def script(repository:, path:, authenticated:)
+      quoted_path   = shell_quote(path)
+      quoted_url    = shell_quote(repository.clone_url.to_s)
+      quoted_branch = shell_quote(repository.source_branch.to_s)
+      auth          = authenticated ? %(-c credential.helper="$HELPER") : ""
+
+      <<~SH
+        set -eu
+        export GIT_TERMINAL_PROMPT=0
+        export GIT_ASKPASS=/bin/true
+        HELPER='!f(){ echo username=x-access-token; echo "password=$AIXLE_GH_TOKEN"; };f'
+        TARGET=#{quoted_path}
+        URL=#{quoted_url}
+        BRANCH=#{quoted_branch}
+
+        if [ -d "$TARGET/.git" ]; then
+          echo "repairing existing clone at $TARGET"
+          git -C "$TARGET" remote set-url origin "$URL"
+          # A single-branch clone cannot see the branch under review.
+          git -C "$TARGET" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+          # A promisor remote with no usable credential is what hangs a fetch
+          # forever instead of failing it.
+          git -C "$TARGET" config --unset-all remote.origin.promisor || true
+          git -C "$TARGET" config --unset-all remote.origin.partialclonefilter || true
+          # --refetch backfills the blobs the filter skipped; older gits do not
+          # have it, and a plain fetch still fixes the refspec half.
+          git #{auth} -C "$TARGET" fetch --refetch --prune origin ||
+            git #{auth} -C "$TARGET" fetch --prune origin
+          if [ -f "$TARGET/.git/shallow" ]; then
+            git #{auth} -C "$TARGET" fetch --unshallow || true
+          fi
+        else
+          echo "cloning $URL into $TARGET"
+          mkdir -p "$(dirname "$TARGET")"
+          git #{auth} clone --branch "$BRANCH" "$URL" "$TARGET"
+        fi
+
+        git -C "$TARGET" config --add safe.directory "$TARGET" || true
+
+        echo "--- result ---"
+        echo "shallow=$(git -C "$TARGET" rev-parse --is-shallow-repository)"
+        echo "remote_branches=$(git -C "$TARGET" for-each-ref --format='%(refname)' refs/remotes/origin | wc -l | tr -d ' ')"
+        echo "head=$(git -C "$TARGET" rev-parse --abbrev-ref HEAD)"
+      SH
+    end
+
+    def shell_quote(value)
+      "'#{value.to_s.gsub("'", "'\\\\''")}'"
+    end
+  end
+end

--- a/app/services/coder/ssh_runner.rb
+++ b/app/services/coder/ssh_runner.rb
@@ -133,7 +133,13 @@ module Coder
     #
     # The remote script provisions what it needs (job directory, `setsid`
     # fallback), so a workspace from an older template works unchanged.
-    def exec_detached(workspace_name:, command:, job_id: nil)
+    #
+    # `env` is exported by the launcher, which travels over SSH and is never
+    # written anywhere, so a secret passed this way reaches the job's process
+    # environment without landing in the `<job_id>.cmd` file — the workspace is
+    # long-lived and shared between sessions, and a credential left on its disk
+    # outlives the session that minted it.
+    def exec_detached(workspace_name:, command:, job_id: nil, env: {})
       raise CommandError, "command must be a non-empty string" if command.to_s.strip.empty?
 
       job_id = (job_id.presence || SecureRandom.hex(6)).to_s
@@ -141,7 +147,7 @@ module Coder
 
       result = exec(
         workspace_name: workspace_name,
-        command:        detach_script(job_id: job_id, command: command.to_s),
+        command:        detach_script(job_id: job_id, command: command.to_s, env: env),
         timeout:        DETACH_TIMEOUT
       )
 
@@ -193,11 +199,11 @@ module Coder
     # Written as a script rather than an inline one-liner so the caller's
     # command lands in a file verbatim through a quoted heredoc — no escaping,
     # no quoting damage, multi-line commands intact.
-    def detach_script(job_id:, command:)
+    def detach_script(job_id:, command:, env: {})
       delimiter = "AIXLE_JOB_EOF_#{SecureRandom.hex(4)}"
 
       <<~SH
-        JOB_DIR="${AIXLE_JOB_DIR:-#{DEFAULT_JOB_DIR}}"
+        #{env_exports(env)}JOB_DIR="${AIXLE_JOB_DIR:-#{DEFAULT_JOB_DIR}}"
         mkdir -p "$JOB_DIR" 2>/dev/null || JOB_DIR="${TMPDIR:-/tmp}/aixle-jobs"
         mkdir -p "$JOB_DIR" || { echo "cannot create a job directory" >&2; exit 1; }
         BASE="$JOB_DIR/#{job_id}"
@@ -220,6 +226,19 @@ module Coder
         fi
         echo "#{JOB_MARKER} job_id=#{job_id} job_dir=$JOB_DIR"
       SH
+    end
+
+    # Single-quoted with the standard `'\''` escape, so a value cannot break out
+    # of its quoting and become shell.
+    def env_exports(env)
+      return "" if env.blank?
+
+      env.map do |key, value|
+        name = key.to_s
+        raise CommandError, "invalid env name: #{name}" unless name.match?(/\A[A-Za-z_][A-Za-z0-9_]*\z/)
+
+        "#{name}='#{value.to_s.gsub("'", "'\\\\''")}'; export #{name}\n"
+      end.join
     end
 
     def status_script(job_id:, tail_lines:)

--- a/app/services/internal_tools/coder_prepare_repo.rb
+++ b/app/services/internal_tools/coder_prepare_repo.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module InternalTools
+  # coder_prepare_repo — put a working clone of a session repository on an
+  # allocated Coder workspace, or repair the one already there.
+  #
+  # Runs detached (a cold clone outlives any single MCP call) and returns a
+  # `job_id` to poll with `coder_job_status`.
+  class CoderPrepareRepo < Base
+    tool do
+      display_name "Coder: Prepare Repository"
+      description "Clone a session repository onto an allocated Coder workspace, or repair an existing clone " \
+                  "(re-point origin, widen the refspec so feature branches exist locally, drop a partial-clone " \
+                  "filter whose fetches hang, unshallow). Run this once after coder_allocate_machine, before " \
+                  "any git work on the box. Returns a `job_id` — poll coder_job_status until it reports exited " \
+                  "with exit_code 0. The GitHub credential is short-lived and never written to the workspace disk."
+      tags :coder
+      inject_when :coder_integration_connected
+      requires_integration :coder
+      input_schema({
+        type: "object",
+        required: %w[workspace_name],
+        properties: {
+          workspace_name: {
+            type: "string",
+            description: "Workspace name returned by coder_allocate_machine."
+          },
+          repository: {
+            type: "string",
+            description: "owner/repo (or bare repo name) to prepare. Defaults to the session's only repository."
+          },
+          path: {
+            type: "string",
+            description: "Absolute path for the clone. Defaults to /root/<repo name>; pass the existing path " \
+                         "(e.g. /root/app) to adopt a clone a previous session left behind."
+          }
+        }
+      })
+    end
+
+    include Concerns::CoderResolver
+
+    def execute
+      require_coder!
+
+      workspace_name = params[:workspace_name].to_s
+      return error("workspace_name is required") if workspace_name.empty?
+
+      lock_service = Coder::LockService.new(coder_integration)
+      unless lock_service.held_by_session?(workspace_name: workspace_name, terminal_session_id: session.id)
+        return error("session does not hold the lock for workspace #{workspace_name}")
+      end
+
+      lock_service.touch(workspace_name: workspace_name, terminal_session_id: session.id)
+
+      repository = resolve_repository
+      return error(no_repository_message) if repository.nil?
+
+      started = Coder::RepoBootstrap.new(coder_integration).prepare(
+        workspace_name: workspace_name,
+        repository:     repository,
+        path:           params[:path].presence
+      )
+
+      success(started.merge(
+        next_step: "poll coder_job_status with this job_id until state=exited; exit_code 0 means the clone is ready"
+      ).to_json)
+    rescue Concerns::CoderResolver::NotConfiguredError => e
+      error(e.message)
+    rescue Coder::RepoBootstrap::Error,
+           Coder::SshRunner::CommandError,
+           Github::TokenService::ConfigurationError,
+           Github::TokenService::AuthenticationError => e
+      error("coder_prepare_repo: #{e.message}")
+    end
+
+    private
+
+    def repositories
+      @repositories ||= session.repositories.includes(:integration).to_a
+    end
+
+    # Accepts either form the agent has at hand: the full_name from the context
+    # file, or the bare repository name.
+    def resolve_repository
+      filter = params[:repository].to_s.strip
+      return repositories.first if filter.blank? && repositories.one?
+      return nil if filter.blank?
+
+      repositories.find { |repo| repo.full_name.to_s.casecmp?(filter) || repo.repo_name.to_s.casecmp?(filter) }
+    end
+
+    def no_repository_message
+      names = repositories.map(&:full_name)
+      return "No repository is attached to this session." if names.empty?
+
+      if params[:repository].present?
+        "No repository matching #{params[:repository]} is attached to this session. Attached: #{names.join(', ')}."
+      else
+        "This session has #{names.size} repositories (#{names.join(', ')}) — pass `repository` to pick one."
+      end
+    end
+  end
+end

--- a/docs/design/coder-pool-hardening.md
+++ b/docs/design/coder-pool-hardening.md
@@ -277,12 +277,19 @@ Removes RC-5.1 for all integrations immediately, without waiting for an image or
 release, and stays correct after the template fix lands (where `HOME` is already set, the
 prefix is a no-op).
 
-**D-10 — Platform owns repo bootstrap, not the image.**
+**D-10 — Platform owns repo bootstrap, not the image.** *(shipped)*
 The credentials for cloning a private product repo (GitHub App installation token) live
-in the platform, not in the AMI. A `coder_prepare_repo` step — full clone (no
-`--filter`), all branches, tokenised `remote.origin.url` rewritten on each allocation
-because the token is short-lived, `GIT_TERMINAL_PROMPT=0` — belongs on the platform side
-and fixes RC-5.2–5.3 for every project rather than one template.
+in the platform, not in the AMI. `coder_prepare_repo` + `Coder::RepoBootstrap` clone what
+is missing and repair what is there — widen the refspec, drop the promisor/partial-clone
+config whose fetches hang, unshallow, `GIT_TERMINAL_PROMPT=0` — fixing RC-5.2–5.3 for
+every project rather than one template.
+
+The credential is **not** written into `remote.origin.url`, and not into the detached
+job's command file either: the workspace is shared and long-lived, so anything on its
+disk outlives the session that minted it. It travels in the launcher's environment (the
+launcher goes over SSH and is never written down) and is read by a `credential.helper`
+shell function. The bootstrap runs detached for the same reason a gate does — a cold
+clone of a real repository outlives any single MCP call.
 
 ### Infrastructure — `aixle-infra`
 

--- a/test/seeds/platform_tools_test.rb
+++ b/test/seeds/platform_tools_test.rb
@@ -30,7 +30,7 @@ class PlatformToolsReconcileTest < ActiveSupport::TestCase
   test "seed creates the Coder MCP system tools" do
     Tools::Reconciler.run!
 
-    %w[coder_allocate_machine coder_ssh_exec coder_release_machine coder_job_status].each do |tool_name|
+    %w[coder_allocate_machine coder_ssh_exec coder_release_machine coder_job_status coder_prepare_repo].each do |tool_name|
       tool = Tool.find_by(name: tool_name)
       assert_not_nil tool, "expected #{tool_name} to be seeded"
       assert_equal "code", tool.source

--- a/test/services/coder/repo_bootstrap_test.rb
+++ b/test/services/coder/repo_bootstrap_test.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Coder
+  class RepoBootstrapTest < ActiveSupport::TestCase
+    # Captures what would be sent to the workspace. Stands in for the app-owned
+    # Coder::SshRunner through its constructor seam.
+    class FakeRunner
+      attr_reader :command, :env, :job_id
+
+      def exec_detached(workspace_name:, command:, job_id: nil, env: {})
+        @command = command
+        @env     = env
+        @job_id  = job_id
+        { job_id: "j1", job_dir: "/var/lib/aixle-jobs", log_path: "/var/lib/aixle-jobs/j1.log", detached: true }
+      end
+    end
+
+    class FakeTokenService
+      def initialize(_integration) = nil
+      def generate_installation_token(repositories: []) = "ghs_faketoken_#{repositories.join}"
+    end
+
+    setup do
+      @company     = create(:company)
+      @user        = create(:user, :admin, company: @company)
+      @project     = create(:project, company: @company, owner: @user)
+      @coder       = create(:integration, :coder, :active, company: @company, connected_by: @user)
+      @github      = create(:integration, :github, :active, company: @company, connected_by: @user)
+      @repository  = create(:repository, full_name: "acme/app", source_branch: "develop",
+                                         integration: @github, scope: @project)
+      @runner      = FakeRunner.new
+    end
+
+    def prepare(path: nil, repository: nil)
+      Github::TokenService.stub(:new, ->(integration) { FakeTokenService.new(integration) }) do
+        Coder::RepoBootstrap.new(@coder, ssh_runner: @runner).prepare(
+          workspace_name: "ws-1",
+          repository:     repository || @repository,
+          path:           path
+        )
+      end
+    end
+
+    test "clones into /root/<repo name> by default and reports the job handle" do
+      result = prepare
+
+      assert_equal "j1", result[:job_id]
+      assert_equal "/root/app", result[:path]
+      assert_equal "acme/app", result[:repository]
+      assert_equal "develop", result[:branch]
+      assert_match(/clone --branch "\$BRANCH"/, @runner.command)
+    end
+
+    test "adopts an existing clone at the path a previous session left behind" do
+      result = prepare(path: "/root/app")
+
+      assert_equal "/root/app", result[:path]
+      assert_match(%r{TARGET='/root/app'}, @runner.command)
+    end
+
+    # The three things every session was rediscovering by hand.
+    test "repairs the refspec, the partial-clone filter and the shallow history" do
+      prepare
+
+      assert_match(/config remote\.origin\.fetch '\+refs\/heads\/\*:refs\/remotes\/origin\/\*'/, @runner.command)
+      assert_match(/--unset-all remote\.origin\.promisor/, @runner.command)
+      assert_match(/--unset-all remote\.origin\.partialclonefilter/, @runner.command)
+      assert_match(/fetch --unshallow/, @runner.command)
+    end
+
+    test "never lets an unauthenticated fetch hang on a credential prompt" do
+      prepare
+
+      assert_match(/GIT_TERMINAL_PROMPT=0/, @runner.command)
+      assert_match(%r{GIT_ASKPASS=/bin/true}, @runner.command)
+    end
+
+    # The workspace is shared and long-lived: a credential written into
+    # remote.origin.url or into the job's command file outlives the session.
+    test "passes the token through the environment and never into the command" do
+      prepare
+
+      assert_equal "ghs_faketoken_app", @runner.env["AIXLE_GH_TOKEN"]
+      assert_no_match(/ghs_faketoken/, @runner.command)
+      assert_match(/credential\.helper/, @runner.command)
+      assert_match(/\$AIXLE_GH_TOKEN/, @runner.command)
+    end
+
+    test "a public repository is cloned with no credential at all" do
+      public_repo = create(:repository, :public_source, full_name: "torvalds/linux",
+                                        clone_url: "https://github.com/torvalds/linux.git", scope: @project)
+
+      result = Coder::RepoBootstrap.new(@coder, ssh_runner: @runner).prepare(
+        workspace_name: "ws-1", repository: public_repo
+      )
+
+      assert_equal "/root/linux", result[:path]
+      assert_empty @runner.env
+      assert_no_match(/credential\.helper="\$HELPER"/, @runner.command)
+    end
+
+    test "refuses a relative path" do
+      error = assert_raises(Coder::RepoBootstrap::Error) { prepare(path: "app") }
+      assert_match(/must be absolute/, error.message)
+    end
+
+    test "refuses a repository whose integration is not active" do
+      @github.update!(status: :error)
+
+      error = assert_raises(Coder::RepoBootstrap::Error) { prepare }
+      assert_match(/no active integration/, error.message)
+    end
+
+    test "says plainly that GitLab is not supported yet" do
+      gitlab = create(:integration, :gitlab, :active, company: @company, connected_by: @user)
+      repo   = create(:repository, full_name: "acme/gl", integration: gitlab, scope: @project,
+                                   clone_url: "https://gitlab.com/acme/gl.git")
+
+      error = assert_raises(Coder::RepoBootstrap::Error) { prepare(repository: repo) }
+      assert_match(/gitlab repositories are not supported yet/i, error.message)
+    end
+  end
+end

--- a/test/services/coder/ssh_runner_test.rb
+++ b/test/services/coder/ssh_runner_test.rb
@@ -282,6 +282,39 @@ module Coder
       assert_match(%r{TMPDIR:-/tmp}, script, "expected a fallback job dir when /var/lib is not writable")
     end
 
+    # A secret belongs in the launcher, which travels over SSH and is never
+    # written down — not in the `<job_id>.cmd` file, which stays on a workspace
+    # that outlives the session.
+    test "detached start exports env in the launcher, never into the command file" do
+      captured_args = nil
+      stub = popen3_stub(out: "aixle_job job_id=j1 job_dir=/var/lib/aixle-jobs\n") do |_env, argv|
+        captured_args = argv
+      end
+
+      Open3.stub(:popen3, stub) do
+        Coder::SshRunner.new(@integration).exec_detached(
+          workspace_name: "ws-1",
+          command:        'git clone "$URL"',
+          job_id:         "j1",
+          env:            { "AIXLE_GH_TOKEN" => "ghs_secret" }
+        )
+      end
+
+      script = captured_args.last
+      launcher, _, command_file = script.partition("cat > \"$BASE.cmd\"")
+
+      assert_match(/AIXLE_GH_TOKEN='ghs_secret'; export AIXLE_GH_TOKEN/, launcher)
+      assert_no_match(/ghs_secret/, command_file, "the secret must not reach the job's command file")
+    end
+
+    test "detached start rejects an env name that is not a shell identifier" do
+      assert_raises(Coder::SshRunner::CommandError) do
+        Coder::SshRunner.new(@integration).exec_detached(
+          workspace_name: "ws-1", command: "true", env: { "TOKEN; rm -rf /" => "x" }
+        )
+      end
+    end
+
     test "detached start reports the fallback job dir chosen by the workspace" do
       stub = popen3_stub(out: "aixle_job job_id=j1 job_dir=/tmp/aixle-jobs\n")
 

--- a/test/services/internal_tools/coder_tools_test.rb
+++ b/test/services/internal_tools/coder_tools_test.rb
@@ -238,6 +238,73 @@ class InternalTools::CoderToolsTest < ActiveSupport::TestCase
     assert_match(/does not hold the lock/, result[:stderr])
   end
 
+  # ---------- coder_prepare_repo ----------
+
+  class FakeRepoBootstrap
+    class << self
+      attr_accessor :last_call
+    end
+
+    def initialize(_integration) = nil
+
+    def prepare(workspace_name:, repository:, path: nil)
+      self.class.last_call = { workspace_name: workspace_name, repository: repository, path: path }
+      { job_id: "j9", job_dir: "/var/lib/aixle-jobs", log_path: "/var/lib/aixle-jobs/j9.log",
+        repository: repository.full_name, path: path || "/root/#{repository.repo_name}" }
+    end
+  end
+
+  def hold_lock(workspace_name = "ws-1")
+    Coder::LockService.new(@integration).acquire(
+      workspace_name: workspace_name, workspace_id: "u1", terminal_session_id: @session.id
+    )
+  end
+
+  test "prepare_repo: starts the bootstrap for the session's only repository" do
+    github = create(:integration, :github, :active, company: @company, connected_by: @user)
+    repo   = create(:repository, full_name: "acme/app", integration: github, scope: @project)
+    @session.define_singleton_method(:repositories) { Repository.where(id: repo.id) }
+    hold_lock
+
+    result = Coder::RepoBootstrap.stub(:new, ->(integration) { FakeRepoBootstrap.new(integration) }) do
+      InternalTools::CoderPrepareRepo.new(
+        params: { workspace_name: "ws-1", path: "/root/app" }, session: @session
+      ).execute
+    end
+
+    assert_equal 0, result[:exit_code]
+    payload = JSON.parse(result[:stdout])
+    assert_equal "j9", payload["job_id"]
+    assert_equal "/root/app", payload["path"]
+    assert_match(/coder_job_status/, payload["next_step"])
+    assert_equal "acme/app", FakeRepoBootstrap.last_call[:repository].full_name
+  end
+
+  test "prepare_repo: asks which repository when the session has several" do
+    github = create(:integration, :github, :active, company: @company, connected_by: @user)
+    one    = create(:repository, full_name: "acme/one", integration: github, scope: @project)
+    two    = create(:repository, full_name: "acme/two", integration: github, scope: @project)
+    @session.define_singleton_method(:repositories) { Repository.where(id: [ one.id, two.id ]) }
+    hold_lock
+
+    result = InternalTools::CoderPrepareRepo.new(
+      params: { workspace_name: "ws-1" }, session: @session
+    ).execute
+
+    assert_equal 1, result[:exit_code]
+    assert_match(/pass `repository` to pick one/, result[:stderr])
+    assert_match(/acme\/one/, result[:stderr])
+  end
+
+  test "prepare_repo: rejects a session that does not hold the workspace lock" do
+    result = InternalTools::CoderPrepareRepo.new(
+      params: { workspace_name: "ws-1" }, session: @session
+    ).execute
+
+    assert_equal 1, result[:exit_code]
+    assert_match(/does not hold the lock/, result[:stderr])
+  end
+
   # ---------- coder_release_machine ----------
 
   test "release: idempotently releases the workspace lock" do


### PR DESCRIPTION
Follow-up to #75. That PR made allocation refuse a sick workspace and let a long gate run detached; this one deals with the other half of what every session was paying for — the repository on the box.

## Why

A workspace created from a template has **no clone at all**, and the boxes in the field carry one an earlier manual session left behind:

- the clone is `--filter=blob:none` and its promisor remote has no credential, so a fetch spawns a second fetch that **hangs forever** on the auth helper instead of failing;
- it is shallow and single-branch, so the branch under review does not exist locally and each session re-derives `--unshallow` plus a wider refspec.

This cannot be fixed in the workspace template: cloning a private repository needs a short-lived GitHub App installation token, which the platform mints and the workspace's EC2 instance profile has no way to obtain.

## What this adds

`Coder::RepoBootstrap` and the `coder_prepare_repo` tool. It clones what is missing and repairs what is there:

- `remote set-url origin` to a clean URL, refspec widened to `+refs/heads/*:refs/remotes/origin/*`;
- `remote.origin.promisor` and `remote.origin.partialclonefilter` unset — the pair that turns a fetch into a hang — then `fetch --refetch` to backfill the blobs the filter skipped, falling back to a plain fetch on gits that predate `--refetch`;
- `--unshallow` when the repository is shallow;
- `GIT_TERMINAL_PROMPT=0` and `GIT_ASKPASS=/bin/true` throughout, so an unauthenticated fetch fails fast instead of hanging.

Public repositories are cloned with no credential at all. GitLab returns a clear "not supported yet" rather than a confusing failure.

## Where the credential lives

Not on the workspace's disk — that is the design constraint, because the box is shared between sessions and long-lived, so anything written there outlives the session that minted it.

`SshRunner#exec_detached` grew an `env` argument that the **launcher** exports. The launcher travels over SSH and is never written down, so the token reaches the job's process environment while the `<job_id>.cmd` file on disk contains only a reference to the variable. A `credential.helper` shell function reads it. Nothing is written into `remote.origin.url`.

Env names are validated as shell identifiers and values are single-quoted with the standard `'\''` escape, so a value cannot break out of its quoting.

## Why detached

Same reason as the gate: a cold clone of a real product repository outlives any single MCP call. The tool returns a `job_id`; the caller polls `coder_job_status` until `exited` with `exit_code` 0.

## Verification

`make check_all` green. New tests cover the repair steps, the no-credential public path, the inactive-integration and GitLab refusals, the relative-path guard, and — the point of the whole design — that the token reaches `env` and never the command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## One pre-existing failure, not from this branch

`SchemaParityTest` fails on `develop` right now: replaying `db/migrate` into the throwaway database yields `define(version: 0)`, i.e. the migrations do not run at all in the parity subprocess, so the dump has no version to match `schema.rb`'s `2026_08_08_130000`.

Reproduced on a clean `develop` checkout, and `git diff develop..HEAD -- db/` on this branch is empty — it touches no migration and no schema. Everything else in `check_all` is green (brakeman, eslint, fe-test, rubocop, system-test, typescript, vite-build; backend coverage 91.45%, frontend 78.36%). Worth its own issue.
