### PR TITLE
feat(mcp): give the personal MCP its own profile tab

### DIFF
--- a/app/controllers/web/profile_controller.rb
+++ b/app/controllers/web/profile_controller.rb
@@ -25,13 +25,27 @@ class Web::ProfileController < Web::ApplicationController
       # throttles it so the button can't turn into a 429 generator.
       usage_limits: InertiaRails.defer(group: "limits") {
         Agents::SubscriptionUsageService.new(membership: current_membership, force: params[:refresh].present?).call
-      },
+      }
+    }
+  end
+
+  # The personal MCP server: its own tab rather than a card on the account
+  # page, because connecting a client and choosing what that client may do are
+  # a task of their own — and the tool picker alone is longer than the rest of
+  # the profile put together.
+  def mcp
+    render inertia: "Profile/Mcp", props: {
       mcp: {
         enabled: current_user.mcp_enabled?,
         last_used_at: current_user.mcp_token_last_used_at,
-        server_url: Settings.mcp.public_server_url,
+        server_url: Tools::PersonalMCP.public_url,
+        server_name: Tools::PersonalMCP::NAME,
         # Present only right after regeneration — shown once, never persisted.
-        token: session.delete(:mcp_token_plaintext)
+        token: session.delete(:mcp_token_plaintext),
+        tool_groups: Tools::PersonalMCP.catalog_groups,
+        # nil means "every tool, including ones added later" — the client
+        # renders that as everything checked, and sends nil back for it.
+        enabled_tools: current_user.mcp_enabled_tools
       }
     }
   end
@@ -40,12 +54,25 @@ class Web::ProfileController < Web::ApplicationController
   # moment a new digest lands.
   def regenerate_mcp_token
     session[:mcp_token_plaintext] = current_user.regenerate_mcp_token!
-    redirect_to profile_path, notice: "MCP token generated — copy it now, it won't be shown again"
+    redirect_to mcp_profile_path, notice: "MCP token generated — copy it now, it won't be shown again"
   end
 
   def disable_mcp_token
     current_user.disable_mcp_token!
-    redirect_to profile_path, notice: "MCP access disabled"
+    redirect_to mcp_profile_path, notice: "MCP access disabled"
+  end
+
+  # `tool_names` absent/null — or a list covering the whole registry — stores
+  # NULL, i.e. "every tool", so tools added in a later release are on without
+  # the user having to come back here. An empty array is a real, if odd,
+  # choice: a server with no tools. Names are intersected with the registry
+  # rather than validated, so a stale name from an old tab is dropped, not a
+  # 500.
+  def update_mcp_tools
+    names = params[:tool_names]
+    Tools::PersonalMCP.update_selection!(current_user, names.nil? ? nil : Array(names).map(&:to_s))
+
+    redirect_to mcp_profile_path, notice: "MCP tools updated"
   end
 
   def usage

--- a/app/frontend/pages/Docs/data/pages/mcp.md
+++ b/app/frontend/pages/Docs/data/pages/mcp.md
@@ -38,13 +38,19 @@ internal server (see resource resolution on the Tools page).
 ## Personal MCP (connect your own agent)
 
 You can point your own agent (Claude Code, Cursor, …) at Aixle directly —
-no session, no container. Enable **Personal MCP** on your profile to get a
-personal token; the profile page shows the exact command to add it, e.g.:
+no session, no container. Enable it on **Profile → MCP** to get a personal
+token. Clients register the server under the name `flow`, so its tools
+appear as `mcp__flow__list_projects` and so on:
 
 ```
-claude mcp add aixle --transport http https://<your-aixle-host>/mcp \
+claude mcp add flow --transport http https://<your-aixle-host>/mcp \
   --header "Authorization: Bearer amcp_…"
 ```
+
+The same tab has an **Add to Cursor** button (a one-click install
+deeplink) and a **Copy JSON** action for any other client's `mcp.json`.
+All three carry the token, so they are only offered while it is on screen
+— it is stored as a digest and shown exactly once.
 
 This server is **session-less** and grants **exactly your own access
 level** — every action runs through the same permission checks as the UI,
@@ -53,6 +59,13 @@ things you do in the app: list your companies and projects, manage board
 tasks, columns and gates, build and run workflows (steps, sub-steps,
 triggers, runs), manage agents, custom tools, skills, MCP servers, config
 items and repositories, and update project settings.
+
+The **Tools** card on the same tab picks which of those the server offers.
+Unchecking what you never use keeps its schemas out of the agent's
+context, and the `tool_catalog` prompt then describes exactly the
+remaining set. Leaving everything checked means "all tools", so ones added
+in a later release arrive switched on. This is not a permission boundary —
+the token always runs as you.
 
 The server also documents itself, so a client does not have to guess. Its
 `instructions` — in your agent's context from the moment it connects —

