### PR TITLE
feat(board): page the board task listings and drop descriptions

### DIFF
--- a/app/frontend/pages/Docs/data/pages/tools.md
+++ b/app/frontend/pages/Docs/data/pages/tools.md
@@ -38,7 +38,7 @@ and lifecycle tools:
 | Tool | Purpose |
 | --- | --- |
 | `board_get_board_info` | Return the current board with its columns. |
-| `board_list_tasks` | List tasks, filtered by column / tag / type / assignee. |
+| `board_list_tasks` | List a page of tasks (no descriptions), filtered by column / tag / type / assignee. |
 | `board_get_task` | Full details for a task. |
 | `board_create_task` | Create a task, optionally in a specific column. |
 | `board_update_task` | Update title, description, priority, tags, or type. |

--- a/app/models/board_task.rb
+++ b/app/models/board_task.rb
@@ -46,6 +46,15 @@ class BoardTask < ApplicationRecord
   # offset pagination from re-serving or skipping a row between pages.
   scope :in_board_order, -> { order(:position, :id) }
 
+  # Reading order for a flat listing that spans columns: columns left to right,
+  # tasks top to bottom inside each one. `in_board_order` cannot do this job by
+  # itself — `position` restarts per column, so rows of different columns would
+  # interleave in whatever order the planner felt like, and offset pagination
+  # over an unstable order re-serves some tasks while never showing others.
+  scope :in_flat_board_order, -> {
+    joins(:board_column).order("board_columns.position ASC, board_tasks.position ASC, board_tasks.id ASC")
+  }
+
   # The first `limit` tasks of *every* column, in one query — what keeps the board's
   # initial payload bounded on a board with hundreds of tasks per column. Ranking
   # happens in a window function because SQL has no per-group LIMIT.

--- a/app/services/context_builders/board_context.rb
+++ b/app/services/context_builders/board_context.rb
@@ -59,7 +59,8 @@ module ContextBuilders
       lines << "### Board Tools"
       lines << ""
       lines << "- **board_get_board_info** — get board details with all columns"
-      lines << "- **board_list_tasks** — list tasks on the board (filter by column_name, status)"
+      lines << "- **board_list_tasks** — list a page of tasks, without descriptions " \
+               "(filter by column_name/tag/task_type/assignee_id; paginate with limit/offset)"
       lines << "- **board_get_task** — get full task details by task_id"
       lines << "- **board_get_comments** — get comments for a task"
       lines << "- **board_get_task_assets** — get assets attached to a task"

--- a/app/services/internal_tools/board_list_tasks.rb
+++ b/app/services/internal_tools/board_list_tasks.rb
@@ -4,7 +4,9 @@ module InternalTools
   class BoardListTasks < Base
     tool do
       display_name "Board List Tasks"
-      description "List tasks on the current board with optional filters for column, tag, task type, or assignee."
+      description "List tasks on the current board one page at a time, with optional filters for " \
+                  "column, tag, task type, or assignee. Rows carry no description — read a task's " \
+                  "description with board_get_task."
       tags :board
       inject_when :workflow_step_session
       input_schema({
@@ -26,31 +28,85 @@ module InternalTools
           column_name: {
             type: "string",
             description: "Filter tasks to a board column by name"
+          },
+          limit: {
+            type: "integer",
+            description: "Tasks per page (default 25, max 100)"
+          },
+          offset: {
+            type: "integer",
+            description: "Tasks to skip before the page starts (default 0). The response carries " \
+                         "`total` and `has_more`; prefer a filter over walking a large board"
           }
         }
       })
     end
+
+    # A row still carries gates, recent runs and counts, so a page is far from free
+    # even with descriptions gone. 25 is what the board page itself loads per column.
+    DEFAULT_LIMIT = 25
+    MAX_LIMIT = 100
+
+    # The three counts a card shows, as scalar subqueries in the page's own query —
+    # the alternative is three extra queries per task.
+    COUNTS_SQL = <<~SQL.squish
+      board_tasks.*,
+      (SELECT COUNT(*) FROM task_comments WHERE board_task_id = board_tasks.id) AS comments_count,
+      (SELECT COUNT(*) FROM board_tasks children WHERE children.parent_task_id = board_tasks.id) AS children_count,
+      (SELECT COUNT(*) FROM task_assets WHERE board_task_id = board_tasks.id) AS assets_count
+    SQL
 
     def execute
       require_workflow_context!
       board = BoardContextResolver.resolve(session)
       return error("No board available in current context") unless board
 
