### PR TITLE
fix(inertia): address partial reloads by their server-side prop names

### DIFF
--- a/app/frontend/pages/Onboarding/OnboardingPage.test.tsx
+++ b/app/frontend/pages/Onboarding/OnboardingPage.test.tsx
@@ -337,10 +337,12 @@ describe('Onboarding/OnboardingPage', () => {
     await userEvent.click(screen.getAllByRole('button', { name: 'Connect' })[0]);
     expect(await screen.findByText('Authentication session failed to start.')).toBeInTheDocument();
 
-    // Retry POSTs a fresh session (apiFetch → mocked fetch resolves 200) then reloads authSessions.
+    // Retry POSTs a fresh session (apiFetch → mocked fetch resolves 200) then reloads auth_sessions.
+    // The partial-reload key is the SERVER prop name (snake_case): inertia_rails filters
+    // `only` before the camelCase prop transformer runs, so 'authSessions' matches nothing.
     await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
 
-    await waitFor(() => expect(router.reload).toHaveBeenCalledWith({ only: ['authSessions'] }));
+    await waitFor(() => expect(router.reload).toHaveBeenCalledWith({ only: ['auth_sessions'] }));
   });
 
   it('renders the ttyd terminal iframe for a ready auth session after clicking Connect', async () => {

--- a/app/frontend/pages/Onboarding/OnboardingPage.tsx
+++ b/app/frontend/pages/Onboarding/OnboardingPage.tsx
@@ -140,7 +140,7 @@ function AgentAuthTerminal({
   const ttydUrl = session?.state === 'ready' && session.websocketUrl ? ttydUrlFromWs(session.websocketUrl) : null;
 
   useInertiaCableStream(session?.cableStream, {
-    only: ['authSessions'],
+    only: ['auth_sessions'],
     enabled: !!session && !isTerminal,
   });
 
@@ -154,7 +154,7 @@ function AgentAuthTerminal({
         body: JSON.stringify({ terminalSession: { agentType, sessionType: 'auth_setup', mode: 'interactive' } }),
       });
       if (res.ok) {
-        router.reload({ only: ['authSessions'] });
+        router.reload({ only: ['auth_sessions'] });
       } else {
         creatingRef.current = false;
       }

--- a/app/frontend/pages/Profile/Show.tsx
+++ b/app/frontend/pages/Profile/Show.tsx
@@ -1093,7 +1093,7 @@ function PersonalMcpSection({ mcp }: { mcp: McpProps }) {
 
 function ProfilePage({ profile, pendingInvitations, agentModels, cableStream, mcp }: Props) {
   const currentCompanyName = profile.currentCompany?.name ?? null;
-  useInertiaCableStream(cableStream, { only: ['profile', 'agentModels'] });
+  useInertiaCableStream(cableStream, { only: ['profile', 'agent_models'] });
 
   const { data, setData, patch, processing, errors, isDirty } = useForm({
     profile: {

--- a/app/frontend/pages/Projects/Assets/AssetsPage.test.tsx
+++ b/app/frontend/pages/Projects/Assets/AssetsPage.test.tsx
@@ -85,7 +85,7 @@ describe('Projects/Assets/AssetsPage', () => {
     await userEvent.click(historyButton);
 
     expect(router.reload).toHaveBeenCalledWith(
-      expect.objectContaining({ data: { history_asset_id: 42 }, only: ['assetVersions'] }),
+      expect.objectContaining({ data: { history_asset_id: 42 }, only: ['asset_versions'] }),
     );
   });
 });

--- a/app/frontend/pages/Projects/Overview/OverviewPage.tsx
+++ b/app/frontend/pages/Projects/Overview/OverviewPage.tsx
@@ -289,7 +289,7 @@ const OverviewPage = () => {
     const interval = setInterval(() => {
       router.reload({
         preserveScroll: true,
-        only: ['summary', 'workflowRunStats', 'boardTaskDistribution', 'recentActivity'],
+        only: ['summary', 'workflow_run_stats', 'board_task_distribution', 'recent_activity'],
       } as never);
     }, 60_000);
     return () => clearInterval(interval);

--- a/app/frontend/shared/resources/assets/AssetsContent.test.tsx
+++ b/app/frontend/shared/resources/assets/AssetsContent.test.tsx
@@ -112,7 +112,7 @@ describe('AssetsContent', () => {
     await userEvent.click(historyBtn as HTMLButtonElement);
 
     expect(router.reload).toHaveBeenCalledWith(
-      expect.objectContaining({ data: { history_asset_id: 42 }, only: ['assetVersions'] }),
+      expect.objectContaining({ data: { history_asset_id: 42 }, only: ['asset_versions'] }),
     );
   });
 

--- a/app/frontend/shared/resources/assets/AssetsContent.tsx
+++ b/app/frontend/shared/resources/assets/AssetsContent.tsx
@@ -137,7 +137,7 @@ export function AssetsContent({
     setHistoryLoading(true);
     router.reload({
       data: { history_asset_id: asset.id },
-      only: ['assetVersions'],
+      only: ['asset_versions'],
       onFinish: () => setHistoryLoading(false),
     });
   }, []);

--- a/app/frontend/shared/resources/connectors/ConnectorCatalogModal.test.tsx
+++ b/app/frontend/shared/resources/connectors/ConnectorCatalogModal.test.tsx
@@ -141,7 +141,7 @@ describe('shared/resources/connectors/ConnectorCatalogModal', () => {
       expect(get).toHaveBeenCalledWith(
         '/company/projects/7/mcp_servers',
         { connector_q: 'issue' },
-        expect.objectContaining({ only: ['connectors', 'connectorQuery'] }),
+        expect.objectContaining({ only: ['connectors', 'connector_query'] }),
       ),
     );
   });

--- a/app/frontend/shared/resources/connectors/ConnectorCatalogModal.tsx
+++ b/app/frontend/shared/resources/connectors/ConnectorCatalogModal.tsx
@@ -85,7 +85,7 @@ export const ConnectorCatalogModal: FC<ConnectorCatalogModalProps> = ({
       {
         preserveState: true,
         replace: true,
-        only: ['connectors', 'connectorQuery'],
+        only: ['connectors', 'connector_query'],
         onFinish: () => setSearching(false),
       },
     );

--- a/test/integration/web/onboarding_render_test.rb
+++ b/test/integration/web/onboarding_render_test.rb
@@ -35,4 +35,32 @@ class Web::OnboardingRenderTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_inertia_page "Onboarding/OnboardingPage"
   end
+
+  # The onboarding UI polls the auth session over a PARTIAL reload (the agent step
+  # asks for `auth_sessions` alone after creating a session, and again on every
+  # cable refresh). inertia_rails filters `only` against the prop names this
+  # controller declares — snake_case — BEFORE the camelCase prop transformer runs
+  # (config/initializers/inertia.rb), so a client asking for "authSessions"
+  # matches nothing and silently gets a response without the prop. That is what
+  # left the Connect panel stuck on "Starting auth session..." until a full page
+  # reload. Pin both halves: the snake_case key resolves, the camelCase one does not.
+  test "the auth_sessions prop is served for a snake_case partial reload" do
+    create(:terminal_session, user: @user)
+
+    assert_equal 1, partial_props("auth_sessions").fetch("authSessions").size
+    assert_not partial_props("authSessions").key?("authSessions")
+  end
+
+  private
+
+  def partial_props(key)
+    get onboarding_path, headers: {
+      "X-Inertia" => "true",
+      "X-Inertia-Partial-Component" => "Onboarding/OnboardingPage",
+      "X-Inertia-Partial-Data" => key
+    }
+
+    assert_response :success
+    JSON.parse(response.body).fetch("props")
+  end
 end


### PR DESCRIPTION
## Problem

Onboarding could not be completed on the first attempt: the "Connect your agents" panel sat on *"Starting auth session..."* forever, no agent could be connected, and "Get started" stayed disabled. A full page reload made everything appear.

## Root cause

`only:` on a partial reload is filtered by `inertia_rails` (`PropsResolver#excluded_by_only_partial_keys?`) against the prop names **the controller declares** — snake_case. The camelCase form only appears later, in the `prop_transformer` from `config/initializers/inertia.rb`. Six call sites asked for the camelCase name, matched nothing, and got back a response with the prop missing; the client merged nothing and kept its stale value.

Verified against `/onboarding`:

```
X-Inertia-Partial-Data: authSessions   → props: ["errors", "currentUser", "projects"]
X-Inertia-Partial-Data: auth_sessions  → props: ["errors", "currentUser", "projects", "authSessions"]
```

Onboarding was hit hardest because the whole step is built on this: after `POST /api/v1/terminal_sessions` it runs `router.reload({ only: ['authSessions'] })`, and every cable broadcast about the session changing state (`starting → ready`) does the same. The session never arrived. A full page reload is not a partial request, which is why it worked there.

Introduced by the onboarding redesign (db0c6837 / 5a086d95), where the agent-connection step started relying on partial reloads.

## What's in this PR

Six keys corrected to the server-side prop names:

| File | Before | After |
|---|---|---|
| `Onboarding/OnboardingPage.tsx` (×2) | `authSessions` | `auth_sessions` |
| `Profile/Show.tsx` | `agentModels` | `agent_models` |
| `assets/AssetsContent.tsx` | `assetVersions` | `asset_versions` |
| `Overview/OverviewPage.tsx` | `workflowRunStats`, `boardTaskDistribution`, `recentActivity` | snake_case |
| `connectors/ConnectorCatalogModal.tsx` | `connectorQuery` | `connector_query` |

Three frontend tests asserted the broken key — corrected. A request test added to `onboarding_render_test.rb` pins both halves of the contract: the snake_case key resolves the prop, the camelCase one does not.

**Left alone:** `only: ['editBranches']` in `RepositoriesContent.tsx` is a different bug — `repositories_controller` serves no such prop under any casing. And `catalogSkills` / `catalogQuery` in `SkillsCatalogModal.tsx` are correct: `skills_controller` declares them in camelCase.

## Verification

`docker compose exec -T web make check_all` — fully green (rails-test, rubocop, brakeman, system-test, eslint, typescript, fe-test, vite-build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)