### PR TITLE
fix(docker): chown app HOME unconditionally so root-owned subdirs can't stick

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -4,13 +4,25 @@ set -e
 # docker-compose overrides the image ENTRYPOINT with this script. Mirror
 # bin/run-as-app so bundle_cache/app_home stay writable under the non-root
 # app user (app_home holds corepack/yarn's global cache — see docker-compose.yml).
-# Only chown -R once (checked via top-level ownership): app_home accumulates a
-# large corepack/yarn cache, and re-walking it on every container start is slow.
+#
+# The chown is UNCONDITIONAL on purpose. A "chown only if the top-level dir is
+# already root-owned" guard was tried and reverted: once /home/app itself is
+# app-owned the guard skips forever, so any subdirectory a root process creates
+# later stays root-owned permanently. That is not hypothetical — root-owned
+# 0700 /home/app/.config and /home/app/.local left Chromium unable to write its
+# profile, which SIGTRAPs it at startup and failed every system test with
+# `Ferrum::ProcessTimeoutError: Browser did not produce websocket url`.
+# The walk is cheap: bundle_cache is the larger of the two (~48k files) and was
+# already being walked unconditionally before app_home existed (~0.15s for both).
+#
+# -h (chown the symlink, never its target) is load-bearing, not cosmetic: this
+# runs as root over caches that package managers write, so a symlink planted
+# there must not hand its target to the app user. BusyBox already behaves this
+# way under -R; the flag states it, so swapping the base image for one with GNU
+# coreutils — where dereferencing is the default — can't silently reintroduce it.
 if [ "$(id -u)" = "0" ]; then
   mkdir -p /bundle_cache /home/app
-  for dir in /bundle_cache /home/app; do
-    [ "$(stat -c '%U' "$dir" 2>/dev/null)" = "app" ] || chown -R app:app "$dir" 2>/dev/null || true
-  done
+  chown -Rh app:app /bundle_cache /home/app 2>/dev/null || true
   # See bin/run-as-app: grant the app user access to the host Docker socket
   # when it's mounted (root:root 660 on the host side). No-op otherwise.
   if [ -S /var/run/docker.sock ]; then

--- a/bin/run-as-app
+++ b/bin/run-as-app
@@ -3,13 +3,12 @@ set -e
 
 # Drop from root to the unprivileged app user (L-22). When bundle_cache/app_home
 # are Docker volumes they are root-owned on first mount — fix that before switching.
-# Only chown -R once (checked via top-level ownership): app_home accumulates a
-# large corepack/yarn cache, and re-walking it on every container start is slow.
+# Unconditional by design, and -h by design; see bin/docker-entrypoint for why
+# the top-level ownership guard was reverted (it pins root-owned subdirectories
+# forever) and why symlinks must never be dereferenced here.
 if [ "$(id -u)" = "0" ]; then
   mkdir -p /bundle_cache /home/app
-  for dir in /bundle_cache /home/app; do
-    [ "$(stat -c '%U' "$dir" 2>/dev/null)" = "app" ] || chown -R app:app "$dir" 2>/dev/null || true
-  done
+  chown -Rh app:app /bundle_cache /home/app 2>/dev/null || true
   # Worker bind-mounts the host Docker socket for container lifecycle
   # management (docker-api gem); it's root:root 660 on the host side, so the
   # unprivileged app user (L-22) can't connect to it unless we grant its


### PR DESCRIPTION
## Problem

Local `rails test:system` fails every test with `Ferrum::ProcessTimeoutError: Browser did not produce websocket url within 60 seconds` — no page is ever loaded, because Chromium never starts.

Root cause is an ownership drift in the `app_home` volume:

```
/home/app          app  755   → guard: skip
/home/app/.config  root 700   → stuck
/home/app/.local   root 700   → stuck
```

Chromium can't write its profile/crashpad dir under an unwritable `$HOME`, so it dies with SIGTRAP (exit 133) before advertising its debugging socket.

## Why it never self-heals

The chown in `bin/docker-entrypoint` / `bin/run-as-app` is guarded by a **top-level** ownership check:

```sh
[ "$(stat -c '%U' "$dir")" = "app" ] || chown -R app:app "$dir"
```

Once `/home/app` itself is app-owned the guard skips forever, so anything a root process creates underneath it later stays root-owned permanently.

## Change

Drop the guard, restore the unconditional `chown -R` that `/bundle_cache` had before `app_home` existed, and add `-h`.

The performance concern the guard was added for does not hold up:

| path | files |
|---|---:|
| `/bundle_cache` | 48,435 |
| `/home/app` | 4,232 |
| **both, `chown -R`** | **0.151s** |

`/bundle_cache` is the larger of the two and was already being walked unconditionally.

`-h` (chown the symlink, never its target) matters because this runs as root over caches that package managers write. BusyBox already behaves this way under `-R` — verified below — so the flag is there to keep a future base-image swap to GNU coreutils, where dereferencing is the default, from silently reintroducing the vector.

## Verification

Broken state recreated, then started through the patched entrypoint:

```
config=app local=app
symlink_target=root      # planted symlink did not hand its target over
chromium=0               # was 133

rails test:system → 7 runs, 42 assertions, 0 failures, 0 errors
```

## Notes

- **CI is unaffected either way** — `docker-compose.ci.yml` declares no volumes, so `/home/app` and `/bundle_cache` are plain image directories that are already app-owned. CI system tests have been green throughout; this is a local-environment failure only.
- On a **Linux host** the recursive chown reaches the bind-mounted `~/.bash_history` and flips it to uid 100. That is a property of the mount rather than of this change (the guard only made it rarer — it still ran on first start), but it is worth knowing. On Docker Desktop/macOS the chown is ignored by VirtioFS; verified the host file is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
