### PR TITLE
fix(boards): record workflow cancellations on the board timeline

### DIFF
--- a/app/dashboards/board_activity_dashboard.rb
+++ b/app/dashboards/board_activity_dashboard.rb
@@ -8,14 +8,10 @@ class BoardActivityDashboard < Administrate::BaseDashboard
     board: Field::BelongsTo,
     board_task: Field::BelongsTo.with_options(optional: true),
     actor: Field::BelongsTo.with_options,
+    # Sourced from the model so the filter list can't drift from the enum.
     event_type: Field::Select.with_options(
       include_blank: false,
-      collection: %w[
-        task_created task_updated task_deleted task_moved
-        comment_added asset_attached
-        workflow_started workflow_completed workflow_failed
-        human_help_requested
-      ]
+      collection: BoardActivity.event_type.values.map(&:to_s)
     ),
     actor_type: Field::Select.with_options(
       include_blank: false,

--- a/app/models/board_activity.rb
+++ b/app/models/board_activity.rb
@@ -11,7 +11,7 @@ class BoardActivity < ApplicationRecord
     task_created task_updated task_deleted task_moved
     task_archived task_unarchived
     comment_added asset_attached
-    workflow_started workflow_completed workflow_failed
+    workflow_started workflow_completed workflow_failed workflow_cancelled
     human_help_requested
   ]
   enumerize :actor_type, in: %i[human agent system]

--- a/app/resources/board_activity_resource.rb
+++ b/app/resources/board_activity_resource.rb
@@ -51,6 +51,8 @@ class BoardActivityResource < ApplicationResource
       "Workflow '#{meta['workflow_name']}' completed on '#{task}'"
     when "workflow_failed"
       "Workflow '#{meta['workflow_name']}' failed on '#{task}'"
+    when "workflow_cancelled"
+      "Workflow '#{meta['workflow_name']}' cancelled on '#{task}'"
     when "human_help_requested"
       "Agent requested help on '#{task}': #{meta['question'].to_s.truncate(80)}"
     else

--- a/app/services/recent_activity_service.rb
+++ b/app/services/recent_activity_service.rb
@@ -102,6 +102,7 @@ class RecentActivityService
     when "workflow_started"      then "Workflow started for \"#{task_title}\""
     when "workflow_completed"    then "Workflow completed for \"#{task_title}\""
     when "workflow_failed"       then "Workflow failed for \"#{task_title}\""
+    when "workflow_cancelled"    then "Workflow cancelled for \"#{task_title}\""
     when "human_help_requested"  then "Human help requested for \"#{task_title}\""
     else                              "Activity on \"#{task_title}\""
     end

--- a/app/services/workflow_service.rb
+++ b/app/services/workflow_service.rb
@@ -144,7 +144,7 @@ class WorkflowService
       )
       board.touch
     rescue StandardError => e
-      Rails.logger.warn("[WorkflowService] Failed to record activity for run ##{run.id}: #{e.message}")
+      Rails.logger.warn("[WorkflowService] Failed to record #{event_type} activity for run ##{run.id}: #{e.message}")
     end
   end
 end

--- a/test/resources/board_activity_resource_test.rb
+++ b/test/resources/board_activity_resource_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BoardActivityResourceTest < ActiveSupport::TestCase
+  setup do
+    @company = create(:company)
+    @user = create(:user, company: @company, name: "Ada Lovelace")
+    @project = create(:project, company: @company, owner: @user)
+    @board = create(:board, project: @project)
+    @column = create(:board_column, board: @board)
+    @task = create(:board_task, board: @board, board_column: @column, title: "Ship it")
+  end
+
+  test "workflow events describe the workflow and task, including cancellation" do
+    descriptions = %w[workflow_started workflow_completed workflow_failed workflow_cancelled].map do |event_type|
+      describe_activity(event_type, metadata: { "workflow_name" => "Nightly build" })
+    end
+
+    assert_equal [ "Workflow 'Nightly build' started on 'Ship it'",
+                   "Workflow 'Nightly build' completed on 'Ship it'",
+                   "Workflow 'Nightly build' failed on 'Ship it'",
+                   "Workflow 'Nightly build' cancelled on 'Ship it'" ], descriptions
+  end
+
+  test "unmapped events fall back to a humanized actor sentence" do
+    assert_equal "Ada Lovelace performed task archived",
+                 describe_activity("task_archived", actor_type: :human)
+  end
+
+  private
+
+  def describe_activity(event_type, actor_type: :system, metadata: {})
+    activity = BoardActivity.create!(
+      board: @board, board_task: @task, event_type:,
+      actor: @user, actor_type:, metadata:
+    )
+    BoardActivityResource.new(activity).to_h["description"]
+  end
+end