--- a/app/frontend/pages/Profile/Mcp.test.tsx
+++ b/app/frontend/pages/Profile/Mcp.test.tsx
@@ -1,0 +1,166 @@
+import '@testing-library/jest-dom/vitest';
+import { router } from '@inertiajs/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderAuthedPage, screen, userEvent } from 'test/renderPage';
+
+import ProfileMcpPage from './Mcp';
+
+const boardTools = [
+  { name: 'list_board_tasks', description: 'Tasks on a board.', readOnly: true },
+  { name: 'move_board_task', description: 'Move a card.', readOnly: false },
+];
+
+const accountTools = [{ name: 'list_projects', description: 'Projects you can access.', readOnly: true }];
+
+const toolGroups = [
+  { tag: 'account', title: 'Account & projects', blurb: 'Where every flow starts.', tools: accountTools },
+  { tag: 'board', title: 'Board', blurb: null, tools: boardTools },
+];
+
+const buildMcp = (overrides = {}) => ({
+  enabled: false,
+  lastUsedAt: null,
+  serverUrl: 'https://flow.example.com/mcp',
+  serverName: 'flow',
+  token: null,
+  toolGroups,
+  enabledTools: null,
+  ...overrides,
+});
+
+const renderPageWith = (mcp = buildMcp()) => renderAuthedPage(<ProfileMcpPage mcp={mcp} />, { props: { mcp } });
+
+// The picker starts collapsed — the full registry is ~85 rows — so a tool's
+// checkbox only exists once its group is open.
+const openGroup = (title: string) => userEvent.click(screen.getByRole('button', { name: new RegExp(title) }));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Profile MCP tab', () => {
+  it('enables MCP by posting to the regenerate-token route when MCP is disabled', async () => {
+    renderPageWith();
+
+    expect(screen.queryByRole('button', { name: 'Disable' })).not.toBeInTheDocument();
+    expect(screen.queryByText(/MCP access is enabled/)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Enable MCP' }));
+
+    expect(router.post).toHaveBeenCalledWith(
+      '/profile/regenerate_mcp_token',
+      {},
+      expect.objectContaining({ preserveScroll: true }),
+    );
+  });
+
+  it('regenerates and disables the token via the router when MCP is enabled', async () => {
+    renderPageWith(buildMcp({ enabled: true, lastUsedAt: '2026-03-01T12:00:00Z' }));
+
+    expect(screen.getByText(/MCP access is enabled/)).toHaveTextContent(/Last used/);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Regenerate token' }));
+    expect(router.post).toHaveBeenCalledWith(
+      '/profile/regenerate_mcp_token',
+      {},
+      expect.objectContaining({ preserveScroll: true }),
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Disable' }));
+    expect(router.delete).toHaveBeenCalledWith(
+      '/profile/disable_mcp_token',
+      expect.objectContaining({ preserveScroll: true }),
+    );
+  });
+
+  it('shows the not-used-yet hint when MCP is enabled but has never been used', () => {
+    renderPageWith(buildMcp({ enabled: true }));
+
+    expect(screen.getByText(/MCP access is enabled/)).toHaveTextContent(/Not used yet/);
+  });
+
+  it('renders the one-time token with a Claude command carrying the server name and URL', () => {
+    renderPageWith(buildMcp({ enabled: true, token: 'amcp_tok_abc123' }));
+
+    expect(screen.getByText('Your token — copy it now, it will not be shown again:')).toBeInTheDocument();
+    expect(screen.getByText('amcp_tok_abc123')).toBeInTheDocument();
+
+    const command = screen.getByText(/claude mcp add flow --transport http/);
+    expect(command).toHaveTextContent('https://flow.example.com/mcp');
+    expect(command).toHaveTextContent('Authorization: Bearer amcp_tok_abc123');
+  });
+
+  // Cursor installs from a deeplink whose `config` is the base64 of the server
+  // entry alone — decoded here so a wrong shape fails loudly rather than
+  // silently producing a link Cursor rejects.
+  it('offers a Cursor install deeplink carrying the URL and bearer token', () => {
+    renderPageWith(buildMcp({ enabled: true, token: 'amcp_tok_abc123' }));
+
+    const link = screen.getByRole('link', { name: 'Add to Cursor' });
+    const href = link.getAttribute('href') ?? '';
+    expect(href).toContain('cursor://anysphere.cursor-deeplink/mcp/install?name=flow');
+
+    const config = new URL(href).searchParams.get('config') ?? '';
+    expect(JSON.parse(atob(config))).toEqual({
+      url: 'https://flow.example.com/mcp',
+      headers: { Authorization: 'Bearer amcp_tok_abc123' },
+    });
+  });
+
+  it('hides the connection snippets until a token has been generated', () => {
+    renderPageWith(buildMcp({ enabled: true }));
+
+    expect(screen.queryByRole('link', { name: 'Add to Cursor' })).not.toBeInTheDocument();
+    expect(screen.queryByText(/claude mcp add/)).not.toBeInTheDocument();
+  });
+
+  it('treats a null selection as every tool enabled', () => {
+    renderPageWith();
+
+    expect(screen.getByText('3 / 3')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save tools' })).toBeDisabled();
+  });
+
+  it('saves a narrowed selection, sending only the checked tool names', async () => {
+    renderPageWith();
+
+    await openGroup('Board');
+    // A tool that changes something is marked in its description, so the row
+    // says what enabling it lets the agent do.
+    expect(screen.getByText(/Move a card\. · writes/)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'move_board_task' }));
+
+    expect(screen.getByText('2 / 3')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save tools' }));
+
+    expect(router.patch).toHaveBeenCalledWith(
+      '/profile/update_mcp_tools',
+      { toolNames: ['list_projects', 'list_board_tasks'] },
+      expect.objectContaining({ preserveScroll: true }),
+    );
+  });
+
+  it('renders a stored selection with only those tools checked', async () => {
+    renderPageWith(buildMcp({ enabledTools: ['list_projects'] }));
+
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+
+    await openGroup('Board');
+    expect(screen.getByRole('checkbox', { name: 'list_board_tasks' })).not.toBeChecked();
+  });
+
+  it('clears and re-selects every tool from the header actions', async () => {
+    renderPageWith();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Clear' }));
+    expect(screen.getByText('0 / 3')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Select all' }));
+    expect(screen.getByText('3 / 3')).toBeInTheDocument();
+    // Back to the stored state, so there is nothing to save.
+    expect(screen.getByRole('button', { name: 'Save tools' })).toBeDisabled();
+  });
+});

--- a/app/frontend/pages/Profile/Mcp.tsx
+++ b/app/frontend/pages/Profile/Mcp.tsx
@@ -1,0 +1,369 @@
+import { Head, router } from '@inertiajs/react';
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  Checkbox,
+  Code,
+  CopyButton,
+  Divider,
+  Group,
+  Stack,
+  Text,
+  Title,
+  UnstyledButton,
+} from '@mantine/core';
+import { IconCheck, IconChevronRight, IconCopy, IconExternalLink } from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
+
+import { AuthLayout } from 'layouts/AuthLayout';
+
+import { disableMCPTokenProfilePath, regenerateMCPTokenProfilePath, updateMCPToolsProfilePath } from 'shared/routes';
+import { StatusBadge } from 'shared/ui/StatusBadge';
+
+import { ProfileTabs } from './ProfileTabs';
+
+interface McpTool {
+  name: string;
+  description: string;
+  readOnly: boolean;
+}
+
+interface McpToolGroup {
+  tag: string;
+  title: string;
+  blurb: string | null;
+  tools: McpTool[];
+}
+
+interface McpProps {
+  enabled: boolean;
+  lastUsedAt: string | null;
+  serverUrl: string;
+  serverName: string;
+  token: string | null;
+  toolGroups: McpToolGroup[];
+  // null means "every tool, including ones added later" — see
+  // Tools::PersonalMCP.update_selection!.
+  enabledTools: string[] | null;
+}
+
+interface Props {
+  mcp: McpProps;
+}
+
+const sorted = (names: Iterable<string>) => [...names].sort();
+const sameSelection = (a: string[], b: string[]) => a.length === b.length && a.every((n, i) => n === b[i]);
+
+// Cursor installs a server from a deeplink whose `config` is the base64 of the
+// server entry alone (no name wrapper) — the same object that would sit under
+// the server's key in mcp.json.
+const clientConfig = (serverUrl: string, token: string) => ({
+  url: serverUrl,
+  headers: { Authorization: `Bearer ${token}` },
+});
+
+const cursorInstallLink = (serverName: string, serverUrl: string, token: string) => {
+  const config = btoa(JSON.stringify(clientConfig(serverUrl, token)));
+  return `cursor://anysphere.cursor-deeplink/mcp/install?name=${encodeURIComponent(serverName)}&config=${encodeURIComponent(config)}`;
+};
+
+function CopyAction({ value, label }: { value: string; label: string }) {
+  return (
+    <CopyButton value={value}>
+      {({ copied, copy }) => (
+        <Button
+          variant="subtle"
+          size="compact-xs"
+          onClick={copy}
+          leftSection={copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+        >
+          {copied ? 'Copied' : label}
+        </Button>
+      )}
+    </CopyButton>
+  );
+}
+
+// The token exists in the UI exactly once, right after it is generated: the
+// server keeps only a digest. Everything a client needs is therefore built and
+// offered here — after a reload the only way back is a new token.
+function ConnectionSection({ mcp }: { mcp: McpProps }) {
+  const claudeCommand = mcp.token
+    ? `claude mcp add ${mcp.serverName} --transport http ${mcp.serverUrl} --header "Authorization: Bearer ${mcp.token}"`
+    : null;
+  const jsonConfig = mcp.token
+    ? JSON.stringify({ mcpServers: { [mcp.serverName]: clientConfig(mcp.serverUrl, mcp.token) } }, null, 2)
+    : null;
+
+  return (
+    <Card p={24}>
+      <Title order={4} mb={4}>
+        Personal MCP
+      </Title>
+      <Text fz={14} c="dimmed" mb="md">
+        Connect your AI agent (Claude Code, Cursor, ...) to Aixle Flow: list your projects, manage board tasks and build
+        workflows — with exactly your access level.
+      </Text>
+
+      <Group gap={8} mb="md">
+        <StatusBadge tone={mcp.enabled ? 'success' : 'neutral'}>{mcp.enabled ? 'Enabled' : 'Disabled'}</StatusBadge>
+        {mcp.enabled && <StatusBadge tone="neutral">{mcp.lastUsedAt ? 'In use' : 'Not used yet'}</StatusBadge>}
+      </Group>
+
+      {mcp.token && (
+        <Box mb="md">
+          <Group justify="space-between" align="center" wrap="nowrap" gap="sm">
+            <Text fz={14} fw={600} c="var(--app-text-primary)">
+              Your token — copy it now, it will not be shown again:
+            </Text>
+            {/* This is the only moment the token exists in the UI, so it needs a
+                copy affordance, not a select-the-text-yourself code block. */}
+            <CopyButton value={mcp.token}>
+              {({ copied, copy }) => (
+                <Button
+                  variant={copied ? 'light' : 'filled'}
+                  size="compact-sm"
+                  onClick={copy}
+                  leftSection={copied ? <IconCheck size={14} /> : <IconCopy size={14} />}
+                >
+                  {copied ? 'Copied' : 'Copy token'}
+                </Button>
+              )}
+            </CopyButton>
+          </Group>
+          <Code block my={8} data-testid="mcp-token">
+            {mcp.token}
+          </Code>
+
+          <Group justify="space-between" align="center" wrap="nowrap" gap="sm" mt="md">
+            <Text fz={13} c="dimmed">
+              Add to Cursor:
+            </Text>
+            {/* The deeplink carries the token, so it only works while this page
+                still holds one — hence the button lives beside the token, not
+                on the always-visible part of the page. */}
+            <Group gap={4} wrap="nowrap">
+              <Button
+                component="a"
+                href={cursorInstallLink(mcp.serverName, mcp.serverUrl, mcp.token)}
+                variant="light"
+                size="compact-sm"
+                leftSection={<IconExternalLink size={14} />}
+              >
+                Add to Cursor
+              </Button>
+              <CopyAction value={jsonConfig ?? ''} label="Copy JSON" />
+            </Group>
+          </Group>
+
+          <Group justify="space-between" align="center" wrap="nowrap" gap="sm" mt="md">
+            <Text fz={13} c="dimmed" mb={4}>
+              Add to Claude Code:
+            </Text>
+            <CopyAction value={claudeCommand ?? ''} label="Copy command" />
+          </Group>
+          <Code block data-testid="mcp-claude-command">
+            {claudeCommand}
+          </Code>
+        </Box>
+      )}
+
+      {mcp.enabled && !mcp.token && (
+        <Text fz={13} c="dimmed" mb="md">
+          MCP access is enabled.
+          {mcp.lastUsedAt ? ` Last used ${new Date(mcp.lastUsedAt).toLocaleString()}.` : ' Not used yet.'}
+        </Text>
+      )}
+
+      <Group gap="sm">
+        <Button
+          variant={mcp.enabled ? 'default' : 'filled'}
+          onClick={() => router.post(regenerateMCPTokenProfilePath(), {}, { preserveScroll: true })}
+        >
+          {mcp.enabled ? 'Regenerate token' : 'Enable MCP'}
+        </Button>
+        {mcp.enabled && (
+          <Button
+            variant="subtle"
+            color="red"
+            onClick={() => router.delete(disableMCPTokenProfilePath(), { preserveScroll: true })}
+          >
+            Disable
+          </Button>
+        )}
+      </Group>
+    </Card>
+  );
+}
+
+function ToolsSection({ mcp }: { mcp: McpProps }) {
+  const allNames = useMemo(() => mcp.toolGroups.flatMap((g) => g.tools.map((t) => t.name)), [mcp.toolGroups]);
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(mcp.enabledTools ?? allNames));
+  const [baseline, setBaseline] = useState<string[]>(() => sorted(mcp.enabledTools ?? allNames));
+  const [saving, setSaving] = useState(false);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const dirty = !sameSelection(sorted(selected), baseline);
+
+  const toggleGroup = (tag: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (!next.delete(tag)) next.add(tag);
+      return next;
+    });
+
+  const setNames = (names: string[], on: boolean) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      names.forEach((n) => (on ? next.add(n) : next.delete(n)));
+      return next;
+    });
+
+  const save = () => {
+    setSaving(true);
+    // Sending every name is how "all" is expressed: the server stores that as
+    // NULL, which keeps tools added in a later release switched on.
+    router.patch(
+      updateMCPToolsProfilePath(),
+      { toolNames: [...selected] },
+      {
+        preserveScroll: true,
+        onSuccess: () => setBaseline(sorted(selected)),
+        onFinish: () => setSaving(false),
+      },
+    );
+  };
+
+  return (
+    <Card p={24} mt={16}>
+      <Group justify="space-between" align="flex-start" wrap="nowrap" gap="sm">
+        <Box>
+          <Title order={4} mb={4}>
+            Tools
+          </Title>
+          <Text fz={14} c="dimmed">
+            Which tools this server offers your agent. Switching the ones you never use off keeps them out of the
+            agent&apos;s context — it is not a permission boundary: the token always runs as you, with your access
+            level.
+          </Text>
+        </Box>
+        <Badge variant="light" size="lg" style={{ flexShrink: 0 }}>
+          {selected.size} / {allNames.length}
+        </Badge>
+      </Group>
+
+      <Group gap="xs" mt="md">
+        <Button variant="default" size="compact-xs" onClick={() => setNames(allNames, true)}>
+          Select all
+        </Button>
+        <Button variant="default" size="compact-xs" onClick={() => setNames(allNames, false)}>
+          Clear
+        </Button>
+      </Group>
+
+      <Divider my="md" />
+
+      {/* Groups start collapsed and their rows are only mounted while open —
+          the real registry is ~85 tools, and rendering every checkbox at once
+          turns this card into most of the page. */}
+      <Stack gap="xs">
+        {mcp.toolGroups.map((group) => {
+          const names = group.tools.map((t) => t.name);
+          const on = names.filter((n) => selected.has(n)).length;
+          const isOpen = expanded.has(group.tag);
+
+          return (
+            <Card key={group.tag} withBorder p={0}>
+              <UnstyledButton onClick={() => toggleGroup(group.tag)} aria-expanded={isOpen} w="100%" px="md" py="sm">
+                <Group justify="space-between" wrap="nowrap" gap="sm">
+                  <Group gap={8} wrap="nowrap">
+                    <IconChevronRight
+                      size={14}
+                      style={{ transform: isOpen ? 'rotate(90deg)' : undefined, flexShrink: 0 }}
+                    />
+                    <Text fw={600} fz={14}>
+                      {group.title}
+                    </Text>
+                  </Group>
+                  <Text fz={12} c="dimmed">
+                    {on} / {names.length}
+                  </Text>
+                </Group>
+              </UnstyledButton>
+
+              {isOpen && (
+                <Box px="md" pb="md">
+                  {group.blurb && (
+                    <Text fz={12} c="dimmed" mb="sm">
+                      {group.blurb}
+                    </Text>
+                  )}
+                  <Group gap="xs" mb="sm">
+                    <Button variant="subtle" size="compact-xs" onClick={() => setNames(names, true)}>
+                      All
+                    </Button>
+                    <Button variant="subtle" size="compact-xs" onClick={() => setNames(names, false)}>
+                      None
+                    </Button>
+                  </Group>
+                  <Stack gap="xs">
+                    {group.tools.map((tool) => (
+                      <Checkbox
+                        key={tool.name}
+                        label={tool.name}
+                        // Appended to the description rather than badged next to
+                        // the label: the label is the checkbox's accessible name,
+                        // and it should stay exactly the tool the agent calls.
+                        description={tool.readOnly ? tool.description : `${tool.description} · writes`}
+                        checked={selected.has(tool.name)}
+                        onChange={(e) => setNames([tool.name], e.currentTarget.checked)}
+                      />
+                    ))}
+                  </Stack>
+                </Box>
+              )}
+            </Card>
+          );
+        })}
+      </Stack>
+
+      <Group mt="md" gap="sm">
+        <Button onClick={save} disabled={!dirty || saving} loading={saving}>
+          Save tools
+        </Button>
+        {dirty && (
+          <Text fz={12} c="dimmed">
+            Unsaved changes. A connected client picks them up on its next connection.
+          </Text>
+        )}
+      </Group>
+    </Card>
+  );
+}
+
+function ProfileMcpPage({ mcp }: Props) {
+  return (
+    <AuthLayout>
+      <Head title="Personal MCP" />
+      <Box maw={1120} mx="auto">
+        <Title order={1} fz={28} fw={600} c="var(--app-text-primary)" mb={4}>
+          My Profile
+        </Title>
+        {/* Unlike the account tab, none of this is per company: the token is the
+            user, and it reaches every company they belong to. */}
+        <Text size="sm" c="dimmed" mb={24}>
+          Your personal MCP token works across every company you belong to.
+        </Text>
+
+        <ProfileTabs active="mcp" />
+
+        <ConnectionSection mcp={mcp} />
+        <ToolsSection mcp={mcp} />
+      </Box>
+    </AuthLayout>
+  );
+}
+
+export default ProfileMcpPage;

