### PR TITLE
fix(mcp): return workflow step instructions in full

### DIFF
--- a/app/services/internal_tools/meta_get_workflow.rb
+++ b/app/services/internal_tools/meta_get_workflow.rb
@@ -31,7 +31,10 @@ module InternalTools
           id: step.id,
           name: step.name,
           position: step.position,
-          instructions: step.instructions&.truncate(500),
+          # Whole text, like sub-steps below: a 500-char cut here made every
+          # meta_update_workflow_step that echoed instructions back a silent
+          # truncation of the step it was editing.
+          instructions: step.instructions,
           agent: step.agent ? { id: step.agent.id, title: step.agent.title } : nil,
           allow_non_interactive: step.allow_non_interactive,
           skip_policy: step.skip_policy,

--- a/app/services/personal_tools/get_workflow.rb
+++ b/app/services/personal_tools/get_workflow.rb
@@ -5,16 +5,15 @@ module PersonalTools
     tool do
       display_name "Get Workflow"
       description "Return a workflow's full definition: base resources, steps, sub-steps, agents, " \
-                  "dependencies. Step instructions are truncated here (instructions_truncated: true) — " \
-                  "use get_workflow_step to read a step's complete instructions before editing it."
+                  "dependencies. Step and sub-step instructions come back complete — use " \
+                  "get_workflow_step for one step's remaining wiring (retries, failure and skip " \
+                  "policy, preferred model, asset specs)."
       audience :user
       tags :workflows
       read_only
       param :project_id, type: :integer, description: "Project id.", required: true
       param :workflow_id, type: :integer, description: "Workflow id.", required: true
     end
-
-    INSTRUCTIONS_LIMIT = 500
 
     def execute
       project = find_project!
@@ -34,23 +33,22 @@ module PersonalTools
 
     private
 
+    # Instructions are returned whole. They used to be cut at 500 characters,
+    # which is shorter than almost every real step: a caller that read a
+    # workflow and then wrote a step back silently dropped the tail it never
+    # saw. Size is the caller's problem to manage (read one workflow at a
+    # time), not a reason to hand back text that looks complete and isn't.
     def step_view(step)
       { id: step.id, name: step.name, position: step.position,
-        instructions: truncate(step.instructions),
-        instructions_truncated: truncated?(step.instructions),
+        instructions: step.instructions,
         agent: step.agent && { id: step.agent.id, title: step.agent.title },
         tool_ids: step.tool_ids, skill_ids: step.skill_ids, mcp_server_ids: step.mcp_server_ids,
         repository_ids: step.repository_ids,
         depends_on_step_ids: step.depends_on_step_ids,
         sub_steps: step.sub_steps.active.order(:position).map { |ss|
           { id: ss.id, name: ss.name, position: ss.position, required: ss.required,
-            instructions: truncate(ss.instructions),
-            instructions_truncated: truncated?(ss.instructions) }
+            instructions: ss.instructions }
         } }
     end
-
-    def truncate(text) = text&.truncate(INSTRUCTIONS_LIMIT)
-
-    def truncated?(text) = text.present? && text.length > INSTRUCTIONS_LIMIT
   end
 end

--- a/app/services/personal_tools/get_workflow_step.rb
+++ b/app/services/personal_tools/get_workflow_step.rb
@@ -4,9 +4,10 @@ module PersonalTools
   class GetWorkflowStep < Base
     tool do
       display_name "Get Workflow Step"
-      description "Return one workflow step in full: the complete, untruncated instructions plus every " \
-                  "wiring field (agent, tools, skills, MCP servers, dependencies, BMAD, retries, assets) " \
-                  "and its sub-steps. Use this before editing a step — get_workflow truncates instructions."
+      description "Return one workflow step with every wiring field (agent, tools, skills, MCP servers, " \
+                  "config items, dependencies, BMAD, retries, failure and skip policy, preferred model, " \
+                  "asset specs) and its sub-steps. get_workflow already carries instructions in full; " \
+                  "this adds the fields it leaves out."
       audience :user
       tags :workflows
       read_only

--- a/app/services/tools/personal_mcp_guides.rb
+++ b/app/services/tools/personal_mcp_guides.rb
@@ -39,8 +39,8 @@ module Tools
       - Start from `list_companies` / `list_projects`. Every id you pass comes
         from a list tool — never invent one, never carry an id across projects.
       - Read before you write: `get_workflow`, `get_workflow_step`, `get_agent`,
