### PR TITLE
fix(workflows): make the workflow Edit dialog reach a route

### DIFF
--- a/app/controllers/web/company/projects/workflows_controller.rb
+++ b/app/controllers/web/company/projects/workflows_controller.rb
@@ -95,6 +95,19 @@ class Web::Company::Projects::WorkflowsController < Web::Company::Projects::Appl
     end
   end
 
+  # The Edit dialog on the workflows page. Goes through WorkflowService so a
+  # `config` edit merges into the existing hash instead of replacing it — the
+  # same write the builder's autosave performs through the API.
+  def update
+    workflow = current_project.workflows.active.find(params[:id])
+
+    if WorkflowService.update(workflow: workflow, params: workflow_params)
+      redirect_to company_project_workflows_path(current_project), notice: "Workflow updated"
+    else
+      redirect_to company_project_workflows_path(current_project), alert: workflow.errors.full_messages.join(", ")
+    end
+  end
+
   def destroy
     workflow = current_project.workflows.find(params[:id])
     workflow.destroy

--- a/app/services/personal_tools/get_workflow.rb
+++ b/app/services/personal_tools/get_workflow.rb
@@ -28,6 +28,8 @@ module PersonalTools
               base_mcp_server_ids: workflow.base_mcp_server_ids,
               base_repository_ids: workflow.base_repository_ids,
               base_config_item_ids: workflow.base_config_item_ids,
+              base_asset_ids: workflow.base_asset_ids,
+              inherit_all_project_resources: workflow.inherit_all_project_resources,
               steps_count: steps.size, steps: steps)
     end
 

--- a/app/services/personal_tools/update_workflow.rb
+++ b/app/services/personal_tools/update_workflow.rb
@@ -5,7 +5,8 @@ module PersonalTools
     tool do
       display_name "Update Workflow"
       description "Update a workflow's name, description and base resources (tools/skills/MCP servers/" \
-                  "repositories granted to every step). Read the current values with get_workflow first."
+                  "repositories/assets granted to every step, or the flag that grants all of the " \
+                  "project's). Read the current values with get_workflow first."
       audience :user
       tags :workflows
       param :project_id, type: :integer, description: "Project id.", required: true
@@ -35,13 +36,24 @@ module PersonalTools
                          "Replaces the whole list — read the current value with get_workflow first. " \
                          "Set repositories on the step instead when only some steps need code.",
             items: { type: "integer" }
+      param :base_asset_ids, type: :array,
+            description: "Asset ids mounted into every step of this workflow. Replaces the whole list — " \
+                         "read the current value with get_workflow first.",
+            items: { type: "integer" }
+      param :inherit_all_project_resources, type: :boolean,
+            description: "When true, every step is granted every resource in the project and the base_* " \
+                         "lists stop being the limit. Convenient for a workflow you trust, and the " \
+                         "opposite of least privilege for one that installs or runs third-party code."
     end
 
     ATTRS = %i[name description].freeze
     # Base resources are not columns — they live in workflow.config, behind the
     # model's base_* readers and merge_config! writer.
     CONFIG_ATTRS = %i[base_tool_ids base_skill_ids base_mcp_server_ids base_repository_ids
-                      base_config_item_ids].freeze
+                      base_config_item_ids base_asset_ids].freeze
+    # Same store, but a flag rather than a list: JSON config does no
+    # ActiveRecord casting, so "false" would land as a truthy string.
+    CONFIG_FLAGS = %i[inherit_all_project_resources].freeze
 
     def execute
       project = find_project!
@@ -50,6 +62,7 @@ module PersonalTools
 
       attrs = ATTRS.each_with_object({}) { |k, h| h[k] = params[k] if params.key?(k) }
       config = CONFIG_ATTRS.each_with_object({}) { |k, h| h[k] = Array(params[k]).map(&:to_i) if params.key?(k) }
+      CONFIG_FLAGS.each { |k| config[k] = ActiveModel::Type::Boolean.new.cast(params[k]) if params.key?(k) }
       return error("No fields to update") if attrs.empty? && config.empty?
 
       ActiveRecord::Base.transaction do
@@ -62,6 +75,8 @@ module PersonalTools
               base_mcp_server_ids: workflow.base_mcp_server_ids,
               base_repository_ids: workflow.base_repository_ids,
               base_config_item_ids: workflow.base_config_item_ids,
