### PR TITLE
fix(board): make the column auto-trigger fire whenever a task changes column

### DIFF
--- a/app/services/task_service.rb
+++ b/app/services/task_service.rb
@@ -23,16 +23,26 @@ class TaskService
       task
     end
 
+    # A column change is a MOVE, not an attribute write. It has to record a
+    # ColumnTransition, log task_moved, and fire the column's auto-trigger — and
+    # `board_column_id` is a permitted attribute on the task endpoint, so without
+    # routing it through #move an ordinary PATCH relocates the card while
+    # silently skipping all three. Everything else still saves in one write, so
+    # a request that renames a task AND moves it produces one task_updated for
+    # the rename and one task_moved for the move.
     def update(task:, params:, actor:)
-      task.assign_attributes(params)
-      changes = task.changes
+      attrs = (params.respond_to?(:to_unsafe_h) ? params.to_h : params).with_indifferent_access
+      to_column = extract_move_target(task, attrs)
 
-      if task.save
-        record_activity(task.board, :task_updated, actor, task: task,
-          metadata: { changes: changes.except("updated_at") })
-      end
+      task.assign_attributes(attrs)
+      changes = task.changes.except("updated_at")
 
-      task
+      return task unless task.save
+
+      record_activity(task.board, :task_updated, actor, task: task, metadata: { changes: changes }) if changes.any?
+      return task if to_column.nil?
+
+      move(task: task, to_column: to_column, actor: actor)
     end
 
     def archive(task:, actor:)
@@ -296,6 +306,21 @@ class TaskService
     end
 
     private
+
+    # Pulls `board_column_id` out of an update's attributes when it names a
+    # DIFFERENT column on this task's board — that is a move, and #update hands
+    # it to #move once the rest of the write has landed. Anything else (blank,
+    # the column the task is already in, or a column belonging to another board)
+    # is left in the attributes, so the model's own `column_belongs_to_board`
+    # validation still rejects a foreign column instead of it being dropped here.
+    def extract_move_target(task, attrs)
+      column_id = attrs[:board_column_id]
+      return nil if column_id.blank? || column_id.to_i == task.board_column_id
+
+      column = task.board.board_columns.find_by(id: column_id)
+      attrs.delete(:board_column_id) if column
+      column
+    end
 
     # Compare-and-set for a gate's one-way `pending` → terminal transition. Takes a
     # row lock, RE-READS the status inside it, and yields only while the gate is

--- a/app/services/task_service.rb
+++ b/app/services/task_service.rb
@@ -293,11 +293,26 @@ class TaskService
     # transaction back (atomic-or-nothing), not silently drop the trigger while
     # committing the domain write. The out-of-transaction check_auto_trigger
     # wrapper above is where best-effort error handling lives.
+    #
+    # The two remaining guards are deliberate and self-clearing, and nothing else
+    # may be added that isn't: an auto-trigger that stops firing and never
+    # resumes is indistinguishable from a broken board.
+    #   • trigger_mode — configuration. Manual means manual.
+    #   • a pending gate — the task is waiting on a precondition (CI, approval).
+    #     Gates carry a TTL and are reconciled, so this clears itself.
+    #
+    # A third guard used to latch on "the workflow's most recent run in this
+    # project failed with quota_exceeded", meant to stop a stampede of runs
+    # against an exhausted vendor account. It never expired: one quota failure
+    # disabled the column permanently, silently, until somebody happened to start
+    # a successful run by hand — and vendor quotas reset on their own, so the
+    # condition it latched on was gone within hours anyway. A run that hits a
+    # quota now fails with failure_reason: "quota_exceeded", which is visible on
+    # the run and does not poison the next move.
     def record_pending_auto_trigger(task:, column:, actor:)
       binding = column.column_workflow_binding
       return nil unless binding&.trigger_mode&.to_sym == :auto
       return nil if task.gates.pending.exists?