--- a/test/services/recent_activity_service_test.rb
+++ b/test/services/recent_activity_service_test.rb
@@ -107,6 +107,17 @@ class RecentActivityServiceTest < ActiveSupport::TestCase
     assert_equal 'Task "Ship it" moved to Done', call[:activities].first[:description]
   end
 
+  test "workflow board activities describe start, completion, failure, and cancellation" do
+    task = create(:board_task, board: @board, board_column: @board_column, title: "Ship it")
+    %w[workflow_started workflow_completed workflow_failed workflow_cancelled].each_with_index do |event_type, i|
+      create_board_activity(event_type:, board_task: task, created_at: (i + 1).minutes.ago)
+    end
+
+    descriptions = call[:activities].map { |a| a[:description] }
+    assert_equal [ 'Workflow started for "Ship it"', 'Workflow completed for "Ship it"',
+                   'Workflow failed for "Ship it"', 'Workflow cancelled for "Ship it"' ], descriptions
+  end
+
   test "board activity preserves event type, actor type, and metadata" do
     create_board_activity(event_type: "comment_added", actor_type: "agent",
                           metadata: { "task_title" => "Docs", "note" => "hi" })

--- a/test/services/workflow_service_test.rb
+++ b/test/services/workflow_service_test.rb
@@ -91,6 +91,23 @@ class WorkflowServiceTest < ActiveSupport::TestCase
     assert_equal "cancelled", run.state
   end
 
+  test "cancel records a workflow_cancelled activity on the task's board" do
+    TemporalWorkflowRegistry.stubs(:start_workflow_execution)
+    TemporalService.stubs(:send_signal)
+    board = create(:board, project: @project)
+    column = create(:board_column, board: board)
+    task = create(:board_task, board: board, board_column: column)
+    run = WorkflowService.start(workflow: @workflow, project: @project, user: @user, task: task)
+
+    assert_difference("BoardActivity.count", 1) do
+      WorkflowService.cancel(run: run)
+    end
+
+    activity = BoardActivity.by_event_type(:workflow_cancelled).sole
+    assert_equal task.id, activity.board_task_id
+    assert_equal run.id, activity.metadata["workflow_run_id"]
+  end
+
   # == approve_step ==
 
   test "approve_step marks completed and sends signal" do


### PR DESCRIPTION
## Problem

`WorkflowService#cancel` records a `BoardActivity` with `event_type: :workflow_cancelled`, but `BoardActivity`'s enum never listed that value. Enumerize discards an unknown value, `validates :event_type, presence: true` then fails, and the `rescue StandardError` in `record_activity` swallows the `RecordInvalid` with a warning. Result: workflow starts, completions and failures show up on the board timeline; cancellations never do.

## Fix

- `workflow_cancelled` added to the `BoardActivity` enum.
- Both readers describe it: `BoardActivityResource#description` (board timeline) and `RecentActivityService#build_board_item` (activity feed). The feed already had a `workflow_cancelled` label for *workflow-run* rows and a colour on the frontend — only the board-activity branch was missing.
- The administrate dashboard's filter list now comes from `BoardActivity.event_type.values` instead of a hand-copied array, so it cannot drift from the enum again (it was already missing `task_archived`/`task_unarchived`).
- The swallowed-error log now names the event type it failed to record.

No migration: `board_activities.event_type` is a plain string column.

## Tests

- `WorkflowServiceTest` — cancelling a run with a board task creates the activity (fails before the fix).
- `RecentActivityServiceTest` — the four workflow board events each get their own description.
- New `BoardActivityResourceTest` — workflow descriptions incl. cancellation, plus the humanized fallback.

`docker compose exec -T web make check_all` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)