### PR TITLE
refactor(profile): redesign My Profile into paired identity/agents bands

### DIFF
--- a/app/frontend/pages/Profile/Show.module.css
+++ b/app/frontend/pages/Profile/Show.module.css
@@ -5,6 +5,47 @@
   margin-bottom: 8px;
 }
 
+/* Two-column band layout: main column (wide, primary actions) beside a side
+   column (companies, defaults) — each row pairs one domain across both
+   columns. Collapses to a single column on narrow viewports. */
+.grid2 {
+  display: grid;
+  grid-template-columns: minmax(0, 1.7fr) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.colMain,
+.colSide {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+}
+
+@media (max-width: 900px) {
+  .grid2 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.companyTile {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  flex-shrink: 0;
+  background: var(--app-bg-elevated);
+  border: 1px solid var(--app-border-default);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--app-font-heading);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--app-text-secondary);
+}
+
 /* The row holds a growing number of actions (re-authenticate, design, remove) beside a text
    column. Without wrapping, each new action steals width from the text until it breaks one
    word per line — so the row wraps as a whole and the text keeps a floor. */

--- a/app/frontend/pages/Profile/Show.test.tsx
+++ b/app/frontend/pages/Profile/Show.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { makeFormStub, renderAuthedPage, screen, userEvent, waitFor, within } from 'test/renderPage';
 
+import { companyMembershipPath } from 'shared/routes';
 import type { AgentCredential, SharedUser } from 'shared/ui';
 
 import ProfilePage from './Show';
@@ -216,6 +217,43 @@ describe('Profile/Show', () => {
     expect(screen.getByText('Platform Administrator')).toBeInTheDocument();
   });
 