-      tasks = board.board_tasks
-                   .select(Arel.sql(<<~SQL.squish))
-                     board_tasks.*,
-                     (SELECT COUNT(*) FROM task_comments WHERE board_task_id = board_tasks.id) AS comments_count,
-                     (SELECT COUNT(*) FROM board_tasks children WHERE children.parent_task_id = board_tasks.id) AS children_count,
-                     (SELECT COUNT(*) FROM task_assets WHERE board_task_id = board_tasks.id) AS assets_count
-                   SQL
-                   .includes(:board_column, :assignee, :workflow_runs, :gates)
-      tasks = tasks.joins(:board_column).where(board_columns: { name: params[:column_name] }) if params[:column_name].present?
-      tasks = tasks.with_tag(params[:tag]) if params[:tag].present?
-      tasks = tasks.where(task_type: params[:task_type]) if params[:task_type].present?
-      tasks = tasks.where(assignee_id: params[:assignee_id]) if params[:assignee_id].present?
+      scope = filtered(board.board_tasks)
+      total = scope.count
+      limit = requested_limit
+      offset = requested_offset
+      rows = page(scope, limit, offset).map { |task| row(task) }
 
-      result = tasks.map { |t| BoardTaskResource.new(t, params: { snake_keys: true }).to_h }
-      success(result.to_json)
+      success({ tasks: rows, total: total, limit: limit, offset: offset,
+                has_more: offset + rows.size < total }.to_json)
+    end
+
+    private
+
+    def filtered(scope)
+      scope = scope.joins(:board_column).where(board_columns: { name: params[:column_name] }) if params[:column_name].present?
+      scope = scope.with_tag(params[:tag]) if params[:tag].present?
+      scope = scope.where(task_type: params[:task_type]) if params[:task_type].present?
+      scope = scope.where(assignee_id: params[:assignee_id]) if params[:assignee_id].present?
+      scope
+    end
+
+    # `preload` rather than `includes`: the flat ordering already joins
+    # board_columns, and a second strategy on the same query would fight the
+    # custom SELECT above. board_column itself is not preloaded — a row reports
+    # `board_column_id`, never the column record.
+    def page(scope, limit, offset)
+      scope.select(Arel.sql(COUNTS_SQL))
+           .preload(:assignee, :workflow_runs, :gates)
+           .in_flat_board_order
+           .limit(limit)
+           .offset(offset)
+    end
+
+    # Descriptions are the one unbounded field on a task, and listing a whole
+    # board's worth of them is what used to make this tool cost thousands of
+    # tokens. Dropped after serialization rather than left out of the SELECT
+    # because the resource reads the attribute.
+    def row(task)
+      BoardTaskResource.new(task, params: { snake_keys: true }).to_h.except("description")
+    end
+
+    def requested_limit
+      params[:limit].present? ? params[:limit].to_i.clamp(1, MAX_LIMIT) : DEFAULT_LIMIT
+    end
+
+    def requested_offset
+      [ params[:offset].to_i, 0 ].max
     end
   end
 end

--- a/app/services/personal_tools/list_board_tasks.rb
+++ b/app/services/personal_tools/list_board_tasks.rb
@@ -4,7 +4,9 @@ module PersonalTools
   class ListBoardTasks < Base
     tool do
       display_name "List Board Tasks"
-      description "List tasks on a project's board, optionally filtered by column, tag or archive state."
+      description "List tasks on a project's board one page at a time, optionally filtered by " \
+                  "column, tag or archive state. Rows carry no description — read one with " \
+                  "get_board_task."
       audience :user
       tags :board
       read_only
@@ -14,9 +16,14 @@ module PersonalTools
       param :archived, type: :boolean,
             description: "Filter by archive state: false returns only active tasks, " \
                          "true only archived ones. Omit to return both."