--- a/app/frontend/pages/Profile/ProfileTabs.tsx
+++ b/app/frontend/pages/Profile/ProfileTabs.tsx
@@ -1,0 +1,33 @@
+import { router } from '@inertiajs/react';
+import { Tabs } from '@mantine/core';
+
+import { mcpProfilePath, profilePath, usageProfilePath } from 'shared/routes';
+
+export type ProfileTab = 'account' | 'usage' | 'mcp';
+
+const TAB_PATHS: Record<ProfileTab, () => string> = {
+  account: profilePath,
+  usage: usageProfilePath,
+  mcp: mcpProfilePath,
+};
+
+// One tab bar for the three profile pages. Each tab is a full page visit — they
+// are separate Inertia pages, not panels — so the bar has to be rendered by
+// every one of them or the user lands somewhere with no way back.
+export function ProfileTabs({ active }: { active: ProfileTab }) {
+  return (
+    <Tabs
+      value={active}
+      onChange={(value) => {
+        if (value && value !== active) router.visit(TAB_PATHS[value as ProfileTab]());
+      }}
+      mb="lg"
+    >
+      <Tabs.List>
+        <Tabs.Tab value="account">Account</Tabs.Tab>
+        <Tabs.Tab value="usage">Usage</Tabs.Tab>
+        <Tabs.Tab value="mcp">MCP</Tabs.Tab>
+      </Tabs.List>
+    </Tabs>
+  );
+}

