### PR TITLE
fix(workflows): restore agent runtime model selection on sessions

### DIFF
--- a/app/frontend/pages/Projects/Workflows/BuilderPage.test.tsx
+++ b/app/frontend/pages/Projects/Workflows/BuilderPage.test.tsx
@@ -755,6 +755,33 @@ describe('Projects/Workflows/BuilderPage', () => {
     await waitFor(() => expect(fetchSpy).not.toHaveBeenCalled());
   });
 
+  it("choosing a Preferred Model PATCHes preferredModel, scoped to the runtime's models", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
+
+    renderAuthedPage(<BuilderPage />, {
+      props: projectProps({
+        steps: [makeStep({ id: 1, name: 'Draft spec', position: 1, requiredAgentRuntime: 'claude_code' })],
+        agentModels: [{ agentType: 'claude_code', models: [{ modelId: 'opus-9', displayName: 'Opus 9' }] }],
+      }),
+    });
+
+    const preferredModelCombobox = screen.getAllByLabelText('Preferred model')[0];
+    await userEvent.click(preferredModelCombobox);
+    await userEvent.click(await screen.findByRole('option', { name: 'Opus 9' }));
+
+    await waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/v1/projects/7/workflows/3/steps/1',
+        expect.objectContaining({ method: 'PATCH' }),
+      ),
+    );
+    const call = fetchSpy.mock.calls.find(([url]) => url === '/api/v1/projects/7/workflows/3/steps/1');
+    const body = JSON.parse((call![1] as RequestInit).body as string);
+    expect(body.step.preferredModel).toBe('opus-9');
+  });
+
   it('selecting a dependency PATCHes dependsOnStepIds and shows the "↳ AFTER" badge in the sidebar', async () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')

--- a/app/frontend/pages/Projects/Workflows/BuilderPage.tsx
+++ b/app/frontend/pages/Projects/Workflows/BuilderPage.tsx
@@ -660,6 +660,7 @@ const BuilderPage = () => {
                       mcpServers={mcpServers}
                       assets={assets}
                       repositories={repositories}
+                      agentModels={agentModels}
                       readOnly={readOnly}
                       onFieldChange={(field, value, immediate) =>
                         updateStepField(selectedSession.id, field, value, immediate)

--- a/app/frontend/pages/Projects/Workflows/SessionEditorPanel.tsx
+++ b/app/frontend/pages/Projects/Workflows/SessionEditorPanel.tsx
@@ -40,6 +40,7 @@ interface Step {
   position: number;
   agentId: number | null;
   requiredAgentRuntime: string | null;
+  preferredModel: string | null;
   allowNonInteractive: boolean;
   skipPolicy: string;
   onFailure: string;
@@ -155,6 +156,15 @@ function AssetRows({ specs, onChange, showNamePattern, disabled, kind }: AssetRo
 
 const GROUP_PREFIX = 'grp:';
 
+interface AgentModel {
+  modelId: string;
+  displayName: string;
+}
+interface AgentModelsEntry {
+  agentType: string;
+  models: AgentModel[];
+}
+
 interface SessionEditorPanelProps {
   step: Step;
   allSteps: Step[];
@@ -165,6 +175,7 @@ interface SessionEditorPanelProps {
   mcpServers: NamedItem[];
   assets: NamedItem[];
   repositories: NamedItem[];
+  agentModels?: AgentModelsEntry[];
   readOnly: boolean;
   onFieldChange: (field: string, value: unknown, immediate?: boolean) => void;
   onAssetSpecsChange: (field: 'inputAssetSpecs' | 'outputAssetSpecs', specs: AssetSpec[]) => void;
@@ -180,12 +191,24 @@ export function SessionEditorPanel({
   mcpServers,
   assets,
   repositories,
+  agentModels = [],
   readOnly,
   onFieldChange,
   onAssetSpecsChange,
 }: SessionEditorPanelProps) {
   const [instructionsExpanded, setInstructionsExpanded] = useState(false);
   const charCount = (step.instructions ?? '').length;
+
+  const modelsMap: Record<string, AgentModel[]> = {};
+  for (const entry of agentModels) modelsMap[entry.agentType] = entry.models;
+  const runtimeModels = step.requiredAgentRuntime ? (modelsMap[step.requiredAgentRuntime] ?? []) : [];
+  const modelOptions = runtimeModels
+    .filter((m) => m.modelId)
+    .map((m) => ({ value: m.modelId, label: m.displayName || m.modelId }));
+  const preferredModelOptions =
+    step.preferredModel && !modelOptions.some((o) => o.value === step.preferredModel)
+      ? [...modelOptions, { value: step.preferredModel, label: step.preferredModel }]
+      : modelOptions;
 
   const groupedToolIds = new Set(toolGroups.flatMap((g) => g.toolIds));
   const toolSelectData = [
@@ -339,7 +362,12 @@ export function SessionEditorPanel({
                 { value: 'gemini_cli', label: 'Gemini CLI' },
               ]}
               value={step.requiredAgentRuntime ?? ''}
-              onChange={(v) => onFieldChange('requiredAgentRuntime', v || null, true)}
+              onChange={(v) => {
+                const runtime = v || null;
+                if (runtime === step.requiredAgentRuntime) return;
+                onFieldChange('requiredAgentRuntime', runtime, true);
+                if (step.preferredModel) onFieldChange('preferredModel', null, true);
+              }}
               disabled={readOnly}
               clearable
               placeholder="None (default)"
@@ -355,6 +383,38 @@ export function SessionEditorPanel({
               }}
             />
           </div>
+          {step.requiredAgentRuntime && (
+            <div>
+              <label className={classes.fieldLabel}>
+                Preferred Model&nbsp;
+                <span
+                  title="Overrides the runtime's default model for this session."
+                  style={{ color: 'var(--text-3)', cursor: 'help' }}
+                >
+                  <IconInfoCircle size={11} style={{ display: 'inline', verticalAlign: 'middle' }} />
+                </span>
+              </label>
+              <Select
+                data={preferredModelOptions}
+                value={step.preferredModel ?? null}
+                onChange={(v) => onFieldChange('preferredModel', v || null, true)}
+                disabled={readOnly}
+                clearable
+                searchable
+                placeholder="Default (runtime selects)"
+                aria-label="Preferred model"
+                styles={{
+                  input: {
+                    background: 'transparent',
+                    border: '1px solid var(--border)',
+                    borderRadius: 4,
+                    color: 'var(--text-1)',
+                    fontSize: 13,
+                  },
+                }}
+              />
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- The Workflow Builder redesign (#212) rewrote the session editor into `SessionEditorPanel.tsx` and dropped the "Preferred Model" select in the process — it never carried `preferredModel` in the local `Step` type or received `agentModels` as a prop, so the model picker for a session's agent runtime silently disappeared (reported: "в настройках воркфлоу пропала возможность выбрать модель у agent runtime").
- The backend (`preferred_model` column, `StepResource`, `SessionService`, workflow duplicator, meta-tools) was untouched — this was a pure frontend regression.
- Restored the "Preferred Model" select in `SessionEditorPanel.tsx`, shown once an Execution Environment is chosen, scoped to that runtime's models via `agentModels`, and cleared when the runtime changes — matching pre-redesign behavior.
- Wired `agentModels` from `BuilderPage.tsx` into `SessionEditorPanel`.

## Test plan
- [x] `docker compose exec -T web make check_all` green (backend + frontend, rebased onto latest `develop`)
- [x] Added regression test in `BuilderPage.test.tsx` covering selecting a Preferred Model PATCHes `preferredModel`
- [x] Manually verified existing runtime-reset test still passes with the new select present

🤖 Generated with [Claude Code](https://claude.com/claude-code)