+      param :limit, type: :integer, description: "Rows per page (default 50, cap 100)."
+      param :offset, type: :integer,
+            description: "Rows to skip before the page starts (default 0). The response " \
+                         "carries `total` and `has_more`."
     end
 
-    LIMIT = 100
+    DEFAULT_LIMIT = 50
+    MAX_LIMIT = 100
 
     def execute
       project = find_project!
@@ -24,22 +31,32 @@ module PersonalTools
       board = project.board
       return error("This project has no board — create one with setup_board") unless board
 
-      tasks = board.board_tasks.includes(:board_column, :assignee)
+      tasks = board.board_tasks.preload(:board_column, :assignee)
       tasks = tasks.where(board_column_id: params[:column_id]) if params[:column_id].present?
       tasks = tasks.with_tag(params[:tag]) if params[:tag].present?
       tasks = filter_by_archived(tasks)
 
-      rows = tasks.limit(LIMIT).map do |t|
+      total = tasks.count
+      limit = requested_limit
+      offset = requested_offset
+      rows = tasks.in_flat_board_order.limit(limit).offset(offset).map do |t|
         { id: t.id, title: t.title, task_type: t.task_type, priority: t.priority,
           column: t.board_column&.name, column_id: t.board_column_id,
           assignee: t.assignee&.name, assignee_id: t.assignee_id, tags: t.tags }
       end
-      payload = { project_id: project.id, tasks: rows }
-      payload[:truncated] = true if tasks.count > LIMIT
-      success(payload)
+      success(project_id: project.id, total: total, limit: limit, offset: offset,
+              has_more: offset + rows.size < total, tasks: rows)
     end
 
     private
+
+    def requested_limit
+      params[:limit].present? ? params[:limit].to_i.clamp(1, MAX_LIMIT) : DEFAULT_LIMIT
+    end
+
+    def requested_offset
+      [ params[:offset].to_i, 0 ].max
+    end
 
     # Omitting the param lists both states, which is what callers written
     # before this filter existed already get. Only an explicit value narrows

--- a/docs/user-guide/tools.md
+++ b/docs/user-guide/tools.md
@@ -39,7 +39,7 @@ internal `aixle-tools` MCP server:
 | Tool                  | Purpose                                                       |
 | --------------------- | ------------------------------------------------------------- |
 | `board_get_board_info` | Return the current board with its columns.                   |
-| `board_list_tasks`     | List tasks, filtered by column / tag / type / assignee.      |
+| `board_list_tasks`     | List a page of tasks (no descriptions), filtered by column / tag / type / assignee. |
 | `board_get_task`       | Full details for a task (defaults to the bound task).         |
 | `board_create_task`    | Create a task, optionally in a specific column.               |
 | `board_update_task`    | Update title, description, priority, tags, or type.           |

--- a/test/integration/personal_mcp_board_test.rb
+++ b/test/integration/personal_mcp_board_test.rb
@@ -68,6 +68,30 @@ class PersonalMCPBoardTest < ActionDispatch::IntegrationTest
     assert_equal [ "First task", archived.title ].sort, listed_titles.sort
   end
 
+  test "list_board_tasks pages the board and reports the unpaginated total" do
+    second = create(:board_task, board: @board, board_column: @todo, title: "Second task")
+    create(:board_task, board: @board, board_column: @done, title: "Third task")
+
+    first_page = payload(call_tool("list_board_tasks", { project_id: @project.id, limit: 2 }))
+    assert_equal [ "First task", second.title ], first_page["tasks"].map { |t| t["title"] }
+    assert_equal 3, first_page["total"]
+    assert_equal 2, first_page["limit"]
+    assert first_page["has_more"]
+
+    last_page = payload(call_tool("list_board_tasks", { project_id: @project.id, limit: 2, offset: 2 }))
+    assert_equal [ "Third task" ], last_page["tasks"].map { |t| t["title"] }
+    assert_equal false, last_page["has_more"] # rubocop:disable Minitest/RefuteFalse
+  end
+
+  test "list_board_tasks rows carry no description" do
+    @task.update!(description: "a long brief nobody asked for")
+
+    row = payload(call_tool("list_board_tasks", { project_id: @project.id }))["tasks"].first
+
+    assert_not row.key?("description")
+    assert_equal "To Do", row["column"]
+  end
+
   test "get_board_task returns full detail with snake_case keys" do
     task = payload(call_tool("get_board_task", { project_id: @project.id, task_id: @task.id }))
     assert_equal "First task", task["title"]