+              base_asset_ids: workflow.base_asset_ids,
+              inherit_all_project_resources: workflow.inherit_all_project_resources,
               updated_fields: (attrs.keys + config.keys).map(&:to_s))
     rescue ActiveRecord::RecordInvalid => e
       error("Failed to update workflow: #{e.message}")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -287,7 +287,7 @@ Rails.application.routes.draw do
               end
             end
           end
-          resources :workflows, only: %i[index create destroy] do
+          resources :workflows, only: %i[index create update destroy] do
             member do
               get :builder
               post :publish

--- a/test/integration/personal_mcp_workflows_test.rb
+++ b/test/integration/personal_mcp_workflows_test.rb
@@ -48,12 +48,15 @@ class PersonalMCPWorkflowsTest < ActionDispatch::IntegrationTest
     tool = create(:tool, scope: @project)
     skill = create(:skill, scope: @project)
     server = create(:mcp_server, scope: @project)
+    asset = create(:asset, scope: @project)
 
     updated = payload(call_tool("update_workflow",
                                 { project_id: @project.id, workflow_id: @workflow.id,
                                   name: "Renamed", description: "new description",
                                   base_tool_ids: [ tool.id ], base_skill_ids: [ skill.id ],
-                                  base_mcp_server_ids: [ server.id ] }))
+                                  base_mcp_server_ids: [ server.id ],
+                                  base_asset_ids: [ asset.id ],
+                                  inherit_all_project_resources: true }))
     assert_equal "Renamed", updated["name"]
     assert_includes updated["updated_fields"], "base_tool_ids"
 
@@ -63,11 +66,27 @@ class PersonalMCPWorkflowsTest < ActionDispatch::IntegrationTest
     assert_equal [ tool.id ], detail["base_tool_ids"]
     assert_equal [ skill.id ], detail["base_skill_ids"]
     assert_equal [ server.id ], detail["base_mcp_server_ids"]
+    assert_equal [ asset.id ], detail["base_asset_ids"]
+    assert detail["inherit_all_project_resources"]
     assert_nil detail["published_at"]
 
     nothing = call_tool("update_workflow", { project_id: @project.id, workflow_id: @workflow.id })
     assert error?(nothing)
     assert_match(/no fields/i, text(nothing))
+  end
+
+  # The flag lives in the config JSON, which does no ActiveRecord casting: stored
+  # unconverted, a false would land as a truthy value and quietly grant every
+  # step every resource in the project.
+  test "update_workflow turns inherit_all_project_resources back off" do
+    @workflow.merge_config!(inherit_all_project_resources: true)
+
+    updated = payload(call_tool("update_workflow",
+                                { project_id: @project.id, workflow_id: @workflow.id,
+                                  inherit_all_project_resources: false }))
+
+    assert_not updated["inherit_all_project_resources"]
+    assert_not @workflow.reload.inherit_all_project_resources
   end
 
   test "get_workflow returns long instructions in full and get_workflow_step adds the wiring" do

--- a/test/integration/web/company/projects/workflows_authorization_test.rb
+++ b/test/integration/web/company/projects/workflows_authorization_test.rb
@@ -7,8 +7,8 @@ require "test_helper"
 #
 # Policy (Web::Company::Projects::WorkflowsPolicy):
 #   reads  (index/builder)                         => project_accessible?
-#   writes (create/destroy/publish/unpublish/      => project_writable?
-#           duplicate)
+#   writes (create/update/destroy/publish/         => project_writable?
+#           unpublish/duplicate)
 # Inaccessible project (stranger / foreign admin) => 404 (current_project's scoped
 # `.find` raises RecordNotFound before the policy). A project has no auto-created
 # workflow, so the fixture is built here (scope: @project => visible_for_project).
@@ -19,8 +19,8 @@ require "test_helper"
 # user_for(role)) — the guard then passes for every policy-allowed role and the
 # assertion reflects the pure authorization outcome (302 redirect, no alert).
 #
-# The policy also declares show?/update?, but this controller exposes no routes
-# for them, so there is nothing to exercise.
+# The policy also declares show?, but this controller exposes no route for it
+# (the workflow's own screen is `builder`), so there is nothing to exercise.
 class Web::Company::Projects::WorkflowsAuthorizationTest < ActionDispatch::IntegrationTest
   include AuthorizationMatrix
 