+  it('shows a monogram tile with the company initials on a membership row', () => {
+    const profile = buildProfile();
+    renderAuthedPage(<ProfilePage {...baseProps(profile)} />, { props: baseProps(profile) });
+
+    expect(screen.getByText('AR')).toBeInTheDocument();
+  });
+
+  it('leaves a company via the shared confirm modal after the user confirms', async () => {
+    const profile = buildProfile();
+    renderAuthedPage(<ProfilePage {...baseProps(profile)} />, { props: baseProps(profile) });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Leave Acme Robotics' }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/Are you sure you want to leave Acme Robotics/)).toBeInTheDocument();
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Leave company' }));
+
+    await waitFor(() =>
+      expect(router.delete).toHaveBeenCalledWith(
+        companyMembershipPath(5),
+        expect.objectContaining({ preserveScroll: true }),
+      ),
+    );
+  });
+
+  it('does NOT leave a company when the confirm modal is cancelled', async () => {
+    const profile = buildProfile();
+    renderAuthedPage(<ProfilePage {...baseProps(profile)} />, { props: baseProps(profile) });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Leave Acme Robotics' }));
+
+    const dialog = await screen.findByRole('dialog');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    expect(router.delete).not.toHaveBeenCalled();
+  });
+
   it('renders the Employee role badge on an employee membership row', () => {
     const profile = buildProfile({
       currentRole: 'employee',
@@ -244,18 +282,19 @@ describe('Profile/Show', () => {
     expect(screen.getByText("Anthropic's AI coding assistant with deep reasoning capabilities")).toBeInTheDocument();
   });
 
-  it('shows the Default Agent Runtime selector and Default Models card when credentials exist', () => {
+  it('shows the Default Runtime selector and Default Models rows when credentials exist', () => {
     const credential = buildCredential({ id: 100, agentType: 'claude_code' });
     const profile = buildProfile({ configuredAgents: ['claude_code'], agentCredentials: [credential] });
     renderAuthedPage(<ProfilePage {...baseProps(profile)} />, { props: baseProps(profile) });
 
-    // Title appears for the runtime selector once credentials are present.
-    expect(screen.getByText('Default Agent Runtime')).toBeInTheDocument();
+    // The Agent Defaults card holds both the runtime selector and the model rows.
+    expect(screen.getByRole('heading', { name: 'Agent Defaults' })).toBeInTheDocument();
+    expect(screen.getByText('Default Runtime')).toBeInTheDocument();
     expect(
       screen.queryByText('No agent credentials configured. Complete onboarding to set up agents.'),
     ).not.toBeInTheDocument();
 
-    // Default Models card renders with one labelled row per credential.
+    // Default Models renders with one labelled row per credential.
     expect(screen.getByText('Default Models')).toBeInTheDocument();
     // The per-credential model row shows the agent's display name (in addition to the runtime card).
     expect(screen.getAllByText('Claude Code').length).toBeGreaterThan(1);
@@ -455,9 +494,9 @@ describe('Profile/Show', () => {
     });
     renderAuthedPage(<ProfilePage {...baseProps(profile)} />, { props: baseProps(profile) });
 
-    // Scope to the runtime card (two+ credentials keep the Select enabled) and pick the other agent.
-    const runtimeCard = screen.getByText('Default Agent Runtime').closest('.mantine-Card-root') as HTMLElement;
-    const select = within(runtimeCard).getByRole('combobox');
+    // Scope to the Default Runtime field (two+ credentials keep the Select enabled) and pick the other agent.
+    const runtimeField = screen.getByText('Default Runtime').closest('div') as HTMLElement;
+    const select = within(runtimeField).getByRole('combobox');
     await userEvent.click(select);
     await userEvent.click(await screen.findByRole('option', { name: 'Cursor CLI' }));
 
@@ -485,9 +524,10 @@ describe('Profile/Show', () => {
     };
     renderAuthedPage(<ProfilePage {...props} />, { props });
 
-    // The Default Models card has one row (one credential) -> a single combobox to disambiguate.
-    const modelsCard = screen.getByText('Default Models').closest('.mantine-Card-root') as HTMLElement;
-    const select = within(modelsCard).getByRole('combobox');
+    // Default Models has one row (one credential) -> a single combobox to disambiguate,
+    // scoped to the section following the "Default Models" label.
+    const modelsSection = screen.getByText('Default Models').parentElement as HTMLElement;
+    const select = within(modelsSection).getByRole('combobox');
     await userEvent.click(select);
     await userEvent.click(await screen.findByRole('option', { name: 'Claude Sonnet 4.5' }));
 

--- a/app/frontend/pages/Profile/Show.tsx
+++ b/app/frontend/pages/Profile/Show.tsx
@@ -26,7 +26,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { modals } from '@mantine/modals';
 import { notifications } from '@mantine/notifications';
 import { type Subscription } from '@rails/actioncable';
-import { IconCheck, IconCopy, IconLock, IconTrash } from '@tabler/icons-react';
+import { IconCheck, IconCopy, IconDoorExit, IconLock, IconTrash } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { z } from 'zod';
 
@@ -190,24 +190,16 @@ function DefaultAgentSelector({ profile }: { profile: SharedUser }) {
 
   if (credentials.length === 0) {
     return (
-      <Card p={20} mt={24}>
-        <Title order={5} mb={4}>
-          Default Agent Runtime
-        </Title>
-        <Text size="sm" c="dimmed">
-          No agent credentials configured. Complete onboarding to set up agents.
-        </Text>
-      </Card>
+      <Text size="sm" c="dimmed">
+        No agent credentials configured. Complete onboarding to set up agents.
+      </Text>
     );
   }
 
   return (
-    <Card p={20} mt={24}>
-      <Title order={5} mb={4}>
-        Default Agent Runtime
-      </Title>
-      <Text size="sm" c="dimmed" mb="md">
-        Used when starting new sessions and as fallback for workflow execution.
+    <Box>
+      <Text size="sm" fw={500} mb={6}>
+        Default Runtime
       </Text>
       <Select
         value={profile.defaultAgentCredentialId?.toString() ?? ''}
@@ -218,7 +210,7 @@ function DefaultAgentSelector({ profile }: { profile: SharedUser }) {
           label: getAgentInfo(c.agentType).name,
         }))}
       />
-    </Card>
+    </Box>
   );
 }
 
@@ -297,20 +289,49 @@ function DefaultModelSelector({ profile, agentModels }: { profile: SharedUser; a
   if (credentials.length === 0) return null;
 
   return (
-    <Card p={20} mt={24}>
-      <Title order={5} mb={4}>
+    <Box>
+      <Text size="sm" fw={500} mb={2}>
         Default Models
-      </Title>
-      <Text size="sm" c="dimmed" mb="md">
-        Set a preferred model per agent runtime. Used when no model is specified in session or workflow step.
+      </Text>
+      <Text size="xs" c="dimmed" mb={10}>
+        Used when no model is specified in a session or workflow step.
       </Text>
       <Stack gap={16}>
         {credentials.map((cred) => (
           <CredentialModelRow key={cred.id} credential={cred} models={modelsMap[cred.agentType] ?? []} />
         ))}
       </Stack>
+    </Box>
+  );
+}
+
+function AgentDefaultsSection({ profile, agentModels }: { profile: SharedUser; agentModels: AgentModelsEntry[] }) {
+  return (
+    <Card p={24}>
+      <Title order={4} mb={4}>
+        Agent Defaults
+      </Title>
+      <Text fz={14} c="dimmed" mb="md">
+        Used when starting new sessions and as a fallback for workflow execution.
+      </Text>
+      <Stack gap={20}>
+        <DefaultAgentSelector profile={profile} />
+        <DefaultModelSelector profile={profile} agentModels={agentModels} />
+      </Stack>
     </Card>
   );
+}
+
+// "Acme Robotics" -> "AR". Duplicated locally rather than shared: the same
+// small helper is copy-pasted across AppSidebar/MembersContent/etc rather
+// than centralized, so this follows the existing pattern.
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  return parts
+    .slice(0, 2)
+    .map((w) => w[0])
+    .join('')
+    .toUpperCase();
 }
 
 function CompaniesSection({
@@ -321,30 +342,38 @@ function CompaniesSection({
   pendingInvitations: SharedMembership[];
 }) {
   const memberships = profile.memberships ?? [];
-  const [leaving, setLeaving] = useState<SharedMembership | null>(null);
-  const [processing, setProcessing] = useState(false);
+  const [leavingId, setLeavingId] = useState<number | null>(null);
 
-  const confirmLeave = () => {
-    if (!leaving) return;
-    setProcessing(true);
-    // Self-removal revokes the membership. Server-side edge cases: the
-    // last-admin guard surfaces as a flash alert; leaving the last company
-    // signs the user out and redirects to the login page.
-    router.delete(companyMembershipPath(leaving.id), {
-      preserveScroll: true,
-      onFinish: () => {
-        setProcessing(false);
-        setLeaving(null);
+  const leaveCompany = (membership: SharedMembership) => {
+    modals.openConfirmModal({
+      title: 'Leave company',
+      children: (
+        <Text size="sm">
+          Are you sure you want to leave {membership.company.name}? You will lose access to its projects and data. You
+          will need a new invitation to rejoin.
+        </Text>
+      ),
+      labels: { confirm: 'Leave company', cancel: 'Cancel' },
+      confirmProps: { color: 'red' },
+      onConfirm: () => {
+        setLeavingId(membership.id);
+        // Self-removal revokes the membership. Server-side edge cases: the
+        // last-admin guard surfaces as a flash alert; leaving the last company
+        // signs the user out and redirects to the login page.
+        router.delete(companyMembershipPath(membership.id), {
+          preserveScroll: true,
+          onFinish: () => setLeavingId(null),
+        });
       },
     });
   };
 
   return (
-    <Card p={24} mt={24}>
-      <Title order={5} mb={4}>
+    <Card p={24}>
+      <Title order={4} mb={4}>
         Companies
       </Title>
-      <Text size="sm" c="dimmed" mb="md">
+      <Text fz={14} c="dimmed" mb="md">
         Companies you are a member of. Company assignment is managed by administrators.
       </Text>
 
@@ -384,6 +413,7 @@ function CompaniesSection({
         {memberships.map((membership) => (
           <Group key={membership.id} justify="space-between" wrap="nowrap">
             <Group gap="sm" wrap="nowrap" miw={0}>
+              <Box className={classes.companyTile}>{getInitials(membership.company.name)}</Box>
               <Text fw={500} truncate>
                 {membership.company.name}
               </Text>
@@ -398,27 +428,21 @@ function CompaniesSection({
                 </Badge>
               )}
             </Group>
-            <Button variant="subtle" color="red" size="xs" onClick={() => setLeaving(membership)}>
-              Leave company
+            <Button
+              variant="subtle"
+              color="red"
+              size="xs"
+              leftSection={<IconDoorExit size={14} />}
+              loading={leavingId === membership.id}
+              onClick={() => leaveCompany(membership)}
+              aria-label={`Leave ${membership.company.name}`}
+              style={{ flexShrink: 0 }}
+            >
+              Leave
             </Button>
           </Group>
         ))}
       </Stack>
-
-      <Modal opened={leaving !== null} onClose={() => setLeaving(null)} title="Leave company" centered>
-        <Text size="sm" mb="md">
-          Are you sure you want to leave {leaving?.company.name}? You will lose access to its projects and data. You
-          will need a new invitation to rejoin.
-        </Text>
-        <Group justify="flex-end" gap="sm">
-          <Button variant="default" onClick={() => setLeaving(null)} disabled={processing}>
-            Cancel
-          </Button>
-          <Button color="red" onClick={confirmLeave} loading={processing}>
-            Leave company
-          </Button>
-        </Group>
-      </Modal>
     </Card>
   );
 }
@@ -883,7 +907,7 @@ function AgentRuntimesSection({ profile }: { profile: SharedUser }) {
 
   return (
     <>
-      <Card p={24} mt={24}>
+      <Card p={24}>
         <Title order={5} mb={4}>
           Agent Runtimes
         </Title>
@@ -1007,7 +1031,7 @@ function PersonalMcpSection({ mcp }: { mcp: McpProps }) {
     : null;
 
   return (
-    <Card p={24} mt={24}>
+    <Card p={24}>
       <Title order={4} mb={4}>
         Personal MCP
       </Title>
@@ -1015,6 +1039,11 @@ function PersonalMcpSection({ mcp }: { mcp: McpProps }) {
         Connect your AI agent (Claude Code, Cursor, ...) to Aixle: list your projects, manage board tasks and build
         workflows — with exactly your access level.
       </Text>
+
+      <Group gap={8} mb="md">
+        <StatusBadge tone={mcp.enabled ? 'success' : 'neutral'}>{mcp.enabled ? 'Enabled' : 'Disabled'}</StatusBadge>
+        {mcp.enabled && <StatusBadge tone="neutral">{mcp.lastUsedAt ? 'In use' : 'Not used yet'}</StatusBadge>}
+      </Group>
 
       {mcp.token && (
         <Box mb="md">
@@ -1138,7 +1167,7 @@ function ProfilePage({ profile, pendingInvitations, agentModels, cableStream, mc
   return (
     <AuthLayout>
       <Head title="My Profile" />
-      <Box maw={600} mx="auto">
+      <Box maw={1120} mx="auto">
         <Title order={1} fz={28} fw={600} c="var(--app-text-primary)" mb={4}>
           My Profile
         </Title>
@@ -1165,102 +1194,110 @@ function ProfilePage({ profile, pendingInvitations, agentModels, cableStream, mc
           </Tabs.List>
         </Tabs>
 
-        <Card p={24}>
-          <Title order={4} mb={4}>
-            Personal Information
-          </Title>
-          <Divider mb="md" />
+        <Box className={classes.grid2}>
+          {/* Main column: personal information, agent runtimes, personal MCP. */}
+          <Box className={classes.colMain}>
+            <Card p={24}>
+              <Title order={4} mb={4}>
+                Personal Information
+              </Title>
+              <Divider mb="md" />
 
-          <form onSubmit={handleSubmit}>
-            <Box mb="lg">
-              <Box className={classes.fieldLabel}>
-                <Text size="sm" fw={500} c="dimmed">
-                  Email
-                </Text>
-                <Tooltip label="Email is managed by Google OAuth and cannot be changed">
-                  <IconLock size={16} color="var(--mantine-color-dimmed)" />
-                </Tooltip>
-              </Box>
-              <Text>{profile.email}</Text>
-              <Text size="xs" c="dimmed" mt={4}>
-                Email is managed by Google OAuth and cannot be changed
-              </Text>
-            </Box>
+              <form onSubmit={handleSubmit}>
+                <Box mb="lg">
+                  <Box className={classes.fieldLabel}>
+                    <Text size="sm" fw={500} c="dimmed">
+                      Email
+                    </Text>
+                    <Tooltip label="Email is managed by Google OAuth and cannot be changed">
+                      <IconLock size={16} color="var(--mantine-color-dimmed)" />
+                    </Tooltip>
+                  </Box>
+                  <Text>{profile.email}</Text>
+                  <Text size="xs" c="dimmed" mt={4}>
+                    Email is managed by Google OAuth and cannot be changed
+                  </Text>
+                </Box>
 
-            <Box mb="lg">
-              <TextInput
-                label="Display Name"
-                value={data.profile.name}
-                onChange={(e) => {
-                  setData('profile', { ...data.profile, name: e.currentTarget.value });
-                  if (clientErrors.name) setClientErrors((prev) => ({ ...prev, name: undefined }));
-                }}
-                error={clientErrors.name || errors['profile.name']}
-                disabled={processing}
-              />
-            </Box>
+                <Box mb="lg">
+                  <TextInput
+                    label="Display Name"
+                    value={data.profile.name}
+                    onChange={(e) => {
+                      setData('profile', { ...data.profile, name: e.currentTarget.value });
+                      if (clientErrors.name) setClientErrors((prev) => ({ ...prev, name: undefined }));
+                    }}
+                    error={clientErrors.name || errors['profile.name']}
+                    disabled={processing}
+                  />
+                </Box>
 
-            <Box mb="lg">
-              <Select
-                label="Agent Language"
-                description="Language AI agents will use to communicate with you in this company"
-                value={data.profile.preferredAgentLanguage}
-                onChange={(val) => {
-                  setData('profile', { ...data.profile, preferredAgentLanguage: val ?? 'en' });
-                  if (clientErrors.preferredAgentLanguage)
-                    setClientErrors((prev) => ({ ...prev, preferredAgentLanguage: undefined }));
-                }}
-                data={LANGUAGE_OPTIONS}
-                disabled={processing}
-                error={clientErrors.preferredAgentLanguage || errors['profile.preferredAgentLanguage']}
-              />
-            </Box>
+                <Box mb="lg">
+                  <Select
+                    label="Agent Language"
+                    description="Language AI agents will use to communicate with you in this company"
+                    value={data.profile.preferredAgentLanguage}
+                    onChange={(val) => {
+                      setData('profile', { ...data.profile, preferredAgentLanguage: val ?? 'en' });
+                      if (clientErrors.preferredAgentLanguage)
+                        setClientErrors((prev) => ({ ...prev, preferredAgentLanguage: undefined }));
+                    }}
+                    data={LANGUAGE_OPTIONS}
+                    disabled={processing}
+                    error={clientErrors.preferredAgentLanguage || errors['profile.preferredAgentLanguage']}
+                  />
+                </Box>
 
-            {/* Sharing is per lifecycle phase because the two are not the same
-                favour: a finished log is a record someone can read later, while
-                a running session is an interactive shell in the container the
-                agent is working in. Unchecked means nobody else can open it —
-                admins included. */}
-            <Box mb="lg">
-              <Text size="sm" fw={500} mb={4}>
-                Session visibility
-              </Text>
-              <Text size="xs" c="dimmed" mb="sm">
-                Controls what other members of your projects can open. Your own sessions are always visible to you.
-              </Text>
-              <Stack gap="sm">
-                <Switch
-                  label="Show my active sessions"
-                  description="Project members can watch a running session — live terminal and editor"
-                  checked={data.profile.shareActiveSessions}
-                  onChange={(e) =>
-                    setData('profile', { ...data.profile, shareActiveSessions: e.currentTarget.checked })
-                  }
-                  disabled={processing}
-                />
-                <Switch
-                  label="Show my finished sessions"
-                  description="Project members can open a finished session and replay its log"
-                  checked={data.profile.shareCompletedSessions}
-                  onChange={(e) =>
-                    setData('profile', { ...data.profile, shareCompletedSessions: e.currentTarget.checked })
-                  }
-                  disabled={processing}
-                />
-              </Stack>
-            </Box>
+                {/* Sharing is per lifecycle phase because the two are not the same
+                    favour: a finished log is a record someone can read later, while
+                    a running session is an interactive shell in the container the
+                    agent is working in. Unchecked means nobody else can open it —
+                    admins included. */}
+                <Box mb="lg">
+                  <Text size="sm" fw={500} mb={4}>
+                    Session visibility
+                  </Text>
+                  <Text size="xs" c="dimmed" mb="sm">
+                    Controls what other members of your projects can open. Your own sessions are always visible to you.
+                  </Text>
+                  <Stack gap="sm">
+                    <Switch
+                      label="Show my active sessions"
+                      description="Project members can watch a running session — live terminal and editor"
+                      checked={data.profile.shareActiveSessions}
+                      onChange={(e) =>
+                        setData('profile', { ...data.profile, shareActiveSessions: e.currentTarget.checked })
+                      }
+                      disabled={processing}
+                    />
+                    <Switch
+                      label="Show my finished sessions"
+                      description="Project members can open a finished session and replay its log"
+                      checked={data.profile.shareCompletedSessions}
+                      onChange={(e) =>
+                        setData('profile', { ...data.profile, shareCompletedSessions: e.currentTarget.checked })
+                      }
+                      disabled={processing}
+                    />
+                  </Stack>
+                </Box>
 
-            <Button type="submit" disabled={!isDirty || !isFormValid || processing} loading={processing}>
-              Save Changes
-            </Button>
-          </form>
-        </Card>
+                <Button type="submit" disabled={!isDirty || !isFormValid || processing} loading={processing}>
+                  Save Changes
+                </Button>
+              </form>
+            </Card>
 
-        <CompaniesSection profile={profile} pendingInvitations={pendingInvitations ?? []} />
-        <DefaultAgentSelector profile={profile} />
-        <DefaultModelSelector profile={profile} agentModels={agentModels} />
-        <AgentRuntimesSection profile={profile} />
-        <PersonalMcpSection mcp={mcp} />
+            <AgentRuntimesSection profile={profile} />
+            <PersonalMcpSection mcp={mcp} />
+          </Box>
+
+          {/* Side column: companies, agent defaults. */}
+          <Box className={classes.colSide}>
+            <CompaniesSection profile={profile} pendingInvitations={pendingInvitations ?? []} />
+            <AgentDefaultsSection profile={profile} agentModels={agentModels} />
+          </Box>
+        </Box>
       </Box>
     </AuthLayout>
   );

--- a/app/frontend/pages/Profile/Usage.test.tsx
+++ b/app/frontend/pages/Profile/Usage.test.tsx
@@ -132,8 +132,16 @@ describe('Profile/Usage', () => {
     expect(screen.queryByText('Total Sessions')).not.toBeInTheDocument();
     expect(screen.queryByText('Per-Project Breakdown')).not.toBeInTheDocument();
     expect(screen.queryByText('Usage Breakdown by Agent Type')).not.toBeInTheDocument();
-    // Section headers (outside Deferred) remain.
-    expect(screen.getByText('Projects Overview')).toBeInTheDocument();
+    // Page chrome (outside Deferred) remains.
+    expect(screen.getByRole('heading', { name: 'My Profile' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Usage' })).toBeInTheDocument();
+  });
+
+  it('navigates back to the Account tab when Account is clicked', async () => {
+    renderAuthedPage(<UsagePage />, { props: selfProps });
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Account' }));
+    expect(router.visit).toHaveBeenCalledWith('/profile');
   });
 
   it('navigates with the chosen period when the period select changes (self)', async () => {

--- a/app/frontend/pages/Profile/Usage.tsx
+++ b/app/frontend/pages/Profile/Usage.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   Badge,
   Box,
+  Divider,
   Grid,
   Group,
   Paper,
@@ -10,7 +11,9 @@ import {
   SimpleGrid,
   Skeleton,
   Table,
+  Tabs,
   Text,
+  Title,
   Tooltip,
 } from '@mantine/core';
 import { IconChartBar, IconClock, IconCoin, IconInfoCircle, IconPlayerPlay, IconRoute } from '@tabler/icons-react';
@@ -31,6 +34,7 @@ import {
 
 import { AuthLayout } from 'layouts/AuthLayout';
 
+import { profilePath } from 'shared/routes';
 import { CHART_SERIES } from 'shared/theme/chartPalette';
 import { type SharedProps } from 'shared/ui';
 import { ContributionHeatmap } from 'shared/ui/ContributionHeatmap';
@@ -189,7 +193,7 @@ function HeatmapPanel() {
   if (!activityHeatmap) return null;
 
   return (
-    <Paper withBorder px={20} py={18} radius="md" bg="var(--app-bg-card)" mb="xl">
+    <Paper withBorder p={24} radius="md" bg="var(--app-bg-card)" mb="xl">
       <ContributionHeatmap days={activityHeatmap.days} />
     </Paper>
   );
@@ -239,10 +243,11 @@ function ProjectBreakdownPanel() {
   const maxCost = projectBreakdowns.length > 0 ? Math.max(...projectBreakdowns.map((p) => p.costCents)) : 1;
 
   return (
-    <Paper withBorder p="md" radius="md" mb="xl">
-      <Text size="sm" fw={600} mb="md">
+    <Paper withBorder p={24} radius="md" mb="xl">
+      <Title order={4} mb={4}>
         Per-Project Breakdown
-      </Text>
+      </Title>
+      <Divider mb="md" />
       <Box
         style={{
           display: 'grid',
@@ -310,10 +315,11 @@ function AgentActivityPanel() {
   const { sessionsByAgent } = agentActivity;
 
   return (
-    <Paper withBorder p="md" radius="md" mb="xl">
-      <Text size="sm" fw={600} mb="md">
+    <Paper withBorder p={24} radius="md" mb="xl">
+      <Title order={4} mb={4}>
         Usage Breakdown by Agent Type
-      </Text>
+      </Title>
+      <Divider mb="md" />
       <Group gap="lg" align="center">
         <Box style={{ width: '40%' }}>
           <ResponsiveContainer width="100%" height={200}>
@@ -373,10 +379,11 @@ function CostTokenPanel({ tickInterval }: { tickInterval: number }) {
   return (
     <Grid mb="xl" gap="md">
       <Grid.Col span={{ base: 12, md: 6 }}>
-        <Paper withBorder p="md" radius="md">
-          <Text size="sm" fw={600} mb="md">
+        <Paper withBorder p={24} radius="md">
+          <Title order={4} mb={4}>
             Daily Cost
-          </Text>
+          </Title>
+          <Divider mb="md" />
           <ResponsiveContainer width="100%" height={220}>
             <AreaChart data={costToken.timeSeries} margin={{ top: 4, right: 8, bottom: 0, left: -10 }}>
               <defs>
@@ -406,10 +413,11 @@ function CostTokenPanel({ tickInterval }: { tickInterval: number }) {
         </Paper>
       </Grid.Col>
       <Grid.Col span={{ base: 12, md: 6 }}>
-        <Paper withBorder p="md" radius="md">
-          <Text size="sm" fw={600} mb="md">
+        <Paper withBorder p={24} radius="md">
+          <Title order={4} mb={4}>
             Daily Token Consumption
-          </Text>
+          </Title>
+          <Divider mb="md" />
           <ResponsiveContainer width="100%" height={220}>
             <AreaChart data={costToken.timeSeries} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
               <defs>
@@ -451,84 +459,88 @@ function SessionsPanel() {
   const { sessions } = usePage<{ props: Props }>().props as unknown as Props;
   if (!sessions) return null;
 
-  if (sessions.length === 0) {
-    return (
-      <Box py="xl" ta="center" style={{ border: '1px solid var(--app-border-default)', borderRadius: 8 }}>
-        <Text c="dimmed">No sessions yet</Text>
-      </Box>
-    );
-  }
-
   return (
-    <Table.ScrollContainer minWidth={800}>
-      <Table striped highlightOnHover verticalSpacing={6} fz="sm">
-        <Table.Thead>
-          <Table.Tr>
-            <Table.Th>ID</Table.Th>
-            <Table.Th>Agent</Table.Th>
-            <Table.Th>Type</Table.Th>
-            <Table.Th>Status</Table.Th>
-            <Table.Th>Project</Table.Th>
-            <Table.Th ta="right">Tokens</Table.Th>
-            <Table.Th ta="right">Cost</Table.Th>
-            <Table.Th>Started</Table.Th>
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>
-          {sessions.map((s) => {
-            const agent = AGENT_LABELS[s.agentType ?? ''] ?? { label: s.agentType ?? '—', color: 'gray' };
-            const stateConfig = STATE_CONFIG[s.state] ?? { label: s.state, color: 'gray' };
-            const typeLabel = SESSION_TYPE_LABELS[s.sessionType] ?? s.sessionType;
-            return (
-              <Table.Tr key={s.id}>
-                <Table.Td>
-                  <Text size="xs" ff="monospace" c="dimmed">
-                    #{s.id}
-                  </Text>
-                </Table.Td>
-                <Table.Td>
-                  <Badge color={agent.color} size="sm" variant="filled">
-                    {agent.label}
-                  </Badge>
-                </Table.Td>
-                <Table.Td>
-                  <Text size="xs" c="dimmed">
-                    {typeLabel}
-                  </Text>
-                </Table.Td>
-                <Table.Td>
-                  <Badge color={stateConfig.color} size="sm" variant="outline">
-                    {stateConfig.label}
-                  </Badge>
-                </Table.Td>
-                <Table.Td>
-                  <Text size="sm" truncate maw={120} c="dimmed">
-                    {s.projectName ?? '—'}
-                  </Text>
-                </Table.Td>
-                <Table.Td ta="right">
-                  <Text size="xs" ff="monospace">
-                    {sessionTokenFmt(s.totalTokens)}
-                  </Text>
-                </Table.Td>
-                <Table.Td ta="right">
-                  <Text size="xs" ff="monospace" fw={s.costCents > 0 ? 600 : 400}>
-                    {s.costCents > 0 ? `$${(s.costCents / 100).toFixed(2)}` : '—'}
-                  </Text>
-                </Table.Td>
-                <Table.Td>
-                  <Tooltip label={s.startedAt ? new Date(s.startedAt).toLocaleString() : s.createdAt}>
-                    <Text size="xs" c="dimmed" style={{ whiteSpace: 'nowrap' }}>
-                      {formatDistanceToNow(new Date(s.startedAt ?? s.createdAt), { addSuffix: true })}
-                    </Text>
-                  </Tooltip>
-                </Table.Td>
+    <Paper withBorder p={24} radius="md">
+      <Title order={4} mb={4}>
+        Sessions
+      </Title>
+      <Divider mb="md" />
+      {sessions.length === 0 ? (
+        <Box py="xl" ta="center">
+          <Text c="dimmed">No sessions yet</Text>
+        </Box>
+      ) : (
+        <Table.ScrollContainer minWidth={800}>
+          <Table striped highlightOnHover verticalSpacing={6} fz="sm">
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>ID</Table.Th>
+                <Table.Th>Agent</Table.Th>
+                <Table.Th>Type</Table.Th>
+                <Table.Th>Status</Table.Th>
+                <Table.Th>Project</Table.Th>
+                <Table.Th ta="right">Tokens</Table.Th>
+                <Table.Th ta="right">Cost</Table.Th>
+                <Table.Th>Started</Table.Th>
               </Table.Tr>
-            );
-          })}
-        </Table.Tbody>
-      </Table>
-    </Table.ScrollContainer>
+            </Table.Thead>
+            <Table.Tbody>
+              {sessions.map((s) => {
+                const agent = AGENT_LABELS[s.agentType ?? ''] ?? { label: s.agentType ?? '—', color: 'gray' };
+                const stateConfig = STATE_CONFIG[s.state] ?? { label: s.state, color: 'gray' };
+                const typeLabel = SESSION_TYPE_LABELS[s.sessionType] ?? s.sessionType;
+                return (
+                  <Table.Tr key={s.id}>
+                    <Table.Td>
+                      <Text size="xs" ff="monospace" c="dimmed">
+                        #{s.id}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge color={agent.color} size="sm" variant="filled">
+                        {agent.label}
+                      </Badge>
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="xs" c="dimmed">
+                        {typeLabel}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge color={stateConfig.color} size="sm" variant="outline">
+                        {stateConfig.label}
+                      </Badge>
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="sm" truncate maw={120} c="dimmed">
+                        {s.projectName ?? '—'}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td ta="right">
+                      <Text size="xs" ff="monospace">
+                        {sessionTokenFmt(s.totalTokens)}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td ta="right">
+                      <Text size="xs" ff="monospace" fw={s.costCents > 0 ? 600 : 400}>
+                        {s.costCents > 0 ? `$${(s.costCents / 100).toFixed(2)}` : '—'}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Tooltip label={s.startedAt ? new Date(s.startedAt).toLocaleString() : s.createdAt}>
+                        <Text size="xs" c="dimmed" style={{ whiteSpace: 'nowrap' }}>
+                          {formatDistanceToNow(new Date(s.startedAt ?? s.createdAt), { addSuffix: true })}
+                        </Text>
+                      </Tooltip>
+                    </Table.Td>
+                  </Table.Tr>
+                );
+              })}
+            </Table.Tbody>
+          </Table>
+        </Table.ScrollContainer>
+      )}
+    </Paper>
   );
 }
 
@@ -560,22 +572,32 @@ const UsagePage = () => {
       {/* Matches the Account tab's content width so the two tabs don't jump
           width when switching between them. */}
       <Box maw={1120} mx="auto">
-        <Group justify="space-between" mb="xl" wrap="wrap">
-          <Box>
-            <Text size="xl" fw={700}>
-              Usage
-            </Text>
-            <Text size="sm" c="dimmed">
-              {/* Usage is always a CURRENT-COMPANY slice (see ProfileController#usage).
-                  For someone who belongs to several companies, an unlabelled total
-                  reads as "everything", so name the company being shown. */}
-              Cross-project agent activity, costs, and sessions
-              {companyName ? ` in ${companyName}` : ''}
-            </Text>
-          </Box>
-          <Group gap="sm">
-            <Select value={period} onChange={(v) => navigate(v ?? '30d')} data={PERIOD_OPTIONS} size="sm" w={140} />
-          </Group>
+        <Title order={1} fz={28} fw={600} c="var(--app-text-primary)" mb={4}>
+          My Profile
+        </Title>
+        <Text size="sm" c="dimmed" mb={24}>
+          {/* Usage is always a CURRENT-COMPANY slice (see ProfileController#usage).
+              For someone who belongs to several companies, an unlabelled total
+              reads as "everything", so name the company being shown. */}
+          Cross-project agent activity, costs, and sessions
+          {companyName ? ` in ${companyName}` : ''}.
+        </Text>
+
+        <Tabs
+          value="usage"
+          onChange={(v) => {
+            if (v === 'account') router.visit(profilePath());
+          }}
+          mb="lg"
+        >
+          <Tabs.List>
+            <Tabs.Tab value="account">Account</Tabs.Tab>
+            <Tabs.Tab value="usage">Usage</Tabs.Tab>
+          </Tabs.List>
+        </Tabs>
+
+        <Group justify="flex-end" mb="xl">
+          <Select value={period} onChange={(v) => navigate(v ?? '30d')} data={PERIOD_OPTIONS} size="sm" w={140} />
         </Group>
 
         {!viewerIsSelf && (
@@ -597,25 +619,23 @@ const UsagePage = () => {
         </SimpleGrid>
 
         {/* Per-project breakdown */}
-        <Text size="md" fw={600} mb="md" mt="xl">
-          Projects Overview
-        </Text>
         <Deferred data="summary" fallback={<Skeleton height={200} radius="sm" mb="xl" />}>
           <ProjectBreakdownPanel />
         </Deferred>
 
         {/* Agent activity */}
-        <Text size="md" fw={600} mb="md" mt="xl">
-          Agent Activity
-        </Text>
-        <Deferred data="agentActivity" fallback={<ChartSkeleton height={200} />}>
+        <Deferred
+          data="agentActivity"
+          fallback={
+            <Box mb="xl">
+              <ChartSkeleton height={200} />
+            </Box>
+          }
+        >
           <AgentActivityPanel />
         </Deferred>
 
         {/* Cost & token usage */}
-        <Text size="md" fw={600} mb="md" mt="xl">
-          Cost & Token Usage
-        </Text>
         <Deferred
           data="costToken"
           fallback={
@@ -633,9 +653,6 @@ const UsagePage = () => {
         </Deferred>
 
         {/* Sessions list */}
-        <Text size="md" fw={600} mb="md" mt="xl">
-          Sessions
-        </Text>
         <Deferred data="sessions" fallback={<Skeleton height={200} radius="sm" />}>
           <SessionsPanel />
         </Deferred>

--- a/app/frontend/pages/Profile/Usage.tsx
+++ b/app/frontend/pages/Profile/Usage.tsx
@@ -557,85 +557,89 @@ const UsagePage = () => {
     <AuthLayout>
       <Head title="Usage" />
 
-      <Group justify="space-between" mb="xl" wrap="wrap">
-        <Box>
-          <Text size="xl" fw={700}>
-            Usage
-          </Text>
-          <Text size="sm" c="dimmed">
-            {/* Usage is always a CURRENT-COMPANY slice (see ProfileController#usage).
-                For someone who belongs to several companies, an unlabelled total
-                reads as "everything", so name the company being shown. */}
-            Cross-project agent activity, costs, and sessions
-            {companyName ? ` in ${companyName}` : ''}
-          </Text>
-        </Box>
-        <Group gap="sm">
-          <Select value={period} onChange={(v) => navigate(v ?? '30d')} data={PERIOD_OPTIONS} size="sm" w={140} />
+      {/* Matches the Account tab's content width so the two tabs don't jump
+          width when switching between them. */}
+      <Box maw={1120} mx="auto">
+        <Group justify="space-between" mb="xl" wrap="wrap">
+          <Box>
+            <Text size="xl" fw={700}>
+              Usage
+            </Text>
+            <Text size="sm" c="dimmed">
+              {/* Usage is always a CURRENT-COMPANY slice (see ProfileController#usage).
+                  For someone who belongs to several companies, an unlabelled total
+                  reads as "everything", so name the company being shown. */}
+              Cross-project agent activity, costs, and sessions
+              {companyName ? ` in ${companyName}` : ''}
+            </Text>
+          </Box>
+          <Group gap="sm">
+            <Select value={period} onChange={(v) => navigate(v ?? '30d')} data={PERIOD_OPTIONS} size="sm" w={140} />
+          </Group>
         </Group>
-      </Group>
 
-      {!viewerIsSelf && (
-        <Alert icon={<IconInfoCircle size={16} />} color="blue" mb="xl">
-          Viewing {targetUser.name ?? targetUser.email}&apos;s usage
-        </Alert>
-      )}
+        {!viewerIsSelf && (
+          <Alert icon={<IconInfoCircle size={16} />} color="blue" mb="xl">
+            Viewing {targetUser.name ?? targetUser.email}&apos;s usage
+          </Alert>
+        )}
 
-      {/* Contribution heatmap */}
-      <Deferred data="activityHeatmap" fallback={<Skeleton height={140} radius="sm" mb="xl" />}>
-        <HeatmapPanel />
-      </Deferred>
-
-      {/* Summary stats */}
-      <SimpleGrid cols={{ base: 2, sm: 3, md: 5 }} mb="xl" spacing="md">
-        <Deferred data="summary" fallback={<SummarySkeletons />}>
-          <SummaryPanel />
+        {/* Contribution heatmap */}
+        <Deferred data="activityHeatmap" fallback={<Skeleton height={140} radius="sm" mb="xl" />}>
+          <HeatmapPanel />
         </Deferred>
-      </SimpleGrid>
 
-      {/* Per-project breakdown */}
-      <Text size="md" fw={600} mb="md" mt="xl">
-        Projects Overview
-      </Text>
-      <Deferred data="summary" fallback={<Skeleton height={200} radius="sm" mb="xl" />}>
-        <ProjectBreakdownPanel />
-      </Deferred>
+        {/* Summary stats */}
+        <SimpleGrid cols={{ base: 2, sm: 3, md: 5 }} mb="xl" spacing="md">
+          <Deferred data="summary" fallback={<SummarySkeletons />}>
+            <SummaryPanel />
+          </Deferred>
+        </SimpleGrid>
 
-      {/* Agent activity */}
-      <Text size="md" fw={600} mb="md" mt="xl">
-        Agent Activity
-      </Text>
-      <Deferred data="agentActivity" fallback={<ChartSkeleton height={200} />}>
-        <AgentActivityPanel />
-      </Deferred>
+        {/* Per-project breakdown */}
+        <Text size="md" fw={600} mb="md" mt="xl">
+          Projects Overview
+        </Text>
+        <Deferred data="summary" fallback={<Skeleton height={200} radius="sm" mb="xl" />}>
+          <ProjectBreakdownPanel />
+        </Deferred>
 
-      {/* Cost & token usage */}
-      <Text size="md" fw={600} mb="md" mt="xl">
-        Cost & Token Usage
-      </Text>
-      <Deferred
-        data="costToken"
-        fallback={
-          <Grid mb="xl" gap="md">
-            <Grid.Col span={{ base: 12, md: 6 }}>
-              <ChartSkeleton height={220} />
-            </Grid.Col>
-            <Grid.Col span={{ base: 12, md: 6 }}>
-              <ChartSkeleton height={220} />
-            </Grid.Col>
-          </Grid>
-        }
-      >
-        <CostTokenPanel tickInterval={tickInterval} />
-      </Deferred>
+        {/* Agent activity */}
+        <Text size="md" fw={600} mb="md" mt="xl">
+          Agent Activity
+        </Text>
+        <Deferred data="agentActivity" fallback={<ChartSkeleton height={200} />}>
+          <AgentActivityPanel />
+        </Deferred>
 
-      {/* Sessions list */}
-      <Text size="md" fw={600} mb="md" mt="xl">
-        Sessions
-      </Text>
-      <Deferred data="sessions" fallback={<Skeleton height={200} radius="sm" />}>
-        <SessionsPanel />
-      </Deferred>
+        {/* Cost & token usage */}
+        <Text size="md" fw={600} mb="md" mt="xl">
+          Cost & Token Usage
+        </Text>
+        <Deferred
+          data="costToken"
+          fallback={
+            <Grid mb="xl" gap="md">
+              <Grid.Col span={{ base: 12, md: 6 }}>
+                <ChartSkeleton height={220} />
+              </Grid.Col>
+              <Grid.Col span={{ base: 12, md: 6 }}>
+                <ChartSkeleton height={220} />
+              </Grid.Col>
+            </Grid>
+          }
+        >
+          <CostTokenPanel tickInterval={tickInterval} />
+        </Deferred>
+
+        {/* Sessions list */}
+        <Text size="md" fw={600} mb="md" mt="xl">
+          Sessions
+        </Text>
+        <Deferred data="sessions" fallback={<Skeleton height={200} radius="sm" />}>
+          <SessionsPanel />
+        </Deferred>
+      </Box>
     </AuthLayout>
   );
 };


### PR DESCRIPTION
## Summary
- Restructures the Account tab into a two-column grid per the design handoff in palad-ai/palad-app#491: Personal Information pairs with Companies (identity band), Agent Runtimes pairs with a merged Agent Defaults card (agents band), Personal MCP spans the wide column. Collapses to one column below 900px.
- Companies rows gain a monogram tile and the bespoke Leave-company confirm dialog is replaced with the shared `modals.openConfirmModal` pattern already used elsewhere on the page.
- Personal MCP gets status chips (Enabled/Disabled, Not used yet/In use).
- Usage tab content width now matches the Account tab so switching tabs doesn't jump width.
- All colors/spacing/typography come from the app's existing `--app-*` design tokens (already matched the reference mockup's palette) — no new literals introduced.

Kept (confirmed with the requester, differed from the static mockup): session-visibility toggles, pending invitations list, the Claude-Code-only "Connect Design" gating, and no "Powered by Aixle" footer (already present via the app's layout chrome).

## Test plan
- [x] `docker compose exec -T web make check_all` green (rails-test, rubocop, brakeman, system-test, eslint, typescript, fe-test, vite-build)
- [x] Extended `Show.test.tsx`: merged Agent Defaults card, monogram tile, leave-company confirm/cancel via the shared modal
- [x] Manually verified in-browser: dark theme, light theme, responsive collapse to one column below 900px, leave-company confirm modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)