--- a/test/models/board_task_test.rb
+++ b/test/models/board_task_test.rb
@@ -231,6 +231,16 @@ class BoardTaskTest < ActiveSupport::TestCase
     assert_equal [ first.id, second.id ], BoardTask.where(board_column: @col1).in_board_order.map(&:id)
   end
 
+  test "in_flat_board_order reads columns left to right and tasks top to bottom" do
+    # Positions restart per column, so `in_board_order` alone would tie every
+    # first-in-column task against every other and leave the order to the planner.
+    done = BoardTask.create!(title: "Done first", board: @board, board_column: @col2, position: 1)
+    backlog_second = BoardTask.create!(title: "Backlog second", board: @board, board_column: @col1, position: 2)
+    backlog_first = BoardTask.create!(title: "Backlog first", board: @board, board_column: @col1, position: 1)
+
+    assert_equal [ backlog_first.id, backlog_second.id, done.id ], BoardTask.in_flat_board_order.map(&:id)
+  end
+
   test "tags_contains requires every listed tag while tags_overlap needs only one" do
     both = BoardTask.create!(title: "Both", board: @board, board_column: @col1, tags: %w[api ui])
     one = BoardTask.create!(title: "One", board: @board, board_column: @col1, tags: %w[api])

--- a/test/services/internal_tools/board_read_tools_test.rb
+++ b/test/services/internal_tools/board_read_tools_test.rb
@@ -25,31 +25,80 @@ class InternalTools::BoardReadToolsTest < ActiveSupport::TestCase
 
   # === board_list_tasks ===
 
-  test "board_list_tasks returns all tasks" do
-    result = InternalTools::BoardListTasks.new(params: {}, session: @session).execute
+  def list_tasks(**params)
+    result = InternalTools::BoardListTasks.new(params: params, session: @session).execute
     assert_equal 0, result[:exit_code]
-    data = JSON.parse(result[:stdout])
-    assert_equal 1, data.size
-    assert_equal "Test task", data.first["title"]
-    assert_equal @task.id, data.first["id"]
+    JSON.parse(result[:stdout])
+  end
+
+  test "board_list_tasks returns a page of tasks with the board's total" do
+    data = list_tasks
+    assert_equal 1, data["total"]
+    assert_equal 0, data["offset"]
+    assert_equal InternalTools::BoardListTasks::DEFAULT_LIMIT, data["limit"]
+    assert_equal false, data["has_more"] # rubocop:disable Minitest/RefuteFalse
+    assert_equal 1, data["tasks"].size
+    assert_equal "Test task", data["tasks"].first["title"]
+    assert_equal @task.id, data["tasks"].first["id"]
+  end
+
+  test "board_list_tasks omits descriptions and points at board_get_task instead" do
+    row = list_tasks["tasks"].first
+
+    assert_not row.key?("description")
+    # Everything a card needs to be read without the description is still there.
+    assert_equal [ "frontend" ], row["tags"]
+    assert_equal 0, row["comments_count"]
+    assert_equal [], row["pending_gates"]
+  end
+
+  test "board_list_tasks pages through the board in a stable column-then-position order" do
+    # A second column's tasks reuse positions 1..n, which is what an unstable
+    # order would interleave differently on every page.
+    second = create(:board_task, board: @board, board_column: @col1, title: "Second")
+    third = create(:board_task, board: @board, board_column: @col2, title: "Third")
+
+    first_page = list_tasks(limit: 2)
+    assert_equal [ @task.title, second.title ], first_page["tasks"].map { |t| t["title"] }
+    assert_equal 3, first_page["total"]
+    assert first_page["has_more"]
+
+    second_page = list_tasks(limit: 2, offset: 2)
+    assert_equal [ third.title ], second_page["tasks"].map { |t| t["title"] }
+    assert_equal 3, second_page["total"]
+    assert_equal false, second_page["has_more"] # rubocop:disable Minitest/RefuteFalse
+  end
+
+  test "board_list_tasks caps the page size and floors the offset" do
+    data = list_tasks(limit: 5_000, offset: -10)
+
+    assert_equal InternalTools::BoardListTasks::MAX_LIMIT, data["limit"]
+    assert_equal 0, data["offset"]
+  end
+
+  test "board_list_tasks counts the whole filtered set, not the page" do
+    create_list(:board_task, 4, board: @board, board_column: @col2, tags: [ "frontend" ])
+
+    data = list_tasks(tag: "frontend", limit: 2)
+
+    assert_equal 5, data["total"]
+    assert_equal 2, data["tasks"].size
+    assert data["has_more"]
   end
 
   test "board_list_tasks filters by column_name" do
     create(:board_task, board: @board, board_column: @col2, title: "Dev task")
 