-      return nil if quota_block_auto_trigger?(binding, column)
 
       TriggerEngine.record_column_trigger(
         binding: binding, task: task,
@@ -438,14 +453,6 @@ class TaskService
           .where("position >= ? AND position < ?", new_pos, old_pos)
           .update_all("position = position + 1")
       end
-    end
-
-    def quota_block_auto_trigger?(binding, column)
-      last_run = binding.workflow.runs
-        .where(project: column.board.project)
-        .order(created_at: :desc)
-        .first
-      last_run&.failure_reason == "quota_exceeded"
     end
   end
 end

--- a/test/controllers/api/v1/projects/board/tasks_controller_test.rb
+++ b/test/controllers/api/v1/projects/board/tasks_controller_test.rb
@@ -209,6 +209,36 @@ module Api
           assert_response :success
         end
 
+        # The board card's column selector calls #move, so this guards the path the
+        # UI actually uses.
+        test "move into an auto-bound column starts that column's workflow" do
+          ColumnWorkflowBinding.create!(board_column: @col2, workflow: @workflow, trigger_mode: :auto, cooldown_seconds: 0)
+          WorkflowService.expects(:start).once.returns(create(:workflow_run, workflow: @workflow, project: @project, user: @user))
+
+          patch :move, params: { project_id: @project.id, id: @task.id, column_id: @col2.id }
+
+          assert_response :success
+          assert_equal @col2.id, @task.reload.board_column_id
+        end
+
+        # Regression: board_column_id is a permitted attribute here, so a plain
+        # PATCH used to relocate the card while skipping the transition record,
+        # the task_moved activity and the column's auto-trigger entirely.
+        test "update that changes the column moves the task, exactly as #move would" do
+          ColumnWorkflowBinding.create!(board_column: @col2, workflow: @workflow, trigger_mode: :auto, cooldown_seconds: 0)
+          WorkflowService.expects(:start).once.returns(create(:workflow_run, workflow: @workflow, project: @project, user: @user))
+
+          assert_difference -> { ColumnTransition.count }, 1 do
+            patch :update, params: {
+              project_id: @project.id, id: @task.id,
+              board_task: { board_column_id: @col2.id }
+            }
+          end
+
+          assert_response :success
+          assert_equal @col2.id, @task.reload.board_column_id
+        end
+
         # === viewer (read-only) enforcement ===
 
         class ViewerTest < ActionController::TestCase

--- a/test/services/task_service_test.rb
+++ b/test/services/task_service_test.rb
@@ -745,7 +745,11 @@ class TaskServiceTest < ActiveSupport::TestCase
     TaskService.check_auto_trigger(task: task, column: @column, actor: @user)
   end
 
-  test "check_auto_trigger does not start workflow when last run failed with quota_exceeded" do
+  # Regression: a quota failure used to latch the column off permanently — the
+  # next move, and every move after it, silently did nothing until somebody
+  # started a successful run by hand. Vendor quotas reset on their own, so the
+  # board has to keep firing and let the run report the quota if it is still hit.
+  test "check_auto_trigger still starts the workflow after a run failed on quota" do
     workflow = create(:workflow, scope: @project)
     ColumnWorkflowBinding.create!(board_column: @column, workflow: workflow, trigger_mode: :auto, cooldown_seconds: 0)
     run = create(:workflow_run, :failed, workflow: workflow, project: @project, user: @user)
@@ -753,7 +757,9 @@ class TaskServiceTest < ActiveSupport::TestCase
 
     task = create(:board_task, board: @board, board_column: @column, assignee: @user)
 
-    WorkflowService.expects(:start).never
+    WorkflowService.expects(:start).with(
+      has_entries(workflow: workflow, task: task, mode: :non_interactive)
+    ).once
 
     TaskService.check_auto_trigger(task: task, column: @column, actor: @user)
   end

--- a/test/services/task_service_test.rb
+++ b/test/services/task_service_test.rb
@@ -133,6 +133,65 @@ class TaskServiceTest < ActiveSupport::TestCase
     assert_not BoardActivity.exists?(board: @board, event_type: :task_updated, board_task: task)
   end
 
+  # A column change arriving as an attribute is still a move: the board's whole
+  # transition pipeline (history, activity, auto-trigger) hangs off #move, and
+  # board_column_id is a permitted attribute on the task endpoint.
+  test "update that changes the column records a transition and a task_moved activity" do
+    other = create(:board_column, board: @board, name: "Done")
+    task = create(:board_task, board: @board, board_column: @column)
+
+    assert_difference -> { ColumnTransition.count }, 1 do
+      TaskService.update(task: task, params: { board_column_id: other.id }, actor: @user)
+    end
+
+    assert_equal other.id, task.reload.board_column_id
+    assert BoardActivity.exists?(board: @board, event_type: :task_moved, board_task: task)
+  end
+
+  test "update that changes the column fires that column's auto-trigger" do
+    other = create(:board_column, board: @board, name: "Done")
+    workflow = create(:workflow, scope: @project)
+    ColumnWorkflowBinding.create!(board_column: other, workflow: workflow, trigger_mode: :auto)
+    task = create(:board_task, board: @board, board_column: @column)
+    WorkflowService.expects(:start).once.returns(create(:workflow_run, workflow: workflow, project: @project, user: @user))
+
+    TaskService.update(task: task, params: { board_column_id: other.id }, actor: @user)
+  end
+
+  test "update that renames and moves in one request logs the rename and the move separately" do
+    other = create(:board_column, board: @board, name: "Done")
+    task = create(:board_task, board: @board, board_column: @column, title: "Old")
+
+    TaskService.update(task: task, params: { title: "New", board_column_id: other.id }, actor: @user)
+
+    assert_equal "New", task.reload.title
+    assert_equal other.id, task.board_column_id
+    assert BoardActivity.exists?(board: @board, event_type: :task_updated, board_task: task)
+    assert BoardActivity.exists?(board: @board, event_type: :task_moved, board_task: task)
+  end
+
+  # Re-submitting the form the card is already in must not manufacture a
+  # transition — a move is a change of column, not a restatement of one.
+  test "update to the column the task is already in records no transition" do
+    task = create(:board_task, board: @board, board_column: @column)
+
+    assert_no_difference -> { ColumnTransition.count } do
+      TaskService.update(task: task, params: { board_column_id: @column.id }, actor: @user)
+    end
+  end
+
+  # The column is resolved on the task's own board, so a foreign id still has to
+  # fail validation rather than be quietly dropped on the way to #move.
+  test "update to a column on another board is rejected" do
+    foreign_column = create(:board_column, board: create(:board, project: create(:project, owner: @user, company: @company)))
+    task = create(:board_task, board: @board, board_column: @column)
+
+    result = TaskService.update(task: task, params: { board_column_id: foreign_column.id }, actor: @user)
+
+    assert result.errors[:board_column].present?
+    assert_equal @column.id, task.reload.board_column_id
+  end
+
   # == destroy ==
 
   test "destroy removes task and records activity" do


### PR DESCRIPTION
Two ways a board's column auto-trigger silently failed to fire. Both end with a card sitting in a workflow-bound column and nothing running.

---

## 1. A column change through `update` was not a move

`board_column_id` is a permitted attribute on `PATCH /api/v1/projects/:project_id/tasks/:id`, and `TaskService.update` assigned it like any other field:

```ruby
task.assign_attributes(params)
task.save
```

So a card could be relocated without any of the things a move is supposed to do:

- no `ColumnTransition` row → the task's transition history has a hole
- no `task_moved` activity → the board timeline never shows it
- **no auto-trigger** → nothing runs

Pinned by a failing test before the fix:

```
Api::V1::Projects::Board::TasksControllerTest#test_update_that_changes_the_column...
- expected at least once, invoked never: WorkflowService.start(any_parameters)
```

`TaskService.update` now pulls a real column change out of the attribute set and hands it to `TaskService.move` once the rest of the write lands.

- **Rename + move in one request** → one `task_updated` for the rename, one `task_moved` for the move. No empty `task_updated` when the column is the only change.
- **"Moving" to the column the task is already in** → not a move; records nothing.
- **A column id from another board** → left in the attributes on purpose, so the model's own `column_belongs_to_board` validation rejects it rather than it being silently dropped on the way to `#move`.

Note the board UI's own selector and drag-and-drop both already called `#move`; this closes the API path.

---

## 2. A single quota failure latched the column off forever

```ruby
return nil if quota_block_auto_trigger?(binding, column)

def quota_block_auto_trigger?(binding, column)
  last_run = binding.workflow.runs.where(project: column.board.project).order(created_at: :desc).first
  last_run&.failure_reason == "quota_exceeded"
end
```

Intent was to stop a stampede of runs against an exhausted vendor account. It never expired: once the workflow's most recent run in that project had failed on quota, **every** subsequent move did nothing — no run, no error, no activity — until somebody happened to start a successful run by hand. Vendor quotas reset on their own (5-hour and weekly windows), so the condition it latched on was typically gone within hours while the board stayed dead.

Removed. A run that hits a quota fails with `failure_reason: "quota_exceeded"`, which is already surfaced on the run page and no longer poisons the next move.

### What still guards the trigger, and why those are allowed

Both remaining guards clear themselves, and the invariant is now written down at the guard site so nothing that latches gets added back:

| guard | why it's safe |
|---|---|
| `trigger_mode != :auto` | Configuration. Manual means manual. |
| `task.gates.pending.exists?` | A real precondition (CI, approval). Gates carry a TTL (`Settings.gates.ttl_hours`, default 12h) and are reconciled every 5 minutes; a gate that goes **stale** is terminal and explicitly stops blocking the column. |

---

## Tests

| layer | cases |
|---|---|
| `TaskServiceTest` | transition + `task_moved` recorded on an update-move; auto-trigger fires; rename-and-move logs both separately; same-column update records nothing; foreign column rejected; **auto-trigger still fires after a run failed on quota** |
| `TasksControllerTest` | `#move` into an auto-bound column starts the workflow (guards the path the UI uses); `#update` that changes the column now does the same |

`make check_all` — all 8 green, backend coverage 91.68%, frontend 81.08%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