--- a/app/frontend/pages/Profile/Show.test.tsx
+++ b/app/frontend/pages/Profile/Show.test.tsx
@@ -57,7 +57,6 @@ const buildCredential = (overrides: Partial<AgentCredential> = {}): AgentCredent
 const baseProps = (profile: SharedUser) => ({
   profile,
   languageOptions: ['en', 'es'],
-  mcp: { enabled: false, lastUsedAt: null, serverUrl: 'http://localhost:4000/mcp', token: null },
   agentModels: [],
 });
 
@@ -407,82 +406,6 @@ describe('Profile/Show', () => {
 
     expect(screen.getByText('Name must be less than 100 characters')).toBeInTheDocument();
     expect(form.patch).not.toHaveBeenCalled();
-  });
-
-  it('enables MCP by posting to the regenerate-token route when MCP is disabled', async () => {
-    const profile = buildProfile();
-    const props = {
-      ...baseProps(profile),
-      mcp: { enabled: false, lastUsedAt: null, serverUrl: 'http://localhost:4000/mcp', token: null },
-    };
-    renderAuthedPage(<ProfilePage {...props} />, { props });
-
-    // Disabled state: primary CTA reads "Enable MCP" and there is no Disable action yet.
-    expect(screen.queryByRole('button', { name: 'Disable' })).not.toBeInTheDocument();
-    expect(screen.queryByText(/MCP access is enabled/)).not.toBeInTheDocument();
-
-    await userEvent.click(screen.getByRole('button', { name: 'Enable MCP' }));
-
-    expect(router.post).toHaveBeenCalledWith(
-      '/profile/regenerate_mcp_token',
-      {},
-      expect.objectContaining({ preserveScroll: true }),
-    );
-  });
-
-  it('regenerates and disables the MCP token via the router when MCP is enabled', async () => {
-    const profile = buildProfile();
-    const props = {
-      ...baseProps(profile),
-      mcp: { enabled: true, lastUsedAt: '2026-03-01T12:00:00Z', serverUrl: 'http://localhost:4000/mcp', token: null },
-    };
-    renderAuthedPage(<ProfilePage {...props} />, { props });
-
-    // Enabled-without-token hint includes the last-used timestamp.
-    expect(screen.getByText(/MCP access is enabled/)).toHaveTextContent(/Last used/);
-
-    await userEvent.click(screen.getByRole('button', { name: 'Regenerate token' }));
-    expect(router.post).toHaveBeenCalledWith(
-      '/profile/regenerate_mcp_token',
-      {},
-      expect.objectContaining({ preserveScroll: true }),
-    );
-
-    await userEvent.click(screen.getByRole('button', { name: 'Disable' }));
-    expect(router.delete).toHaveBeenCalledWith(
-      '/profile/disable_mcp_token',
-      expect.objectContaining({ preserveScroll: true }),
-    );
-  });
-
-  it('shows the not-used-yet hint when MCP is enabled but has never been used', () => {
-    const profile = buildProfile();
-    const props = {
-      ...baseProps(profile),
-      mcp: { enabled: true, lastUsedAt: null, serverUrl: 'http://localhost:4000/mcp', token: null },
-    };
-    renderAuthedPage(<ProfilePage {...props} />, { props });
-
-    expect(screen.getByText(/MCP access is enabled/)).toHaveTextContent(/Not used yet/);
-  });
-
-  it('renders the one-time MCP token and the ready-to-paste Claude command when a token is present', () => {
-    const profile = buildProfile();
-    const props = {
-      ...baseProps(profile),
-      mcp: { enabled: true, lastUsedAt: null, serverUrl: 'http://localhost:4000/mcp', token: 'mcp_tok_abc123' },
-    };
-    renderAuthedPage(<ProfilePage {...props} />, { props });
-
-    expect(screen.getByText('Your token — copy it now, it will not be shown again:')).toBeInTheDocument();
-    // The token renders on its own in a Code block…
-    expect(screen.getByText('mcp_tok_abc123')).toBeInTheDocument();
-    // …and is embedded in the copyable `claude mcp add` command with the server URL.
-    const command = screen.getByText(/claude mcp add aixle --transport http/);
-    expect(command).toHaveTextContent('http://localhost:4000/mcp');
-    expect(command).toHaveTextContent('Authorization: Bearer mcp_tok_abc123');
-    // With MCP already enabled the primary button rotates the token rather than enabling.
-    expect(screen.getByRole('button', { name: 'Regenerate token' })).toBeInTheDocument();
   });
 
   it('patches the default agent runtime when a different credential is selected', async () => {

--- a/app/frontend/pages/Profile/Show.tsx
+++ b/app/frontend/pages/Profile/Show.tsx
@@ -1,12 +1,10 @@
 import { Deferred, Head, router, useForm } from '@inertiajs/react';
 import {
-  CopyButton,
   Alert,
   Badge,
   Box,
   Button,
   Card,
-  Code,
   Center,
   Divider,
   Group,
@@ -16,7 +14,6 @@ import {
   Skeleton,
   Stack,
   Switch,
-  Tabs,
   Text,
   TextInput,
   ThemeIcon,
@@ -27,7 +24,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { modals } from '@mantine/modals';
 import { notifications } from '@mantine/notifications';
 import { type Subscription } from '@rails/actioncable';
-import { IconCheck, IconCopy, IconDoorExit, IconLock, IconTrash } from '@tabler/icons-react';
+import { IconCheck, IconDoorExit, IconLock, IconTrash } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { z } from 'zod';
 
@@ -42,16 +39,14 @@ import {
   apiV1TerminalSessionPath,
   apiV1TerminalSessionsPath,
   companyMembershipPath,
-  disableMCPTokenProfilePath,
   finishApiV1TerminalSessionPath,
   healthApiV1CloudAwsConnectionPath,
-  regenerateMCPTokenProfilePath,
-  usageProfilePath,
 } from 'shared/routes';
 import { AGENT_BRAND_COLORS, TERMINAL_BG } from 'shared/theme/vendorColors';
 import { type AgentCredential, type AgentType, type SharedMembership, type SharedUser, type UserRole } from 'shared/ui';
 import { StatusBadge, type StatusTone } from 'shared/ui/StatusBadge';
 
+import { ProfileTabs } from './ProfileTabs';
 import classes from './Show.module.css';
 import { UsageLimitsCard, type UsageLimitsEntry } from './UsageLimitsCard';
 
@@ -161,13 +156,6 @@ interface AgentModelsEntry {
   models: AgentModel[];
 }
 
-interface McpProps {
-  enabled: boolean;
-  lastUsedAt: string | null;
-  serverUrl: string;
-  token: string | null;
-}
-
 interface Props {
   profile: SharedUser;
   // Memberships still in the `invited` state — profile.memberships is active-only.
@@ -176,7 +164,6 @@ interface Props {
   languageOptions: string[];
   agentModels: AgentModelsEntry[];
   cableStream?: string;
-  mcp: McpProps;
   // Deferred (group "limits"): absent until Inertia's follow-up request lands.
   usageLimits?: UsageLimitsEntry[];
 }
@@ -1041,102 +1028,7 @@ function AgentRuntimesSection({ profile }: { profile: SharedUser }) {
   );
 }
 
-function PersonalMcpSection({ mcp }: { mcp: McpProps }) {
-  const claudeCommand = mcp.token
-    ? `claude mcp add aixle --transport http ${mcp.serverUrl} --header "Authorization: Bearer ${mcp.token}"`
-    : null;
-
-  return (
-    <Card p={24}>
-      <Title order={4} mb={4}>
-        Personal MCP
-      </Title>
-      <Text fz={14} c="dimmed" mb="md">
-        Connect your AI agent (Claude Code, Cursor, ...) to Aixle: list your projects, manage board tasks and build
-        workflows — with exactly your access level.
-      </Text>
-
-      <Group gap={8} mb="md">
-        <StatusBadge tone={mcp.enabled ? 'success' : 'neutral'}>{mcp.enabled ? 'Enabled' : 'Disabled'}</StatusBadge>
-        {mcp.enabled && <StatusBadge tone="neutral">{mcp.lastUsedAt ? 'In use' : 'Not used yet'}</StatusBadge>}
-      </Group>
-
-      {mcp.token && (
-        <Box mb="md">
-          <Group justify="space-between" align="center" wrap="nowrap" gap="sm">
-            <Text fz={14} fw={600} c="var(--app-text-primary)">
-              Your token — copy it now, it will not be shown again:
-            </Text>
-            {/* This is the only moment the token exists in the UI, so it needs a
-                copy affordance, not a select-the-text-yourself code block. */}
-            <CopyButton value={mcp.token}>
-              {({ copied, copy }) => (
-                <Button
-                  variant={copied ? 'light' : 'filled'}
-                  size="compact-sm"
-                  onClick={copy}
-                  leftSection={copied ? <IconCheck size={14} /> : <IconCopy size={14} />}
-                >
-                  {copied ? 'Copied' : 'Copy token'}
-                </Button>
-              )}
-            </CopyButton>
-          </Group>
-          <Code block my={8} data-testid="mcp-token">
-            {mcp.token}
-          </Code>
-          <Group justify="space-between" align="center" wrap="nowrap" gap="sm">
-            <Text fz={13} c="dimmed" mb={4}>
-              Add to Claude Code:
-            </Text>
-            <CopyButton value={claudeCommand ?? ''}>
-              {({ copied, copy }) => (
-                <Button
-                  variant="subtle"
-                  size="compact-xs"
-                  onClick={copy}
-                  leftSection={copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
-                >
-                  {copied ? 'Copied' : 'Copy command'}
-                </Button>
-              )}
-            </CopyButton>
-          </Group>
-          <Code block data-testid="mcp-claude-command">
-            {claudeCommand}
-          </Code>
-        </Box>
-      )}
-
-      {mcp.enabled && !mcp.token && (
-        <Text fz={13} c="dimmed" mb="md">
-          MCP access is enabled.
-          {mcp.lastUsedAt ? ` Last used ${new Date(mcp.lastUsedAt).toLocaleString()}.` : ' Not used yet.'}
-        </Text>
-      )}
-
-      <Group gap="sm">
-        <Button
-          variant={mcp.enabled ? 'default' : 'filled'}
-          onClick={() => router.post(regenerateMCPTokenProfilePath(), {}, { preserveScroll: true })}
-        >
-          {mcp.enabled ? 'Regenerate token' : 'Enable MCP'}
-        </Button>
-        {mcp.enabled && (
-          <Button
-            variant="subtle"
-            color="red"
-            onClick={() => router.delete(disableMCPTokenProfilePath(), { preserveScroll: true })}
-          >
-            Disable
-          </Button>
-        )}
-      </Group>
-    </Card>
-  );
-}
-
-function ProfilePage({ profile, pendingInvitations, agentModels, cableStream, mcp, usageLimits }: Props) {
+function ProfilePage({ profile, pendingInvitations, agentModels, cableStream, usageLimits }: Props) {
   const currentCompanyName = profile.currentCompany?.name ?? null;
   useInertiaCableStream(cableStream, { only: ['profile', 'agent_models'] });
 
@@ -1197,21 +1089,10 @@ function ProfilePage({ profile, pendingInvitations, agentModels, cableStream, mc
           </Text>
         )}
 
-        <Tabs
-          value="account"
-          onChange={(v) => {
-            if (v === 'usage') router.visit(usageProfilePath());
-          }}
-          mb="lg"
-        >
-          <Tabs.List>
-            <Tabs.Tab value="account">Account</Tabs.Tab>
-            <Tabs.Tab value="usage">Usage</Tabs.Tab>
-          </Tabs.List>
-        </Tabs>
+        <ProfileTabs active="account" />
 
         <Box className={classes.grid2}>
-          {/* Main column: personal information, agent runtimes, personal MCP. */}
+          {/* Main column: personal information, agent runtimes. */}
           <Box className={classes.colMain}>
             <Card p={24}>
               <Title order={4} mb={4}>
@@ -1309,7 +1190,6 @@ function ProfilePage({ profile, pendingInvitations, agentModels, cableStream, mc
             <Deferred data="usageLimits" fallback={<Skeleton height={180} radius="sm" />}>
               <UsageLimitsCard entries={usageLimits ?? []} />
             </Deferred>
-            <PersonalMcpSection mcp={mcp} />
           </Box>
 
           {/* Side column: companies, agent defaults. */}

--- a/app/frontend/pages/Profile/Usage.tsx
+++ b/app/frontend/pages/Profile/Usage.tsx
@@ -11,7 +11,6 @@ import {
   SimpleGrid,
   Skeleton,
   Table,
-  Tabs,
   Text,
   Title,
   Tooltip,
@@ -34,11 +33,12 @@ import {
 
 import { AuthLayout } from 'layouts/AuthLayout';
 
-import { profilePath } from 'shared/routes';
 import { CHART_SERIES } from 'shared/theme/chartPalette';
 import { type SharedProps } from 'shared/ui';
 import { ContributionHeatmap } from 'shared/ui/ContributionHeatmap';
 import { StatusBadge } from 'shared/ui/StatusBadge';
+
+import { ProfileTabs } from './ProfileTabs';
 
 type Period = '7d' | '30d' | '90d' | '1y';
 
@@ -585,18 +585,7 @@ const UsagePage = () => {
           {companyName ? ` in ${companyName}` : ''}.
         </Text>
 
-        <Tabs
-          value="usage"
-          onChange={(v) => {
-            if (v === 'account') router.visit(profilePath());
-          }}
-          mb="lg"
-        >
-          <Tabs.List>
-            <Tabs.Tab value="account">Account</Tabs.Tab>
-            <Tabs.Tab value="usage">Usage</Tabs.Tab>
-          </Tabs.List>
-        </Tabs>
+        <ProfileTabs active="usage" />
 
         <Group justify="flex-end" mb="xl">
           <Select value={period} onChange={(v) => navigate(v ?? '30d')} data={PERIOD_OPTIONS} size="sm" w={140} />

--- a/app/frontend/shared/routes.ts
+++ b/app/frontend/shared/routes.ts
@@ -847,6 +847,11 @@ export function adminNamespaceResourceQuotaPath(id: ScalarType, options?: object
   return "/" + "admin" + "/" + "namespace_resource_quotas" + "/" + id + ($hasPresentOwnProperty(options, "format") ? "." + (options as any).format : "") + $buildOptions(options, ["id","format"]);
 }
 
+/** /admin/catalog_syncs(.:format) */
+export function adminCatalogSyncsPath(options?: object): string {
+  return "/" + "admin" + "/" + "catalog_syncs" + ($hasPresentOwnProperty(options, "format") ? "." + (options as any).format : "") + $buildOptions(options, ["format"]);
+}
+
 /** / */
 export function rootPath(options?: object): string {
   return "/" + $buildOptions(options, []);
@@ -937,6 +942,11 @@ export function usageProfilePath(options?: object): string {
   return "/" + "profile" + "/" + "usage" + ($hasPresentOwnProperty(options, "format") ? "." + (options as any).format : "") + $buildOptions(options, ["format"]);
 }
 
+/** /profile/mcp(.:format) */
+export function mcpProfilePath(options?: object): string {
+  return "/" + "profile" + "/" + "mcp" + ($hasPresentOwnProperty(options, "format") ? "." + (options as any).format : "") + $buildOptions(options, ["format"]);
+}
+
 /** /profile/update_default_model(.:format) */
 export function updateDefaultModelProfilePath(options?: object): string {
   return "/" + "profile" + "/" + "update_default_model" + ($hasPresentOwnProperty(options, "format") ? "." + (options as any).format : "") + $buildOptions(options, ["format"]);
@@ -955,6 +965,11 @@ export function regenerateMCPTokenProfilePath(options?: object): string {
 /** /profile/disable_mcp_token(.:format) */
 export function disableMCPTokenProfilePath(options?: object): string {
   return "/" + "profile" + "/" + "disable_mcp_token" + ($hasPresentOwnProperty(options, "format") ? "." + (options as any).format : "") + $buildOptions(options, ["format"]);
+}
+
+/** /profile/update_mcp_tools(.:format) */
+export function updateMCPToolsProfilePath(options?: object): string {
+  return "/" + "profile" + "/" + "update_mcp_tools" + ($hasPresentOwnProperty(options, "format") ? "." + (options as any).format : "") + $buildOptions(options, ["format"]);
 }
 
 /** /profile(.:format) */
@@ -1225,6 +1240,11 @@ export function companyProjectMCPServerPath(project_id: ScalarType, id: ScalarTy
 /** /company/projects/:project_id/connectors(.:format) */
 export function companyProjectConnectorsPath(project_id: ScalarType, options?: object): string {
   return "/" + "company" + "/" + "projects" + "/" + project_id + "/" + "connectors" + ($hasPresentOwnProperty(options, "format") ? "." + (options as any).format : "") + $buildOptions(options, ["project_id","format"]);
+}
+
+/** /company/projects/:project_id/skills/manual(.:format) */
+export function manualCompanyProjectSkillsPath(project_id: ScalarType, options?: object): string {
+  return "/" + "company" + "/" + "projects" + "/" + project_id + "/" + "skills" + "/" + "manual" + ($hasPresentOwnProperty(options, "format") ? "." + (options as any).format : "") + $buildOptions(options, ["project_id","format"]);
 }
 
 /** /company/projects/:project_id/skills(.:format) */

--- a/app/services/tools/personal_mcp.rb
+++ b/app/services/tools/personal_mcp.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Tools
+  # The personal (token-authenticated) MCP server as its users see it: the name
+  # their client registers it under, the URL they point at, and which of the
+  # registry's `audience :user` tools it actually serves them.
+  module PersonalMCP
+    # The name a client registers this server under. It prefixes every tool the
+    # agent sees (`mcp__flow__list_projects`), so it is user-visible surface,
+    # not an internal id — keep it in step with the product name.
+    NAME = "flow"
+
+    class << self
+      # `MCP_PUBLIC_SERVER_URL` wins; otherwise the app's own public host.
+      # Built here rather than as a settings.yml default because the
+      # per-environment `protocol` (https everywhere except development/test)
+      # is only known once the environment file has been merged — the literal
+      # `http://` that default used to hardcode handed every deployed user a
+      # URL their MCP client refuses.
+      def public_url
+        Settings.mcp.public_server_url.presence || "#{Settings.protocol}://#{Settings.domain}/mcp"
+      end
+
+      # The tool definitions this user's server serves, ordered by name.
+      #
+      # `mcp_enabled_tools` is nil for "everything" — including tools shipped
+      # after the user last touched the picker. An array narrows it, and names
+      # that have since left the registry are dropped rather than kept as dead
+      # entries.
+      def definitions_for(user)
+        defs = Registry.for_audience(:user).sort_by(&:name)
+        return defs if user.mcp_enabled_tools.nil?
+
+        allowed = user.mcp_enabled_tools.to_set
+        defs.select { |d| allowed.include?(d.name) }
+      end
+
+      # The picker's shape: the same groups the `tool_catalog` prompt uses, so
+      # what a user switches off in the UI is described to them the same way the
+      # agent has it described. Unlike the prompt, a tool appears exactly once —
+      # a multi-tagged tool (`trigger_task_workflow` is both :board and
+      # :workflows) lands in its first group, because two checkboxes for one
+      # tool would disagree with each other. A tool whose tags have no group
+      # still shows up, under "Other" — never silently unselectable.
+      def catalog_groups
+        remaining = Registry.for_audience(:user).sort_by(&:name)
+
+        groups = PersonalMCPGuides::CATALOG_GROUPS.filter_map do |group|
+          tools, remaining = remaining.partition { |d| d.tags.include?(group[:tag]) }
+          next if tools.empty?
+
+          { tag: group[:tag].to_s, title: group[:title], blurb: group[:blurb], tools: tools.map { |d| tool_entry(d) } }
+        end
+
+        return groups if remaining.empty?
+
+        groups << { tag: "other", title: "Other", blurb: nil, tools: remaining.map { |d| tool_entry(d) } }
+      end
+
+      # Persists a selection. `names` nil (or covering the whole registry) is
+      # stored as NULL so tools added later stay switched on — a materialized
+      # "everything" list would silently freeze the server at today's surface.
+      def update_selection!(user, names)
+        known = Registry.for_audience(:user).map(&:name)
+        selected = names.nil? ? nil : Array(names).map(&:to_s).uniq & known
+        selected = nil if selected && selected.sort == known.sort
+
+        user.update!(mcp_enabled_tools: selected)
+      end
+
+      private
+
+      # The wire name, not the display name: `list_projects` is what the user
+      # sees in their agent, so it is what they recognize in the picker.
+      def tool_entry(defn)
+        {
+          name: defn.name,
+          description: defn.description,
+          read_only: defn.annotations.fetch("readOnlyHint", false)
+        }
+      end
+    end
+  end
+end

--- a/app/services/tools/personal_mcp_guides.rb
+++ b/app/services/tools/personal_mcp_guides.rb
@@ -106,9 +106,10 @@ module Tools
 
       # Generated from the live registry: adding a tool updates the catalog,
       # and a tool that carries no known tag still shows up (under "Other")
-      # rather than silently vanishing from the map.
-      def tool_catalog
-        defs = Registry.for_audience(:user)
+      # rather than silently vanishing from the map. `defs` is what the caller
+      # is actually serving — a user who has switched tools off must not be
+      # handed a catalog advertising them.
+      def tool_catalog(defs = Registry.for_audience(:user))
         known = CATALOG_GROUPS.map { |g| g[:tag] }
         sections = CATALOG_GROUPS.filter_map do |group|
           section(group[:title], group[:blurb], defs.select { |d| d.tags.include?(group[:tag]) })

--- a/app/services/tools/personal_mcp_request_handler.rb
+++ b/app/services/tools/personal_mcp_request_handler.rb
@@ -49,11 +49,15 @@ module Tools
     attr_reader :user
 
     def server
+      # The user's own selection, not the whole registry: a client that is only
+      # ever asked about boards should not carry 80 tool schemas in its context.
+      definitions = PersonalMCP.definitions_for(user)
+
       MCP::Server.new(
-        name: "aixle",
+        name: PersonalMCP::NAME,
         instructions: PersonalMCPGuides::INSTRUCTIONS,
-        tools: Registry.for_audience(:user).sort_by(&:name).map { |defn| define_tool(defn) },
-        prompts: PROMPTS.map { |spec| define_prompt(spec) },
+        tools: definitions.map { |defn| define_tool(defn) },
+        prompts: PROMPTS.map { |spec| define_prompt(spec, definitions) },
         resources: [ reference_resource ],
         server_context: { user: user }
       )
@@ -96,31 +100,36 @@ module Tools
     end
 
     # Complex flows need more guidance than tool descriptions can carry —
-    # served as MCP prompts the client pulls in on demand. `guide` names the
-    # PersonalMCPGuides method, called inside the block so nothing is rendered
-    # until a client actually asks for that prompt.
+    # served as MCP prompts the client pulls in on demand. `render` takes the
+    # tools this server is serving (the catalog describes exactly those, no
+    # more) and is called inside the block, so nothing is rendered until a
+    # client actually asks for that prompt.
     PROMPTS = [
-      { name: "setup_project", guide: :setup_project, title: "Aixle project setup guide",
+      { name: "setup_project", render: ->(_defs) { PersonalMCPGuides.setup_project },
+        title: "Aixle project setup guide",
         description: "How to take an Aixle project from nothing to a running workflow: company and " \
                      "project, integrations, repositories, secrets, tools/skills/MCP servers, agents, " \
                      "the board, then the workflow and its trigger." },
-      { name: "build_workflow", guide: :build_workflow, title: "Aixle workflow building guide",
+      { name: "build_workflow", render: ->(_defs) { PersonalMCPGuides.build_workflow },
+        title: "Aixle workflow building guide",
         description: "How to build an Aixle workflow end-to-end: concepts, the order to call the " \
                      "workflow tools, step/sub-step structure, running and inspecting runs." },
-      { name: "author_step", guide: :author_step, title: "Aixle step authoring guide",
+      { name: "author_step", render: ->(_defs) { PersonalMCPGuides.author_step },
+        title: "Aixle step authoring guide",
         description: "How to write a good Aixle workflow step: instructions, agent/tools/skills, " \
                      "sub-steps, dependencies, and failure handling." },
-      { name: "tool_catalog", guide: :tool_catalog, title: "Aixle tool catalog",
+      { name: "tool_catalog", render: ->(defs) { PersonalMCPGuides.tool_catalog(defs) },
+        title: "Aixle tool catalog",
         description: "Every tool this server exposes, grouped by area (account, integrations, project " \
                      "resources, board, workflows) with a one-line summary each." }
     ].freeze
 
-    def define_prompt(spec)
+    def define_prompt(spec, definitions)
       MCP::Prompt.define(name: spec[:name], description: spec[:description]) do |_args, server_context: nil|
         MCP::Prompt::Result.new(
           description: spec[:title],
           messages: [ MCP::Prompt::Message.new(
-            role: "user", content: { type: "text", text: PersonalMCPGuides.public_send(spec[:guide]) }
+            role: "user", content: { type: "text", text: spec[:render].call(definitions) }
           ) ]
         )
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -232,10 +232,12 @@ Rails.application.routes.draw do
 
     resource :profile, only: %i[show update], controller: "profile" do
       get :usage, on: :member
+      get :mcp, on: :member
       put :update_default_model, on: :member
       delete :destroy_credential, on: :member
       post :regenerate_mcp_token, on: :member
       delete :disable_mcp_token, on: :member
+      patch :update_mcp_tools, on: :member
     end
     resource :onboarding, only: %i[show update], controller: "onboarding"
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -64,12 +64,16 @@ aws:
   region:            <%= ENV['AWS_DEFAULT_REGION'] || 'fake' %>
 
 mcp:
-  name: aixle-mcp-server
+  name: flow-mcp-server
   server_url: <%= ENV['MCP_SERVER_URL'] || 'http://web:4002/action_mcp' %>
-  # The URL users configure their own MCP clients with (personal token) —
-  # public host, unlike server_url which agent containers reach over the
-  # docker network.
-  public_server_url: <%= ENV['MCP_PUBLIC_SERVER_URL'] || "http://#{ENV['DOMAIN'] || 'localhost:4000'}/mcp" %>
+  # Override for the URL users configure their own MCP clients with (personal
+  # token) — a public host, unlike server_url which agent containers reach over
+  # the docker network. Blank by default: the fallback is built from the app's
+  # own protocol + domain in Tools::PersonalMCP.public_url, because the
+  # per-environment `protocol` (https outside development/test) is not readable
+  # from this file — hardcoding `http://` here handed deployed users a URL
+  # their MCP client refuses.
+  public_server_url: <%= ENV['MCP_PUBLIC_SERVER_URL'] %>
 
 cloud:
   # Where the in-container credential_process helper asks for short-lived cloud

--- a/db/migrate/20260817120000_add_mcp_enabled_tools_to_users.rb
+++ b/db/migrate/20260817120000_add_mcp_enabled_tools_to_users.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Which tools a user's personal MCP server exposes.
+#
+# NULL means "every tool this server has", including tools added in a later
+# release — that is the only value that keeps working as the registry grows,
+# so it stays the default rather than a materialized list of today's names.
+# An array narrows the server to exactly those tool names.
+class AddMCPEnabledToolsToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :mcp_enabled_tools, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_17_000003) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -1047,6 +1047,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_000003) do
     t.datetime "deleted_at"
     t.citext "email", null: false
     t.bigint "last_company_id"
+    t.jsonb "mcp_enabled_tools"
     t.string "mcp_token_digest"
     t.datetime "mcp_token_last_used_at"
     t.string "name", null: false

--- a/docs/user-guide/mcp.md
+++ b/docs/user-guide/mcp.md
@@ -69,17 +69,38 @@ session's tools, but your own Aixle account, so an outside client
 (Claude Code, Claude Desktop, any MCP client) can drive the platform for
 you — list projects, build workflows, run them, work the board.
 
-Enable it under **Profile → Personal MCP**, which hands you an `amcp_`
-token and the ready-made command:
+Enable it under **Profile → MCP**, which hands you an `amcp_` token and,
+alongside it, the two ways to install the server. Clients register it
+under the name `flow`, so its tools appear as `mcp__flow__list_projects`
+and so on.
 
 ```
-claude mcp add aixle --transport http $MCP_SERVER_URL --header "Authorization: Bearer amcp_…"
+claude mcp add flow --transport http $MCP_SERVER_URL --header "Authorization: Bearer amcp_…"
 ```
+
+For Cursor the same tab has an **Add to Cursor** button — a
+`cursor://anysphere.cursor-deeplink/mcp/install` link carrying the URL and
+the bearer header — plus a **Copy JSON** action for any other client's
+`mcp.json`. All three carry the token, so they are only offered while the
+token is on screen: it is stored as a digest and shown exactly once.
 
 The token carries **exactly your own access level** — every call runs
 through the same Pundit policies as the UI, across every company you are
 an active member of. There is no "current project": tools take an
 explicit `project_id`. Regenerating the token revokes the old one.
+
+### Choosing which tools it serves
+
+The **Tools** card on the same tab lists every tool the server can offer,
+grouped the way the `tool_catalog` prompt groups them. Unchecking the ones
+you never use keeps their schemas out of your agent's context; the
+`tool_catalog` prompt then describes exactly the remaining set. It is not
+a permission boundary — the token always runs as you, with your access
+level — just a smaller surface.
+
+Leaving everything checked is stored as "all tools", so tools added in a
+later release arrive switched on. A client picks up a change on its next
+connection.
 
 Beyond its ~85 tools, the server ships its own documentation:
 

--- a/test/integration/personal_mcp_test.rb
+++ b/test/integration/personal_mcp_test.rb
@@ -78,6 +78,30 @@ class PersonalMCPTest < ActionDispatch::IntegrationTest
     refute_includes names, "meta_create_tool"
   end
 
+  # The server name prefixes every tool inside the client
+  # (`mcp__flow__list_projects`), so it is user-visible surface — renaming it is
+  # a wire change, not a cosmetic one.
+  test "the server introduces itself as flow" do
+    info = rpc("initialize", { protocolVersion: "2025-06-18", capabilities: {},
+                               clientInfo: { name: "test-client", version: "1" } })
+           .dig("result", "serverInfo")
+
+    assert_equal "flow", info["name"]
+  end
+
+  test "a narrowed tool selection is what the server serves, catalog included" do
+    @user.update!(mcp_enabled_tools: %w[list_projects])
+
+    names = rpc("tools/list").dig("result", "tools").map { |t| t["name"] }
+    assert_equal %w[list_projects], names
+
+    # A catalog advertising tools the client cannot call is worse than no
+    # catalog: the agent plans a call that comes back "unknown tool".
+    catalog = prompt_text("tool_catalog")
+    assert_match(/`list_projects`/, catalog)
+    refute_match(/`list_companies`/, catalog)
+  end
+
   test "personal tools are not materialized as shadow rows and stay out of session serving" do
     Tools::Reconciler.run!
 

--- a/test/integration/web/profile_controller_test.rb
+++ b/test/integration/web/profile_controller_test.rb
@@ -123,6 +123,66 @@ class Web::ProfileControllerTest < ActionDispatch::IntegrationTest
     assert AgentCredential.exists?(credential.id)
   end
 
+  # ── the MCP tab ──
+
+  test "mcp renders its own page with the connection details and the tool catalog" do
+    get mcp_profile_path
+
+    assert_inertia_page "Profile/Mcp"
+    assert_inertia_props do |props|
+      assert_equal "flow", props[:mcp][:serverName]
+      assert_equal Tools::PersonalMCP.public_url, props[:mcp][:serverUrl]
+      # No selection yet: the client renders "everything", including tools
+      # added after this page was last opened.
+      assert_nil props[:mcp][:enabledTools]
+      assert_includes props[:mcp][:toolGroups].flat_map { |g| g[:tools] }.map { |t| t[:name] }, "list_projects"
+    end
+  end
+
+  # The token exists exactly once, in the response to the regeneration itself —
+  # so the redirect has to land on the page that renders it.
+  test "regenerate_mcp_token redirects to the mcp tab and shows the token once" do
+    post regenerate_mcp_token_profile_path
+
+    assert_redirected_to mcp_profile_path
+    follow_redirect!
+    assert_inertia_props { |props| assert props[:mcp][:token].starts_with?(User::MCP_TOKEN_PREFIX) }
+
+    get mcp_profile_path
+    assert_inertia_props { |props| assert_nil props[:mcp][:token] }
+  end
+
+  test "disable_mcp_token redirects to the mcp tab" do
+    @user.regenerate_mcp_token!
+
+    delete disable_mcp_token_profile_path
+
+    assert_redirected_to mcp_profile_path
+    assert_not @user.reload.mcp_enabled?
+  end
+
+  test "update_mcp_tools stores the selection and drops names the registry does not know" do
+    patch update_mcp_tools_profile_path, params: { toolNames: %w[list_projects not_a_tool] }, as: :json
+
+    assert_redirected_to mcp_profile_path
+    assert_equal %w[list_projects], @user.reload.mcp_enabled_tools
+  end
+
+  test "update_mcp_tools stores a full selection as 'everything'" do
+    @user.update!(mcp_enabled_tools: %w[list_projects])
+
+    patch update_mcp_tools_profile_path,
+          params: { toolNames: Tools::Registry.for_audience(:user).map(&:name) }, as: :json
+
+    assert_nil @user.reload.mcp_enabled_tools
+  end
+
+  test "update_mcp_tools accepts an empty selection" do
+    patch update_mcp_tools_profile_path, params: { toolNames: [] }, as: :json
+
+    assert_empty @user.reload.mcp_enabled_tools
+  end
+
   private
 
   # The same person's credential in a second company they belong to: theirs, but not

--- a/test/services/tools/personal_mcp_test.rb
+++ b/test/services/tools/personal_mcp_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Tools::PersonalMCPTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @all = Tools::Registry.for_audience(:user).map(&:name)
+  end
+
+  test "public_url falls back to the app's own protocol and domain" do
+    Settings.mcp.stubs(:public_server_url).returns(nil)
+    Settings.stubs(:protocol).returns("https")
+    Settings.stubs(:domain).returns("flow.example.com")
+
+    assert_equal "https://flow.example.com/mcp", Tools::PersonalMCP.public_url
+  end
+
+  test "public_url prefers the explicit override" do
+    Settings.mcp.stubs(:public_server_url).returns("https://mcp.example.com/rpc")
+
+    assert_equal "https://mcp.example.com/rpc", Tools::PersonalMCP.public_url
+  end
+
+  test "a user with no selection is served every user-audience tool" do
+    assert_nil @user.mcp_enabled_tools
+    assert_equal @all.sort, Tools::PersonalMCP.definitions_for(@user).map(&:name)
+  end
+
+  test "a selection narrows what is served, and stale names simply disappear" do
+    @user.update!(mcp_enabled_tools: %w[list_projects gone_in_a_later_release])
+
+    assert_equal %w[list_projects], Tools::PersonalMCP.definitions_for(@user).map(&:name)
+  end
+
+  test "an empty selection serves nothing" do
+    @user.update!(mcp_enabled_tools: [])
+
+    assert_empty Tools::PersonalMCP.definitions_for(@user)
+  end
+
+  test "update_selection! stores the subset it was given, minus names it does not know" do
+    Tools::PersonalMCP.update_selection!(@user, %w[list_projects list_companies not_a_tool])
+
+    assert_equal %w[list_companies list_projects], @user.reload.mcp_enabled_tools.sort
+  end
+
+  # Storing "everything" as a materialized list would freeze the server at
+  # today's surface: a tool shipped next release would arrive switched off for
+  # every user who ever opened the picker.
+  test "selecting every tool is stored as NULL, so later tools stay on" do
+    @user.update!(mcp_enabled_tools: %w[list_projects])
+
+    Tools::PersonalMCP.update_selection!(@user, @all)
+
+    assert_nil @user.reload.mcp_enabled_tools
+  end
+
+  test "update_selection! with nil resets to every tool" do
+    @user.update!(mcp_enabled_tools: %w[list_projects])
+
+    Tools::PersonalMCP.update_selection!(@user, nil)
+
+    assert_nil @user.reload.mcp_enabled_tools
+  end
+
+  test "catalog_groups covers every servable tool exactly once" do
+    groups = Tools::PersonalMCP.catalog_groups
+    listed = groups.flat_map { |g| g[:tools].map { |t| t[:name] } }
+
+    assert_equal @all.sort, listed.sort
+    assert_equal listed.uniq, listed
+    assert(groups.all? { |g| g[:title].present? && g[:tools].any? })
+  end
+
+  test "catalog_groups describes a tool with its description and read-only hint" do
+    entries = Tools::PersonalMCP.catalog_groups.flat_map { |g| g[:tools] }
+
+    read = entries.find { |t| t[:name] == "list_projects" }
+    assert read[:read_only]
+    assert_match(/projects/i, read[:description])
+
+    # The hint drives the "writes" marker in the picker, so a tool that changes
+    # something must not come through as read-only.
+    assert_equal false, entries.find { |t| t[:name] == "create_project" }[:read_only] # rubocop:disable Minitest/RefuteFalse
+  end
+end


### PR DESCRIPTION
## What

The Personal MCP card leaves the account page for a tab of its own, `/profile/mcp`, and grows the pieces that never fit on a card.

| | |
|---|---|
| **Own tab** | `GET /profile/mcp` → `Profile/Mcp`. Tabs (`Account · Usage · MCP`) become a shared `ProfileTabs` — Usage carried its own copy, which had no way to reach the new page. Token regeneration/disable redirect here, since this is where the token renders. |
| **Tool picker** | Pick which of the 89 `audience :user` tools the server offers. Groups match the ones the `tool_catalog` prompt uses, collapsed by default, `All`/`None` per group, `· writes` marks the non-read-only ones. |
| **Add to Cursor** | `cursor://anysphere.cursor-deeplink/mcp/install?name=flow&config=<base64>` one-click install, plus **Copy JSON** for any other client's `mcp.json`, beside the existing Claude Code command. |
| **`http` → `https`** | The public server URL was hardcoded `http://`. |
| **`aixle` → `flow`** | The name clients register the server under. |

## Why these choices

**`mcp_enabled_tools` NULL means "everything".** Including tools shipped in a later release — so selecting all in the UI stores NULL again rather than materialising today's list, which would silently freeze the server's surface at the moment someone last opened the picker. An empty array is a real (if odd) choice: a server with no tools. Unknown names are intersected away, so a stale name from an old tab is a no-op, not a 500.

**The `tool_catalog` prompt is filtered to match what is served.** A catalog advertising tools the client cannot call is worse than no catalog — the agent plans a call that comes back "unknown tool". `PersonalMCPGuides.tool_catalog` now takes the served definitions; `PROMPTS` entries carry a `render` lambda instead of a method name.

**This is not a permission boundary,** and both the UI and the docs say so: the token always runs as the user, with their access level. It is about context size — 89 tool schemas is a lot to carry for someone who only ever asks about boards.

**The URL scheme was a real bug.** `settings.yml` had `http://#{DOMAIN}/mcp` hardcoded, and nothing in the infra repo sets `MCP_PUBLIC_SERVER_URL` — so every deployed user was handed a URL their MCP client refuses. The default moved into `Tools::PersonalMCP.public_url` because settings.yml cannot read the merged per-environment `protocol` (https everywhere but development/test); the env override still wins.

**The server name is user-visible surface.** It prefixes every tool inside the client (`mcp__flow__list_projects`), so renaming it is a wire change, covered by a test. The session-side internal server is still `aixle-tools` — a separate rename touching six docs pages and the session context builders, deliberately not bundled here.

**A multi-tagged tool appears once in the picker.** `trigger_task_workflow` is both `:board` and `:workflows`; two checkboxes for one tool would disagree with each other, so it lands in its first group. The prompt's catalog keeps listing it under both — a doc can repeat itself, a control cannot.

## Tests

- `test/services/tools/personal_mcp_test.rb` — URL fallback/override, NULL vs subset vs empty selection, stale-name drop, all-selected → NULL, catalog covers every tool exactly once.
- `test/integration/personal_mcp_test.rb` — the server introduces itself as `flow`; a narrowed selection is what `tools/list` and the catalog prompt serve.
- `test/integration/web/profile_controller_test.rb` — the new page and its props, redirects onto the tab, the three `update_mcp_tools` shapes.
- `app/frontend/pages/Profile/Mcp.test.tsx` — token/command rendering, the Cursor deeplink decoded and asserted, picker save/clear/restore.

`docker compose exec -T web make check_all` green (backend 91.86%, frontend 81.35%).

## Migration

`add_mcp_enabled_tools_to_users` — one nullable jsonb column, no backfill: existing users read as "every tool", which is what they have today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