-        `get_skill`, `get_mcp_server`. `get_workflow` truncates step
-        instructions; `get_workflow_step` returns them in full.
+        `get_skill`, `get_mcp_server`. `get_workflow` carries step instructions
+        in full; `get_workflow_step` adds one step's remaining wiring.
       - Every id list on an update (`tool_ids`, `skill_ids`, `mcp_server_ids`,
         `depends_on_step_ids`, the workflow's `base_*` lists) REPLACES the
         current one. Read the current value first, then send the whole list.
@@ -127,9 +127,8 @@ module Tools
           #{sections.compact.join("\n").rstrip}
 
           Two rules worth repeating, because they are what usually goes wrong:
-          read a workflow step with `get_workflow_step` before editing it (the
-          listing truncates instructions), and remember that an id list on an
-          update replaces the current one wholesale.
+          read a workflow step before editing it, and remember that an id list
+          on an update replaces the current one wholesale.
         TEXT
       end
 
@@ -294,9 +293,9 @@ module Tools
           Rules:
           - Ask the user before destructive actions (`delete_workflow`,
             `delete_workflow_step`, `delete_sub_step`, `delete_workflow_trigger`).
-          - `get_workflow` truncates step instructions. Read a step with
-            `get_workflow_step` before editing it, or you will overwrite text you
-            never saw. The same applies to every id list (`tool_ids`, `skill_ids`,
+          - Read a step (`get_workflow`, or `get_workflow_step` for its full
+            wiring) before editing it, or you will overwrite text you never saw.
+            The same applies to every id list (`tool_ids`, `skill_ids`,
             `mcp_server_ids`, `depends_on_step_ids`, and the workflow's `base_*`
             lists): an update REPLACES the list, so read the current value first.
           - The off-board trigger kinds (slack, schedule, webhook, event) fire with

--- a/test/integration/personal_mcp_workflows_test.rb
+++ b/test/integration/personal_mcp_workflows_test.rb
@@ -70,7 +70,7 @@ class PersonalMCPWorkflowsTest < ActionDispatch::IntegrationTest
     assert_match(/no fields/i, text(nothing))
   end
 
-  test "get_workflow_step returns full instructions and wiring while get_workflow truncates and flags" do
+  test "get_workflow returns long instructions in full and get_workflow_step adds the wiring" do
     long = "x" * 900
     agent = create(:agent, scope: @project)
     tool = create(:tool, scope: @project)
@@ -81,9 +81,8 @@ class PersonalMCPWorkflowsTest < ActionDispatch::IntegrationTest
     create(:sub_step, step: step, name: "check A", instructions: long)
 
     listed = payload(call_tool("get_workflow", { project_id: @project.id, workflow_id: @workflow.id }))["steps"].first
-    assert_equal 500, listed["instructions"].length
-    assert listed["instructions_truncated"]
-    assert listed["sub_steps"].first["instructions_truncated"]
+    assert_equal long, listed["instructions"]
+    assert_equal long, listed["sub_steps"].first["instructions"]
 
     full = payload(call_tool("get_workflow_step",
                              { project_id: @project.id, workflow_id: @workflow.id, step_id: step.id }))

--- a/test/services/internal_tools/meta_workflow_tools_test.rb
+++ b/test/services/internal_tools/meta_workflow_tools_test.rb
@@ -208,8 +208,9 @@ class InternalTools::MetaWorkflowToolsTest < ActiveSupport::TestCase
   # ── meta_get_workflow ──
 
   test "meta_get_workflow returns full workflow structure" do
+    long = "x" * 900
     wf = create(:workflow, scope: @project, name: "Full WF")
-    step = create(:step, workflow: wf, name: "S1", position: 1, instructions: "Do it")
+    step = create(:step, workflow: wf, name: "S1", position: 1, instructions: long)
     create(:sub_step, step: step, name: "SS1", position: 1)
     @workflow_run.update!(shared_context: { "target_workflow_id" => wf.id })
 
@@ -223,6 +224,7 @@ class InternalTools::MetaWorkflowToolsTest < ActiveSupport::TestCase
     assert_equal "Full WF", data["name"]
     assert_equal 1, data["steps_count"]
     assert_equal "S1", data["steps"][0]["name"]
+    assert_equal long, data["steps"][0]["instructions"]
     assert_equal 1, data["steps"][0]["sub_steps"].size
   end
 


### PR DESCRIPTION
## What

`get_workflow` (personal MCP) and `meta_get_workflow` (agent-facing meta tool) cut step instructions at 500 characters. That is shorter than nearly every real step, so:

- a caller that read a workflow and then wrote a step back silently dropped the tail it never saw;
- `instructions_truncated: true` told the caller *that* something was missing, never *what*;
- in `meta_get_workflow` sub-steps were already returned whole, so the two halves of the same payload disagreed.

Both now return the text whole. `get_workflow_step` keeps its role as the read for one step's remaining wiring (config items, BMAD, retries, failure/skip policy, preferred model, asset specs) rather than as "the un-truncated read", and the tool descriptions plus the three `personal_mcp_guides` passages that advertised the truncation were updated to match.

`instructions_truncated` is gone from the `get_workflow` payload — an extra field disappearing, no rename.

## Tests

- `personal_mcp_workflows_test`: the truncation assertions now assert full text on both step and sub-step.
- `meta_workflow_tools_test`: `meta_get_workflow` now builds the step with 900-char instructions and asserts they come back whole (previously the fixture was short enough to pass either way).

Not run locally by request — leaving the verification to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