-    result = InternalTools::BoardListTasks.new(params: { column_name: "In Dev" }, session: @session).execute
-    data = JSON.parse(result[:stdout])
-    assert_equal 1, data.size
-    assert_equal "Dev task", data.first["title"]
+    data = list_tasks(column_name: "In Dev")
+    assert_equal 1, data["total"]
+    assert_equal [ "Dev task" ], data["tasks"].map { |t| t["title"] }
   end
 
   test "board_list_tasks filters by tag" do
     create(:board_task, board: @board, board_column: @col1, title: "Other task", tags: [ "backend" ])
 
-    result = InternalTools::BoardListTasks.new(params: { tag: "frontend" }, session: @session).execute
-    data = JSON.parse(result[:stdout])
-    assert_equal 1, data.size
-    assert_equal "Test task", data.first["title"]
+    data = list_tasks(tag: "frontend")
+    assert_equal [ "Test task" ], data["tasks"].map { |t| t["title"] }
   end
 
   test "board_list_tasks does not produce N+1 queries" do


### PR DESCRIPTION
## Why

Both MCP surfaces that list board tasks shipped the whole board at once.

- `board_list_tasks` (workflow-session tool): no limit, no offset, and every row carried the task's full `description` on top of its gates, recent runs and counts. A board with a few hundred tasks cost an agent thousands of context tokens to list, and the cost grew with the board.
- `list_board_tasks` (personal MCP): capped at 100 rows with a `truncated` flag — bounded, but tasks past the first hundred were unreachable except by filter.

The board page itself got per-column paging in #122; the tool surfaces did not.

## What

- **`limit` / `offset` on both tools**, with `total` and `has_more` in the response so a caller knows what it is missing. Workflow tool: default 25 (`BoardTask::PAGE_SIZE`), cap 100. Personal tool: default 50, cap 100 (slimmer rows).
- **No `description` in list rows.** `board_get_task` / `get_board_task` stay the way to read one.
- The workflow tool's payload is now an object (`{tasks, total, limit, offset, has_more}`) instead of a bare array, to carry the page metadata. Nothing in the codebase parses it — only agents read it.
- **`BoardTask.in_flat_board_order`** — `position` restarts per column, so ordering by it alone lets rows of different columns interleave however the planner likes, and offset pagination over an unstable order re-serves some tasks while never showing others. The new scope gives the flat listings the board's reading order: columns left to right, tasks top to bottom, id as tie-break.
- Incidental, in the area: the workflow tool eager-loaded `board_column` it never serialized (`includes` → `preload`, and the column is not loaded at all — the row reports `board_column_id`); the agent's board-context hint advertised a `status` filter this tool has never had.

## Tests

- `board_read_tools_test.rb` — page metadata, description omission, stable order across a page boundary, limit cap / offset floor, `total` over the filtered set rather than the page. The existing N+1 test still holds at ≤ 8 queries.
- `personal_mcp_board_test.rb` — paging + total through the real `/mcp` endpoint, and no `description` in rows.
- `board_task_test.rb` — the new scope's column-then-position order.

`docker compose exec -T web make check_all` green (backend 91.88%, frontend 81.6%).

## Not covered

`board_get_comments` and `list_board_comments` are the next-fattest context source — comment bodies are unbounded and neither has a cursor. Left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