@@ -43,6 +43,16 @@ class Web::Company::Projects::WorkflowsAuthorizationTest < ActionDispatch::Integ
     assert_project_write do
       post company_project_workflows_path(@project),
            params: { workflow: { name: "Authz WF #{SecureRandom.hex(4)}", description: "x" } }
+    end
+  end
+
+  # A rename per role iteration would collide on the name-uniqueness validation,
+  # which fails the write without ever reaching the policy — so each role edits
+  # its own throwaway workflow.
+  test "update is a project write" do
+    assert_project_write do
+      patch company_project_workflow_path(@project, create(:workflow, scope: @project)),
+            params: { workflow: { description: "authz edit" } }
     end
   end
 

--- a/test/integration/web/company/projects/workflows_controller_test.rb
+++ b/test/integration/web/company/projects/workflows_controller_test.rb
@@ -69,6 +69,31 @@ class Web::Company::Projects::WorkflowsControllerTest < ActionDispatch::Integrat
     assert_response :redirect
   end
 
+  # The workflows page's Edit dialog PATCHes this path (WorkflowsPage.tsx), and its
+  # own Vitest coverage passes on a mocked `router.patch` — so a missing route here
+  # looked green on both sides while renaming a workflow in the UI did nothing.
+  test "update renames a workflow and edits its description" do
+    wf = create(:workflow, scope: @project, name: "Old name", description: "old description")
+
+    patch company_project_workflow_path(@project, wf),
+          params: { workflow: { name: "New name", description: "new description" } }
+    assert_response :redirect
+
+    wf.reload
+    assert_equal "New name", wf.name
+    assert_equal "new description", wf.description
+  end
+
+  test "update reports validation errors instead of renaming" do
+    create(:workflow, scope: @project, name: "Taken")
+    wf = create(:workflow, scope: @project, name: "Keeps its name")
+
+    patch company_project_workflow_path(@project, wf), params: { workflow: { name: "Taken" } }
+    assert_response :redirect
+
+    assert_equal "Keeps its name", wf.reload.name
+  end
+
   test "destroy redirects on success" do
     wf = create(:workflow, scope: @project)
 


### PR DESCRIPTION
## The bug

`WorkflowsPage.tsx` PATCHes `/company/projects/:id/workflows/:id` from the Edit dialog, but the web route set declared `only: %i[index create destroy]` — no `update` route, no `update` action. Renaming or re-describing a workflow in the UI silently did nothing.

Both suites stayed green over it: the page's Vitest test asserts that PATCH against a mocked `router.patch`, and the authorization matrix *documented* the hole instead of flagging it — "The policy also declares show?/update?, but this controller exposes no routes for them, so there is nothing to exercise." The policy has granted `update? = project_writable?` all along.

## Commits

1. `test(workflows)` — the failing test alone. CI witnessed it: `No route matches [PATCH]`, 2 failures out of 4772 runs ([run 32046249847](https://github.com/AixleHQ/flow/actions/runs/32046249847)).
2. `fix(workflows)` — route + action + the personal-MCP side. Green ([run 32049912268](https://github.com/AixleHQ/flow/actions/runs/32049912268)).

## The fix

- `resources :workflows` gains `update`, and `WorkflowsController#update` goes through `WorkflowService.update` like the API's — so a `config` edit merges into the existing hash instead of replacing it.
- Authorization matrix: `update is a project write` added, and the comment now names only `show?` as routeless. Each role edits its own throwaway workflow, because a shared rename would collide on name-uniqueness and fail the write before the policy ran.

## Personal MCP

`update_workflow` already existed and covered name, description and the base tool/skill/MCP-server/repository/config-item lists. It gained the two editable fields the builder has and it lacked:

- `base_asset_ids`
- `inherit_all_project_resources` — cast explicitly, because `config` is JSON with no ActiveRecord casting: an uncast `false` would have stored a truthy value and quietly granted every step every resource in the project. Covered by a test that turns the flag back off.

`get_workflow` now reports both, keeping read-before-write symmetric.

Nothing to add on Profile → Personal MCP: `Tools::PersonalMCP.catalog_groups` builds the sections from the live registry, grouped by tag, with each checkbox's label and description taken from the tool definition — `update_workflow` is tagged `:workflows` and already appears under "Workflows & runs".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
