### PR TITLE
feat(profile): show Claude subscription usage limits

### DIFF
--- a/app/controllers/web/profile_controller.rb
+++ b/app/controllers/web/profile_controller.rb
@@ -19,6 +19,13 @@ class Web::ProfileController < Web::ApplicationController
       language_options: CompanyMembership::AGENT_LANGUAGES,
       agent_models: current_membership&.agent_models_for_props || [],
       cable_stream: inertia_cable_stream(current_user),
+      # Plan-usage windows (Claude's 5-hour / weekly limits) are fetched from the
+      # vendor over HTTP, so they are deferred: the page must never wait on
+      # Anthropic to render. `?refresh=1` is the Refresh button; the service
+      # throttles it so the button can't turn into a 429 generator.
+      usage_limits: InertiaRails.defer(group: "limits") {
+        Agents::SubscriptionUsageService.new(membership: current_membership, force: params[:refresh].present?).call
+      },
       mcp: {
         enabled: current_user.mcp_enabled?,
         last_used_at: current_user.mcp_token_last_used_at,

--- a/app/frontend/pages/Profile/Show.tsx
+++ b/app/frontend/pages/Profile/Show.tsx
@@ -1,4 +1,4 @@
-import { Head, router, useForm } from '@inertiajs/react';
+import { Deferred, Head, router, useForm } from '@inertiajs/react';
 import {
   CopyButton,
   Alert,
@@ -13,6 +13,7 @@ import {
   Loader,
   Modal,
   Select,
+  Skeleton,
   Stack,
   Switch,
   Tabs,
@@ -52,6 +53,7 @@ import { type AgentCredential, type AgentType, type SharedMembership, type Share
 import { StatusBadge, type StatusTone } from 'shared/ui/StatusBadge';
 
 import classes from './Show.module.css';
+import { UsageLimitsCard, type UsageLimitsEntry } from './UsageLimitsCard';
 
 const LANGUAGE_OPTIONS = [
   { value: 'en', label: 'English' },
@@ -175,6 +177,8 @@ interface Props {
   agentModels: AgentModelsEntry[];
   cableStream?: string;
   mcp: McpProps;
+  // Deferred (group "limits"): absent until Inertia's follow-up request lands.
+  usageLimits?: UsageLimitsEntry[];
 }
 
 function DefaultAgentSelector({ profile }: { profile: SharedUser }) {
@@ -1132,7 +1136,7 @@ function PersonalMcpSection({ mcp }: { mcp: McpProps }) {
   );
 }
 
-function ProfilePage({ profile, pendingInvitations, agentModels, cableStream, mcp }: Props) {
+function ProfilePage({ profile, pendingInvitations, agentModels, cableStream, mcp, usageLimits }: Props) {
   const currentCompanyName = profile.currentCompany?.name ?? null;
   useInertiaCableStream(cableStream, { only: ['profile', 'agent_models'] });
 
@@ -1301,6 +1305,10 @@ function ProfilePage({ profile, pendingInvitations, agentModels, cableStream, mc
             </Card>
 
             <AgentRuntimesSection profile={profile} />
+            {/* Deferred: reads the vendor's usage endpoint, so it must not hold up the page. */}
+            <Deferred data="usageLimits" fallback={<Skeleton height={180} radius="sm" />}>
+              <UsageLimitsCard entries={usageLimits ?? []} />
+            </Deferred>
             <PersonalMcpSection mcp={mcp} />
           </Box>
 

--- a/app/frontend/pages/Profile/UsageLimitsCard.test.tsx
+++ b/app/frontend/pages/Profile/UsageLimitsCard.test.tsx
@@ -1,0 +1,99 @@
+import '@testing-library/jest-dom/vitest';
+import { router } from '@inertiajs/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderPage, screen, userEvent } from 'test/renderPage';
+
+import { UsageLimitsCard, formatResetsIn, type UsageLimitsEntry } from './UsageLimitsCard';
+
+const buildEntry = (overrides: Partial<UsageLimitsEntry> = {}): UsageLimitsEntry => ({
+  agentType: 'claude_code',
+  status: 'ok',
+  windows: [
+    { key: 'five_hour', utilization: 33, resetsAt: '2026-08-16T18:00:00Z' },
+    { key: 'seven_day', utilization: 13, resetsAt: '2026-08-20T00:59:59Z' },
+  ],
+  extraUsage: null,
+  fetchedAt: '2026-08-16T12:00:00Z',
+  ...overrides,
+});
+
+describe('UsageLimitsCard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when no credential bills against a plan', () => {
+    renderPage(<UsageLimitsCard entries={[]} />);
+
+    expect(screen.queryByText('Usage limits')).not.toBeInTheDocument();
+  });
+
+  it('labels each window the way Claude Code does and shows how much is used', () => {
+    renderPage(<UsageLimitsCard entries={[buildEntry()]} />);
+
+    expect(screen.getByText('Current session (5 hours)')).toBeInTheDocument();
+    expect(screen.getByText('Current week (all models)')).toBeInTheDocument();
+    expect(screen.getByText('33%')).toBeInTheDocument();
+    expect(screen.getByText('13%')).toBeInTheDocument();
+  });
+
+  it('shows model-scoped weeklies and extra usage when the account has them', () => {
+    const entry = buildEntry({
+      windows: [{ key: 'seven_day_opus', utilization: 91, resetsAt: null }],
+      extraUsage: { enabled: true, utilization: 25, monthlyLimit: 100, usedCredits: 25 },
+    });
+
+    renderPage(<UsageLimitsCard entries={[entry]} />);
+
+    expect(screen.getByText('Current week (Opus)')).toBeInTheDocument();
+    expect(screen.getByText('91%')).toBeInTheDocument();
+    expect(screen.getByText('Extra usage this month')).toBeInTheDocument();
+    expect(screen.getByText('25 / 100 credits')).toBeInTheDocument();
+  });
+
+  it('tells the user to re-authenticate when the sign-in no longer works', () => {
+    renderPage(<UsageLimitsCard entries={[buildEntry({ status: 'unauthorized', windows: [] })]} />);
+
+    expect(screen.getByText(/re-authenticate/i)).toBeInTheDocument();
+    expect(screen.queryByText('Current session (5 hours)')).not.toBeInTheDocument();
+  });
+
+  it('says the vendor is throttling instead of showing an empty panel', () => {
+    renderPage(<UsageLimitsCard entries={[buildEntry({ status: 'rate_limited', windows: [] })]} />);
+
+    expect(screen.getByText(/throttling usage checks/i)).toBeInTheDocument();
+  });
+
+  it('reloads only the usage prop when refreshed, asking the server for fresh numbers', async () => {
+    const reload = vi.spyOn(router, 'reload').mockImplementation(() => undefined);
+    renderPage(<UsageLimitsCard entries={[buildEntry()]} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    expect(reload).toHaveBeenCalledWith(expect.objectContaining({ only: ['usage_limits'], data: { refresh: '1' } }));
+  });
+
+  it('names the agent only when more than one runtime reports limits', () => {
+    const { rerender } = renderPage(<UsageLimitsCard entries={[buildEntry()]} />);
+    expect(screen.queryByText('Claude Code')).not.toBeInTheDocument();
+
+    rerender(<UsageLimitsCard entries={[buildEntry(), buildEntry({ agentType: 'codex' })]} />);
+    expect(screen.getByText('Claude Code')).toBeInTheDocument();
+  });
+});
+
+describe('formatResetsIn', () => {
+  const now = Date.parse('2026-08-16T12:00:00Z');
+
+  it('counts down in the largest units that still say something useful', () => {
+    expect(formatResetsIn('2026-08-16T12:45:00Z', now)).toBe('resets in 45m');
+    expect(formatResetsIn('2026-08-16T14:30:00Z', now)).toBe('resets in 2h 30m');
+    expect(formatResetsIn('2026-08-19T16:00:00Z', now)).toBe('resets in 3d 4h');
+  });
+
+  it('handles a window with no reset time and one that has already lapsed', () => {
+    expect(formatResetsIn(null, now)).toBeNull();
+    expect(formatResetsIn('2026-08-16T11:00:00Z', now)).toBe('resets now');
+  });
+});

--- a/app/frontend/pages/Profile/UsageLimitsCard.tsx
+++ b/app/frontend/pages/Profile/UsageLimitsCard.tsx
@@ -1,0 +1,208 @@
+import { router } from '@inertiajs/react';
+import { Alert, Box, Button, Card, Group, Progress, Stack, Text, Title, Tooltip } from '@mantine/core';
+import { IconRefresh } from '@tabler/icons-react';
+import { useState } from 'react';
+
+/** One rolling quota window as the vendor reports it. `utilization` is a percentage (0-100). */
+export interface UsageWindow {
+  key: string;
+  utilization: number;
+  resetsAt: string | null;
+}
+
+/** Pay-as-you-go spend on top of the plan. Fields stay null until something is consumed. */
+export interface ExtraUsage {
+  enabled: boolean;
+  utilization: number | null;
+  monthlyLimit: number | null;
+  usedCredits: number | null;
+}
+
+export interface UsageLimitsEntry {
+  agentType: string;
+  status: 'ok' | 'unauthorized' | 'rate_limited' | 'unavailable';
+  windows?: UsageWindow[];
+  extraUsage?: ExtraUsage | null;
+  fetchedAt: string;
+}
+
+// Same wording Claude Code's own /usage view uses, so the two never disagree.
+const WINDOW_LABELS: Record<string, string> = {
+  five_hour: 'Current session (5 hours)',
+  seven_day: 'Current week (all models)',
+  seven_day_opus: 'Current week (Opus)',
+  seven_day_sonnet: 'Current week (Sonnet)',
+};
+
+const AGENT_LABELS: Record<string, string> = {
+  claude_code: 'Claude Code',
+};
+
+const STATUS_MESSAGES: Record<Exclude<UsageLimitsEntry['status'], 'ok'>, string> = {
+  unauthorized: 'Your Claude sign-in no longer works — re-authenticate above to see your limits.',
+  rate_limited: 'Anthropic is throttling usage checks right now. Try again in a minute.',
+  unavailable: "Couldn't reach Anthropic for usage limits.",
+};
+
+// A quota is worth noticing well before it runs out: amber from 70%, red from 90%.
+function utilizationColor(utilization: number): string {
+  if (utilization >= 90) return 'var(--app-danger-fg)';
+  if (utilization >= 70) return 'var(--app-warning-fg)';
+  return 'var(--app-success-fg)';
+}
+
+export function formatResetsIn(iso: string | null, now: number = Date.now()): string | null {
+  if (!iso) return null;
+  const target = new Date(iso).getTime();
+  if (Number.isNaN(target)) return null;
+
+  const minutes = Math.floor((target - now) / 60_000);
+  if (minutes <= 0) return 'resets now';
+
+  const days = Math.floor(minutes / 1440);
+  const hours = Math.floor((minutes % 1440) / 60);
+  if (days > 0) return `resets in ${days}d ${hours}h`;
+  if (hours > 0) return `resets in ${hours}h ${minutes % 60}m`;
+  return `resets in ${minutes}m`;
+}
+
+function WindowRow({ quota }: { quota: UsageWindow }) {
+  const label = WINDOW_LABELS[quota.key] ?? quota.key.replace(/_/g, ' ');
+  const percent = Math.min(100, Math.max(0, Math.round(quota.utilization)));
+  const resets = formatResetsIn(quota.resetsAt);
+
+  return (
+    <Box>
+      <Group justify="space-between" align="baseline" mb={4} gap="xs">
+        <Text size="sm" fw={500}>
+          {label}
+        </Text>
+        <Text size="sm" fw={600} c={utilizationColor(quota.utilization)}>
+          {percent}%
+        </Text>
+      </Group>
+      <Progress
+        value={percent}
+        color={utilizationColor(quota.utilization)}
+        size="sm"
+        radius="xl"
+        aria-label={`${label}: ${percent}% used`}
+      />
+      {resets && (
+        <Text size="xs" c="dimmed" mt={4}>
+          {resets}
+        </Text>
+      )}
+    </Box>
+  );
+}
+
+function ExtraUsageRow({ extraUsage }: { extraUsage: ExtraUsage }) {
+  const used = extraUsage.usedCredits ?? 0;
+  const limit = extraUsage.monthlyLimit;
+
+  return (
+    <Box>
+      <Group justify="space-between" align="baseline" mb={4} gap="xs">
+        <Text size="sm" fw={500}>
+          Extra usage this month
+        </Text>
+        <Text size="sm" fw={600}>
+          {limit === null ? `${used} credits` : `${used} / ${limit} credits`}
+        </Text>
+      </Group>
+      {extraUsage.utilization !== null && (
+        <Progress
+          value={Math.min(100, Math.max(0, Math.round(extraUsage.utilization)))}
+          color={utilizationColor(extraUsage.utilization)}
+          size="sm"
+          radius="xl"
+          aria-label={`Extra usage: ${Math.round(extraUsage.utilization)}% of the monthly cap`}
+        />
+      )}
+    </Box>
+  );
+}
+
+function EntryBody({ entry }: { entry: UsageLimitsEntry }) {
+  if (entry.status !== 'ok') {
+    return (
+      <Alert color={entry.status === 'unauthorized' ? 'red' : 'yellow'} variant="light" p="sm">
+        <Text size="sm">{STATUS_MESSAGES[entry.status]}</Text>
+      </Alert>
+    );
+  }
+
+  const windows = entry.windows ?? [];
+  if (windows.length === 0) {
+    return (
+      <Text size="sm" c="dimmed">
+        No usage recorded in the current windows yet.
+      </Text>
+    );
+  }
+
+  return (
+    <Stack gap={16}>
+      {windows.map((quota) => (
+        <WindowRow key={quota.key} quota={quota} />
+      ))}
+      {entry.extraUsage?.enabled && <ExtraUsageRow extraUsage={entry.extraUsage} />}
+    </Stack>
+  );
+}
+
+/**
+ * Subscription quota panel. Renders nothing when no credential on this membership
+ * bills against a plan — an API key or a Bedrock connection has no window to show.
+ */
+export function UsageLimitsCard({ entries }: { entries: UsageLimitsEntry[] }) {
+  const [refreshing, setRefreshing] = useState(false);
+
+  if (entries.length === 0) return null;
+
+  const handleRefresh = () => {
+    setRefreshing(true);
+    router.reload({
+      only: ['usage_limits'],
+      data: { refresh: '1' },
+      onFinish: () => setRefreshing(false),
+    });
+  };
+
+  return (
+    <Card p={24}>
+      <Group justify="space-between" align="flex-start" mb={4} gap="xs" wrap="nowrap">
+        <Box>
+          <Title order={5} mb={4}>
+            Usage limits
+          </Title>
+          <Text size="sm" c="dimmed">
+            How much of your subscription&apos;s rolling quotas this sign-in has used. Limits belong to the Anthropic
+            account, not to this company.
+          </Text>
+        </Box>
+        <Tooltip label="Check again (throttled to protect the vendor limit)">
+          <Button variant="subtle" size="xs" px={8} loading={refreshing} onClick={handleRefresh} aria-label="Refresh">
+            <IconRefresh size={16} />
+          </Button>
+        </Tooltip>
+      </Group>
+
+      <Stack gap={20} mt="md">
+        {entries.map((entry) => (
+          <Box key={entry.agentType}>
+            {entries.length > 1 && (
+              <Text size="xs" fw={600} c="dimmed" tt="uppercase" mb={8}>
+                {AGENT_LABELS[entry.agentType] ?? entry.agentType.replace(/_/g, ' ')}
+              </Text>
+            )}
+            <EntryBody entry={entry} />
+          </Box>
+        ))}
+      </Stack>
+    </Card>
+  );
+}
+
+export default UsageLimitsCard;

--- a/app/services/agents/base_adapter.rb
+++ b/app/services/agents/base_adapter.rb
@@ -343,6 +343,17 @@ module Agents
       { models: fetch_available_models(credentials, credential: credential), source: :api }
     end
 
+    # Plan-usage windows for a credential whose auth is a consumer subscription
+    # rather than metered API billing — how much of a rolling quota has been
+    # burned and when it resets. nil means "this credential has no such windows":
+    # an API key or a cloud-provider connection bills per token, and most agents
+    # have no equivalent concept at all.
+    # @param _credentials [Hash] decrypted credential data from AgentCredential
+    # @return [Hash, nil] { status:, windows: [{ key:, utilization:, resets_at: }], ... }
+    def fetch_subscription_usage(_credentials)
+      nil
+    end
+
     # Model ids a stored default may still carry after the vendor retired them,
     # mapped to the replacement to run instead. A retired id is not "an older
     # model" — the vendor answers 404, so every session started from that pin

--- a/app/services/agents/claude_code_adapter.rb
+++ b/app/services/agents/claude_code_adapter.rb
@@ -720,6 +720,59 @@ module Agents
       "claude-2.0" => "claude-sonnet-5"
     }.freeze
 
+    # =================================================================
+    # Subscription usage limits (claude.ai Pro/Max)
+    # =================================================================
+    #
+    # The numbers Claude Code's own `/usage` view shows: how much of the rolling
+    # 5-hour and 7-day quotas the account has burned, and when each resets. Only
+    # a claude.ai OAuth login has them — an API key bills per token and a Bedrock
+    # connection bills to AWS, so neither has a window to report.
+    USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
+
+    # Windows the endpoint reports, in the order they are worth reading. The
+    # model-scoped weeklies are null for an account that hasn't touched that
+    # model in the current window, and are simply omitted then.
+    USAGE_WINDOW_KEYS = %w[five_hour seven_day seven_day_opus seven_day_sonnet].freeze
+
+    # Anthropic buckets this endpoint per client and answers 429 to anything that
+    # polls hard or arrives without a User-Agent. The CLI identifies itself and
+    # polls no faster than ~180s; we do the same (the poll floor lives in
+    # Agents::SubscriptionUsageService, which is the only caller).
+    USAGE_USER_AGENT = "claude-cli/#{CONFIG_VERSION} (external, aixle)"
+
+    # True when inference on this credential is billed against a claude.ai
+    # subscription — the only case where 5-hour / weekly windows exist.
+    def subscription_login?(credentials)
+      chosen_inference(credentials) == "claudeAiOauth"
+    end
+
+    # @param credentials [Hash] decrypted credential data
+    # @return [Hash, nil] nil when the credential has no subscription windows at
+    #   all; otherwise { status:, windows:, extra_usage: } with status one of
+    #   "ok" | "unauthorized" | "rate_limited" | "unavailable". A failure is a
+    #   status, not an exception: a usage panel is never worth breaking the
+    #   profile page over.
+    def fetch_subscription_usage(credentials)
+      return nil unless subscription_login?(credentials)
+
+      token = credentials.dig("claudeAiOauth", "accessToken")
+      return nil if token.blank?
+
+      response = request_subscription_usage(token)
+      case response
+      when Net::HTTPSuccess          then parse_subscription_usage(response.body)
+      when Net::HTTPUnauthorized, Net::HTTPForbidden then { status: "unauthorized" }
+      when Net::HTTPTooManyRequests  then { status: "rate_limited" }
+      else
+        Rails.logger.warn("[ClaudeCodeAdapter] usage endpoint returned #{response.code}: #{response.body.to_s.truncate(200)}")
+        { status: "unavailable" }
+      end
+    rescue StandardError => e
+      Rails.logger.warn("[ClaudeCodeAdapter] subscription usage fetch failed: #{e.class}: #{e.message}")
+      { status: "unavailable" }
+    end
+
     # Default environment variables for Claude Code runtime.
     def default_env_vars(session)
       route_token = session.route_token
@@ -831,6 +884,46 @@ module Agents
     rescue StandardError => e
       Rails.logger.warn("[ClaudeCodeAdapter] Token refresh error: #{e.class}: #{e.message}")
       nil
+    end
+
+    def request_subscription_usage(token)
+      uri = URI(USAGE_URL)
+      req = Net::HTTP::Get.new(uri)
+      req["Authorization"] = "Bearer #{token}"
+      req["Accept"] = "application/json"
+      req["anthropic-beta"] = OAUTH_BETA_HEADER
+      req["User-Agent"] = USAGE_USER_AGENT
+      Net::HTTP.start(uri.hostname, uri.port, use_ssl: true, open_timeout: 5, read_timeout: 10) { |http| http.request(req) }
+    end
+
+    # A window the account has not touched in the current period comes back null;
+    # utilization 0 is a real answer and must survive (0 is not blank in Ruby, but
+    # spelling the nil check out keeps that from being a silent trap).
+    def parse_subscription_usage(body)
+      data = JSON.parse(body.to_s)
+      windows = USAGE_WINDOW_KEYS.filter_map do |key|
+        window = data[key]
+        next unless window.is_a?(Hash) && !window["utilization"].nil?
+
+        { key: key, utilization: window["utilization"].to_f, resets_at: window["resets_at"] }
+      end
+
+      { status: "ok", windows: windows, extra_usage: parse_extra_usage(data["extra_usage"]) }
+    end
+
+    # Pay-as-you-go spend on top of the plan, once the account has turned it on.
+    # Its fields stay null until something is actually consumed, so they are
+    # passed through as-is rather than defaulted to zero — "not started" and
+    # "nothing used" are different states to show.
+    def parse_extra_usage(raw)
+      return nil unless raw.is_a?(Hash) && raw["is_enabled"]
+
+      {
+        enabled: true,
+        utilization: raw["utilization"]&.to_f,
+        monthly_limit: raw["monthly_limit"]&.to_f,
+        used_credits: raw["used_credits"]&.to_f
+      }
     end
 
     # Keep whichever OAuth block has the later expiry; never drop one that only the

--- a/app/services/agents/subscription_usage_service.rb
+++ b/app/services/agents/subscription_usage_service.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Agents
+  # Plan-usage windows (Claude's rolling 5-hour and weekly limits) for every
+  # credential on a membership that reports them.
+  #
+  # Cached per credential because the vendor endpoint is bucketed per client and
+  # answers 429 to anything chatty — and the profile page would otherwise call it
+  # on every render, including the partial reloads Inertia fires for other props.
+  # The cache key carries the credential's updated_at, so a re-auth or a rotated
+  # token invalidates it for free: a credential that has just switched from a
+  # subscription to Bedrock never keeps serving the windows it used to have.
+  class SubscriptionUsageService
+    # Anthropic's usage endpoint tolerates a poll every ~180s; hold that as the
+    # floor for a successful answer.
+    OK_TTL = 3.minutes
+    # A failure gets a shorter hold so a transient error doesn't pin the panel
+    # for a full period.
+    ERROR_TTL = 1.minute
+    # How stale a cached answer must be before the "Refresh" button actually
+    # re-fetches. Without it the button is a 429 generator.
+    MIN_REFRESH_INTERVAL = 30.seconds
+
+    # Resolving an agent_type to its adapter is the seam this service is tested
+    # through: the vendor HTTP call lives in the adapter (and is contract-tested
+    # there), so caching and throttling can be exercised without a network stub.
+    DEFAULT_ADAPTER_RESOLVER = ->(agent_type) { AgentCredentialsService.for(agent_type).adapter }
+
+    # @param membership [CompanyMembership, nil] nil for a super admin (no credentials)
+    # @param force [Boolean] user asked for a refresh (still throttled)
+    # @param adapter_resolver [#call] agent_type -> adapter (test seam)
+    def initialize(membership:, force: false, adapter_resolver: DEFAULT_ADAPTER_RESOLVER)
+      @membership = membership
+      @force = force
+      @adapter_resolver = adapter_resolver
+    end
+
+    # @return [Array<Hash>] one entry per credential that reports usage windows:
+    #   { agent_type:, status:, windows:, extra_usage:, fetched_at: }
+    def call
+      return [] if @membership.nil?
+
+      @membership.credentials.filter_map { |credential| usage_for(credential) }
+    end
+
+    private
+
+    def usage_for(credential)
+      cached = Rails.cache.read(cache_key(credential))
+      return cached if cached && !refetch?(cached)
+
+      usage = adapter_for(credential).fetch_subscription_usage(credential.config_data)
+      return nil if usage.nil? # not a subscription login — nothing to show
+
+      entry = usage.merge(agent_type: credential.agent_type, fetched_at: Time.current)
+      Rails.cache.write(cache_key(credential), entry, expires_in: entry[:status] == "ok" ? OK_TTL : ERROR_TTL)
+      entry
+    rescue StandardError => e
+      # A credential we can't read (rotated encryption key, unknown agent type)
+      # must not take the profile page down with it.
+      Rails.logger.warn("[SubscriptionUsageService] #{credential.agent_type} usage unavailable: #{e.class}: #{e.message}")
+      nil
+    end
+
+    def refetch?(cached)
+      @force && cached[:fetched_at].to_time <= MIN_REFRESH_INTERVAL.ago
+    end
+
+    def adapter_for(credential)
+      @adapter_resolver.call(credential.agent_type)
+    end
+
+    def cache_key(credential)
+      "agent_subscription_usage/#{credential.id}/#{credential.updated_at.to_i}"
+    end
+  end
+end

--- a/test/integration/web/profile_controller_test.rb
+++ b/test/integration/web/profile_controller_test.rb
@@ -55,6 +55,29 @@ class Web::ProfileControllerTest < ActionDispatch::IntegrationTest
     assert_equal "en", other_membership.reload.preferred_agent_language
   end
 
+  # The usage panel reads Anthropic over HTTP. Deferring it is the contract that
+  # keeps a slow or throttled vendor off the profile page's critical path.
+  test "show defers the usage limits prop rather than blocking the render on the vendor" do
+    get profile_path
+
+    assert_inertia_deferred_props :usage_limits, group: "limits"
+    assert_inertia_props do |props|
+      !props.key?(:usageLimits)
+    end
+  end
+
+  test "the deferred usage limits prop resolves to an empty list when no credential bills against a plan" do
+    # Billed to the member's own AWS account, so there is no plan window to read
+    # — and no request to Anthropic to find that out.
+    create(:agent_credential, user: @user, company: @company, agent_type: "claude_code",
+                              config_data: { "awsBedrock" => { "region" => "us-east-1" } })
+
+    get profile_path
+    inertia_load_deferred_props("limits")
+
+    assert_inertia_props usageLimits: []
+  end
+
   test "update_default_model redirects on success" do
     credential = create(:agent_credential, user: @user)
 

--- a/test/services/agents/claude_code_adapter_test.rb
+++ b/test/services/agents/claude_code_adapter_test.rb
@@ -1289,6 +1289,84 @@ module Agents
       assert_includes config, "sso_region = eu-central-1"
     end
 
+    # == Subscription usage limits ==
+
+    test "fetch_subscription_usage returns the windows the endpoint reports, newest-scoped first" do
+      stub_request(:get, ClaudeCodeAdapter::USAGE_URL)
+        .with(headers: {
+          "Authorization" => "Bearer sub-token",
+          "anthropic-beta" => "oauth-2025-04-20",
+          "User-Agent" => ClaudeCodeAdapter::USAGE_USER_AGENT
+        })
+        .to_return(status: 200, body: {
+          five_hour: { utilization: 33.0, resets_at: "2026-08-16T18:00:00+00:00" },
+          seven_day: { utilization: 13.5, resets_at: "2026-08-20T00:59:59+00:00" },
+          seven_day_opus: nil,
+          seven_day_sonnet: { utilization: 2.0, resets_at: "2026-08-20T00:59:59+00:00" },
+          extra_usage: { is_enabled: false, monthly_limit: nil, used_credits: nil, utilization: nil }
+        }.to_json, headers: { "Content-Type" => "application/json" })
+
+      usage = @adapter.fetch_subscription_usage({ "claudeAiOauth" => { "accessToken" => "sub-token" } })
+
+      assert_equal "ok", usage[:status]
+      assert_equal %w[five_hour seven_day seven_day_sonnet], usage[:windows].map { |w| w[:key] }
+      assert_in_delta 33.0, usage[:windows].first[:utilization]
+      assert_equal "2026-08-16T18:00:00+00:00", usage[:windows].first[:resets_at]
+      assert_nil usage[:extra_usage] # is_enabled false → nothing to show
+    end
+
+    test "fetch_subscription_usage keeps a zero-utilization window and surfaces enabled extra usage" do
+      stub_request(:get, ClaudeCodeAdapter::USAGE_URL)
+        .to_return(status: 200, body: {
+          five_hour: { utilization: 0, resets_at: nil },
+          extra_usage: { is_enabled: true, monthly_limit: 100, used_credits: 12.5, utilization: 12.5 }
+        }.to_json, headers: { "Content-Type" => "application/json" })
+
+      usage = @adapter.fetch_subscription_usage({ "claudeAiOauth" => { "accessToken" => "sub-token" } })
+
+      assert_equal %w[five_hour], usage[:windows].map { |w| w[:key] }
+      assert_in_delta 0.0, usage[:windows].first[:utilization]
+      assert_nil usage[:windows].first[:resets_at]
+      assert_equal({ enabled: true, utilization: 12.5, monthly_limit: 100.0, used_credits: 12.5 }, usage[:extra_usage])
+    end
+
+    test "fetch_subscription_usage reports a dead token as unauthorized rather than raising" do
+      stub_request(:get, ClaudeCodeAdapter::USAGE_URL).to_return(status: 401, body: "{}")
+
+      usage = @adapter.fetch_subscription_usage({ "claudeAiOauth" => { "accessToken" => "sub-token" } })
+
+      assert_equal({ status: "unauthorized" }, usage)
+    end
+
+    test "fetch_subscription_usage reports throttling separately so the UI can say try again" do
+      stub_request(:get, ClaudeCodeAdapter::USAGE_URL).to_return(status: 429, body: "slow down")
+
+      usage = @adapter.fetch_subscription_usage({ "claudeAiOauth" => { "accessToken" => "sub-token" } })
+
+      assert_equal({ status: "rate_limited" }, usage)
+    end
+
+    test "fetch_subscription_usage degrades to unavailable on a server error or a network failure" do
+      stub_request(:get, ClaudeCodeAdapter::USAGE_URL).to_return(status: 500, body: "boom")
+      assert_equal({ status: "unavailable" },
+                   @adapter.fetch_subscription_usage({ "claudeAiOauth" => { "accessToken" => "sub-token" } }))
+
+      stub_request(:get, ClaudeCodeAdapter::USAGE_URL).to_timeout
+      assert_equal({ status: "unavailable" },
+                   @adapter.fetch_subscription_usage({ "claudeAiOauth" => { "accessToken" => "sub-token" } }))
+    end
+
+    test "fetch_subscription_usage returns nil for credentials that bill somewhere other than a plan" do
+      # An API key bills per token; a Bedrock connection bills to AWS. Neither has
+      # a 5-hour window, and neither should cost a request to find that out.
+      assert_nil @adapter.fetch_subscription_usage({ "primaryApiKey" => "sk-ant-x" })
+      assert_nil @adapter.fetch_subscription_usage({
+        "awsBedrock" => { "region" => "us-east-1" },
+        "claudeAiOauth" => { "accessToken" => "sub-token" }
+      })
+      assert_nil @adapter.fetch_subscription_usage({})
+    end
+
     private
 
     def connect_bedrock

--- a/test/services/agents/subscription_usage_service_test.rb
+++ b/test/services/agents/subscription_usage_service_test.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Agents
+  class SubscriptionUsageServiceTest < ActiveSupport::TestCase
+    # Stands in for a vendor adapter. The HTTP call itself is contract-tested in
+    # ClaudeCodeAdapterTest; what matters here is how often the service asks.
+    class CountingAdapter
+      attr_reader :calls
+
+      def initialize(result)
+        @result = result
+        @calls = 0
+      end
+
+      def fetch_subscription_usage(_credentials)
+        @calls += 1
+        @result
+      end
+    end
+
+    OK_USAGE = {
+      status: "ok",
+      windows: [ { key: "five_hour", utilization: 33.0, resets_at: "2026-08-16T18:00:00+00:00" } ],
+      extra_usage: nil
+    }.freeze
+
+    setup do
+      # The test env's cache is :null_store (writes are no-ops, reads return nil),
+      # which would make every render look like a cache miss — so stub a live
+      # MemoryStore, as the OAuth state test does.
+      Rails.stubs(:cache).returns(ActiveSupport::Cache::MemoryStore.new)
+
+      @company = create(:company)
+      @user = create(:user, :admin, company: @company)
+      @membership = CompanyMembership.find_by!(user: @user, company: @company)
+      @credential = create(:agent_credential, :claude_code, user: @user, company: @company)
+    end
+
+    # A fresh membership per call, as a real request gets one: the credential list
+    # is memoized on the instance, so reusing one would hide a stale cache key.
+    def build_service(adapter, force: false)
+      SubscriptionUsageService.new(
+        membership: CompanyMembership.find(@membership.id),
+        force: force,
+        adapter_resolver: ->(_type) { adapter }
+      )
+    end
+
+    test "returns nothing for a super admin, who has no membership and no credentials" do
+      assert_equal [], SubscriptionUsageService.new(membership: nil).call
+    end
+
+    test "returns one entry per credential that reports windows, tagged with its agent type" do
+      entries = build_service(CountingAdapter.new(OK_USAGE)).call
+
+      assert_equal 1, entries.size
+      assert_equal "claude_code", entries.first[:agent_type]
+      assert_equal "ok", entries.first[:status]
+      assert_equal [ "five_hour" ], entries.first[:windows].map { |w| w[:key] }
+      assert_kind_of Time, entries.first[:fetched_at]
+    end
+
+    test "drops a credential whose adapter reports no subscription windows" do
+      assert_equal [], build_service(CountingAdapter.new(nil)).call
+    end
+
+    test "serves repeat renders from the cache instead of re-asking the vendor" do
+      adapter = CountingAdapter.new(OK_USAGE)
+
+      3.times { build_service(adapter).call }
+
+      assert_equal 1, adapter.calls
+    end
+
+    test "a re-authenticated credential is re-read rather than served from the old cache" do
+      adapter = CountingAdapter.new(OK_USAGE)
+      build_service(adapter).call
+
+      travel_to 1.second.from_now do
+        @credential.touch # what a re-auth or a token refresh does
+        build_service(adapter).call
+      end
+
+      assert_equal 2, adapter.calls
+    end
+
+    test "a failure is cached only briefly so the panel recovers on its own" do
+      adapter = CountingAdapter.new({ status: "unavailable" })
+      build_service(adapter).call
+
+      travel_to (SubscriptionUsageService::ERROR_TTL + 1.second).from_now do
+        build_service(adapter).call
+      end
+
+      assert_equal 2, adapter.calls
+    end
+
+    test "the refresh button re-reads once the throttle window has passed" do
+      adapter = CountingAdapter.new(OK_USAGE)
+      build_service(adapter).call
+
+      travel_to (SubscriptionUsageService::MIN_REFRESH_INTERVAL + 1.second).from_now do
+        build_service(adapter, force: true).call
+      end
+
+      assert_equal 2, adapter.calls
+    end
+
+    test "the refresh button cannot be used to hammer the vendor endpoint" do
+      adapter = CountingAdapter.new(OK_USAGE)
+      build_service(adapter).call
+
+      5.times { build_service(adapter, force: true).call }
+
+      assert_equal 1, adapter.calls
+    end
+
+    test "one broken credential does not take the whole panel down" do
+      exploding = Class.new do
+        def fetch_subscription_usage(_credentials) = raise(ActiveSupport::MessageEncryptor::InvalidMessage)
+      end.new
+
+      assert_equal [], build_service(exploding).call
+    end
+  end
+end


### PR DESCRIPTION
## What

A member signed in with a claude.ai plan has no way to see how much of it is left until a session starts failing mid-run. This adds the numbers Claude Code's own `/usage` view shows, to the profile page:

- **Current session (5 hours)** and **Current week (all models)**
- **Current week (Opus)** / **(Sonnet)** — only when the account has used that model in the window
- **Extra usage this month** — only when pay-as-you-go is switched on

Each is a bar with its reset time ("resets in 2h 14m"), amber from 70%, red from 90%.

## Where the data comes from

`GET https://api.anthropic.com/api/oauth/usage`, the endpoint Claude Code itself calls (`fetchUtilization`), with `Authorization: Bearer <claudeAiOauth.accessToken>`, `anthropic-beta: oauth-2025-04-20`, and a User-Agent — a missing UA lands the request in an aggressively rate-limited bucket.

```json
{ "five_hour":        { "utilization": 33.0, "resets_at": "…" },
  "seven_day":        { "utilization": 13.0, "resets_at": "…" },
  "seven_day_opus":   null,
  "seven_day_sonnet": { "utilization": 2.0,  "resets_at": "…" },
  "extra_usage": { "is_enabled": false, "monthly_limit": null, "used_credits": null, "utilization": null } }
```

## Design notes

**Only subscription logins have windows.** An API key bills per token and a Bedrock connection bills to AWS, so `fetch_subscription_usage` returns `nil` for both and the card renders nothing rather than an empty frame. The check is `chosen_inference(credentials) == "claudeAiOauth"` — local, so those credentials never cost a request to rule out.

**The vendor endpoint is treated as fragile.** Three things guard it:

- the prop is `InertiaRails.defer(group: "limits")`, so the page never waits on Anthropic to render;
- answers are cached per credential for 3 minutes (the poll floor the endpoint tolerates), failures for 1 minute, with the credential's `updated_at` in the cache key so a re-auth or rotated token invalidates it for free;
- the Refresh button re-reads only if the cached answer is older than 30s — otherwise it is a 429 generator.

**Failures are a status, not an exception.** `unauthorized` / `rate_limited` / `unavailable` each render their own sentence. A usage panel is never worth breaking the profile page over.

**The adapter method is on `BaseAdapter`** (returning `nil`), so the service asks every credential on the membership generically and other runtimes can implement it later without touching the caller.

## Tests

| layer | what |
|---|---|
| adapter (WebMock contract) | window ordering, zero-utilization windows survive, model-scoped weeklies omitted when null, extra usage, 401 → `unauthorized`, 429 → `rate_limited`, 500/timeout → `unavailable`, API-key/Bedrock → `nil` with no request |
| service | caching, re-auth invalidation, error TTL, refresh throttle, one broken credential doesn't sink the panel |
| request | prop is declared deferred and absent from the initial render; resolves to `[]` when nothing bills against a plan |
| frontend | labels, per-model windows, extra usage, both failure states, refresh reloads only `usage_limits`, countdown formatting |

`make check_all`: rails-test, rubocop, brakeman, eslint, typescript, fe-test, vite-build all green. Coverage 91.77% backend / 81.16% frontend.

System tests fail locally on this machine for an unrelated reason — Chromium cannot start in the dev container, fixed separately in #115. They are green in CI and green locally with that fix applied.

## Not verified

The response shape is taken from the Claude Code binary and public reports of the endpoint, not from a 200 observed here — no valid subscription token was available in the dev database. Worth one sanity check on staging against a real login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
