### PR TITLE
feat(sidebar): add collapsible nav groups and compact AI Builder card

### DIFF
--- a/app/frontend/shared/ui/AppSidebar.module.css
+++ b/app/frontend/shared/ui/AppSidebar.module.css
@@ -35,6 +35,10 @@
 /* ── Nav group label ─────────────────────────────────────────────────────── */
 
 .navGroupLabel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.1em;
@@ -44,8 +48,16 @@
   margin: 12px 0 4px;
   white-space: nowrap;
   overflow: hidden;
-  transition: opacity 0.15s;
-  display: block;
+  transition: opacity 0.15s, color 0.12s;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 5px;
+  font-family: inherit;
+}
+
+.navGroupLabel:hover {
+  color: var(--app-text-secondary);
 }
 
 .navGroupLabelCollapsed {
@@ -54,6 +66,18 @@
   height: 4px;
   margin: 8px 0 2px;
   overflow: hidden;
+  pointer-events: none;
+}
+
+.groupCaret {
+  display: flex;
+  opacity: 0.6;
+  transition: transform 0.15s;
+  flex-shrink: 0;
+}
+
+.groupCaretCollapsed {
+  transform: rotate(-90deg);
 }
 
 /* ── Nav overview item (first "Overview" item) ───────────────────────────── */
@@ -145,7 +169,7 @@
 }
 
 .navItemIconCollapsed {
-  width: var(--sb-col-width, 52px);
+  width: var(--sb-col-width, 60px);
   text-align: center;
   margin: 0 auto;
   flex-shrink: 0;
@@ -771,12 +795,15 @@
 }
 
 .aiBanner {
-  margin: 8px 10px 4px;
-  padding: 13px;
+  padding: 10px 10px 4px;
+  flex-shrink: 0;
+}
+
+.aiBannerCard {
   border: 1px solid var(--app-border-default);
   border-radius: 8px;
-  background: var(--app-bg-paper);
-  flex-shrink: 0;
+  background: var(--app-bg-card);
+  padding: 10px;
 }
 
 .aiBannerIcon {
@@ -792,25 +819,6 @@
   transition: background 0.12s, border-color 0.12s;
 }
 
-.aiBannerIconStacked {
-  margin-bottom: 10px;
-}
-
-.aiBannerTitle {
-  font-size: 14px;
-  font-weight: 700;
-  color: var(--app-text-primary);
-  letter-spacing: -0.01em;
-  margin-bottom: 4px;
-}
-
-.aiBannerBody {
-  font-size: 11px;
-  color: var(--app-text-secondary);
-  line-height: 1.45;
-  margin-bottom: 12px;
-}
-
 .aiBannerCta {
   background: var(--app-cta-invert-bg);
   color: var(--app-cta-invert-fg);
@@ -818,19 +826,27 @@
   width: 100%;
   border: 1px solid transparent;
   cursor: pointer;
-  padding: 8px 12px;
+  padding: 9px 12px;
   font-size: 12px;
   font-weight: 600;
   font-family: inherit;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 5px;
+  gap: 6px;
   transition: background 0.12s;
 }
 
 .aiBannerCta:hover {
   background: var(--app-cta-invert-bg-hover);
+}
+
+.aiBannerCap {
+  font-size: 11px;
+  color: var(--app-text-tertiary);
+  line-height: 1.45;
+  margin-top: 9px;
+  text-align: center;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/app/frontend/shared/ui/AppSidebar.test.tsx
+++ b/app/frontend/shared/ui/AppSidebar.test.tsx
@@ -184,7 +184,7 @@ describe('AppSidebar', () => {
     const user = userEvent.setup();
     renderAuthedPage(<AppSidebar projectId="7" context="project" projects={projects} currentProjectId="7" />);
 
-    expect(screen.getByText('AI Builder')).toBeInTheDocument();
+    expect(screen.getByText('Tasks, boards, and workflows — from one prompt.')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /Build with AI/ }));
 
     expect(router.visit).toHaveBeenCalledWith('/company/projects/7/aixle_builder');
@@ -237,6 +237,47 @@ describe('AppSidebar', () => {
 
     // After collapsing, the button flips to the expand affordance.
     expect(screen.getByRole('button', { name: 'Expand sidebar' })).toBeInTheDocument();
+  });
+
+  it('collapses and re-expands a nav group, hiding and showing its items', async () => {
+    const user = userEvent.setup();
+    renderAuthedPage(<AppSidebar projectId="7" context="project" projects={projects} currentProjectId="7" />);
+
+    // All groups are expanded by default.
+    expect(screen.getByRole('link', { name: 'Tasks' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Work' }));
+    expect(screen.queryByRole('link', { name: 'Tasks' })).not.toBeInTheDocument();
+    // Other groups are unaffected.
+    expect(screen.getByRole('link', { name: 'Agents' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Work' }));
+    expect(screen.getByRole('link', { name: 'Tasks' })).toBeInTheDocument();
+  });
+
+  it('persists a collapsed nav group across remounts', async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderAuthedPage(
+      <AppSidebar projectId="7" context="project" projects={projects} currentProjectId="7" />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Work' }));
+    expect(screen.queryByRole('link', { name: 'Tasks' })).not.toBeInTheDocument();
+    unmount();
+
+    renderAuthedPage(<AppSidebar projectId="7" context="project" projects={projects} currentProjectId="7" />);
+    expect(screen.queryByRole('link', { name: 'Tasks' })).not.toBeInTheDocument();
+  });
+
+  it('shows every item in the icon rail even when its group is collapsed', async () => {
+    const user = userEvent.setup();
+    renderAuthedPage(<AppSidebar projectId="7" context="project" projects={projects} currentProjectId="7" />);
+
+    await user.click(screen.getByRole('button', { name: 'Work' }));
+    expect(screen.queryByRole('link', { name: 'Tasks' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
+    expect(screen.getByRole('link', { name: 'Tasks' })).toBeInTheDocument();
   });
 
   // The company switcher is a Slack-style rail left of the sidebar. A

--- a/app/frontend/shared/ui/AppSidebar.tsx
+++ b/app/frontend/shared/ui/AppSidebar.tsx
@@ -62,8 +62,26 @@ import { ColorSchemeToggle } from './ColorSchemeToggle';
 import type { SharedMembership, SharedPermissions, SharedProject, SharedProps } from './types';
 
 const SIDEBAR_WIDTH = 220;
-const SIDEBAR_COLLAPSED_WIDTH = 52;
+const SIDEBAR_COLLAPSED_WIDTH = 60;
 const STORAGE_KEY = 'sidebar-collapsed';
+const GROUPS_STORAGE_KEY = 'sidebar-collapsed-groups';
+
+const readCollapsedGroups = (): Set<string> => {
+  try {
+    const raw = localStorage.getItem(GROUPS_STORAGE_KEY);
+    return raw ? new Set(JSON.parse(raw) as string[]) : new Set();
+  } catch {
+    return new Set();
+  }
+};
+
+const writeCollapsedGroups = (groups: Set<string>) => {
+  try {
+    localStorage.setItem(GROUPS_STORAGE_KEY, JSON.stringify([...groups]));
+  } catch {
+    // localStorage unavailable (private browsing, quota exceeded)
+  }
+};
 
 const getInitials = (name: string): string => {
   const parts = name.trim().split(/\s+/).filter(Boolean);
@@ -269,14 +287,13 @@ function AiBanner({ collapsed, projectId }: AiBannerProps) {
 
   return (
     <div className={classes.aiBanner}>
-      <div className={`${classes.aiBannerIcon} ${classes.aiBannerIconStacked}`}>
-        <IconWand size={16} />
+      <div className={classes.aiBannerCard}>
+        <button type="button" onClick={handleClick} className={classes.aiBannerCta}>
+          <IconSparkles size={13} />
+          <span>Build with AI</span>
+        </button>
+        <div className={classes.aiBannerCap}>Tasks, boards, and workflows — from one prompt.</div>
       </div>
-      <div className={classes.aiBannerTitle}>AI Builder</div>
-      <div className={classes.aiBannerBody}>Tasks, boards, and workflows — connected, from one prompt.</div>
-      <button type="button" onClick={handleClick} className={classes.aiBannerCta}>
-        <IconSparkles size={13} />✦ Build with AI
-      </button>
     </div>
   );
 }
@@ -287,10 +304,12 @@ interface SidebarNavProps {
   groups: NavGroup[];
   collapsed: boolean;
   isAdmin: boolean;
+  collapsedGroups: Set<string>;
+  toggleGroup: (label: string) => void;
   onNavigate?: () => void;
 }
 
-function SidebarNav({ groups, collapsed, isAdmin, onNavigate }: SidebarNavProps) {
+function SidebarNav({ groups, collapsed, isAdmin, collapsedGroups, toggleGroup, onNavigate }: SidebarNavProps) {
   // Read the path from Inertia, not `window.location`. AuthLayout is a
   // persistent layout for project pages, so the sidebar can survive a visit
   // without re-rendering — reading `window.location.pathname` at render time
@@ -303,54 +322,68 @@ function SidebarNav({ groups, collapsed, isAdmin, onNavigate }: SidebarNavProps)
         const visibleItems = group.items.filter((item) => !item.adminOnly || isAdmin);
         if (visibleItems.length === 0) return null;
 
+        // In the icon rail, groups always show every icon — there's no room for a
+        // label to click, so per-group collapse only applies to the expanded sidebar.
+        const groupCollapsed = !collapsed && group.label !== undefined && collapsedGroups.has(group.label);
+
         return (
           <Fragment key={groupIdx}>
             {group.label && (
-              <div className={`${classes.navGroupLabel} ${collapsed ? classes.navGroupLabelCollapsed : ''}`}>
-                {group.label}
-              </div>
+              <button
+                type="button"
+                onClick={() => toggleGroup(group.label as string)}
+                aria-expanded={!groupCollapsed}
+                className={`${classes.navGroupLabel} ${collapsed ? classes.navGroupLabelCollapsed : ''}`}
+              >
+                <span>{group.label}</span>
+                <IconChevronDown
+                  size={12}
+                  className={`${classes.groupCaret} ${groupCollapsed ? classes.groupCaretCollapsed : ''}`}
+                />
+              </button>
             )}
-            {visibleItems.map((item, itemIdx) => {
-              const isActive = currentPath === item.path || currentPath.startsWith(item.path + '/');
-              const isOverview = groupIdx === 0 && itemIdx === 0 && !group.label;
+            {!groupCollapsed &&
+              visibleItems.map((item, itemIdx) => {
+                const isActive = currentPath === item.path || currentPath.startsWith(item.path + '/');
+                const isOverview = groupIdx === 0 && itemIdx === 0 && !group.label;
 
-              if (collapsed) {
-                const iconEl = <span className={classes.navItemIconCollapsed}>{item.icon}</span>;
+                if (collapsed) {
+                  const iconEl = <span className={classes.navItemIconCollapsed}>{item.icon}</span>;
+                  return (
+                    <Tooltip key={item.path} label={item.label} position="right" withArrow>
+                      <Link
+                        href={item.path}
+                        onClick={onNavigate}
+                        aria-label={item.label}
+                        aria-current={isActive ? 'page' : undefined}
+                        className={[
+                          isOverview ? classes.navOverview : classes.navItem,
+                          isOverview ? classes.navOverviewCollapsed : classes.navItemCollapsed,
+                          isActive ? (isOverview ? classes.navOverviewActive : classes.navItemActive) : '',
+                        ].join(' ')}
+                      >
+                        {iconEl}
+                      </Link>
+                    </Tooltip>
+                  );
+                }
+
                 return (
-                  <Tooltip key={item.path} label={item.label} position="right" withArrow>
-                    <Link
-                      href={item.path}
-                      onClick={onNavigate}
-                      aria-label={item.label}
-                      aria-current={isActive ? 'page' : undefined}
-                      className={[
-                        isOverview ? classes.navOverview : classes.navItem,
-                        isOverview ? classes.navOverviewCollapsed : classes.navItemCollapsed,
-                        isActive ? (isOverview ? classes.navOverviewActive : classes.navItemActive) : '',
-                      ].join(' ')}
-                    >
-                      {iconEl}
-                    </Link>
-                  </Tooltip>
+                  <Link
+                    key={item.path}
+                    href={item.path}
+                    onClick={onNavigate}
+                    aria-current={isActive ? 'page' : undefined}
+                    className={[
+                      isOverview ? classes.navOverview : classes.navItem,
+                      isActive ? (isOverview ? classes.navOverviewActive : classes.navItemActive) : '',
+                    ].join(' ')}
+                  >
+                    <span className={classes.navItemIcon}>{item.icon}</span>
+                    <span className={classes.navItemLabel}>{item.label}</span>
+                  </Link>
                 );
-              }
-
-              return (
-                <Link
-                  key={item.path}
-                  href={item.path}
-                  onClick={onNavigate}
-                  aria-current={isActive ? 'page' : undefined}
-                  className={[
-                    isOverview ? classes.navOverview : classes.navItem,
-                    isActive ? (isOverview ? classes.navOverviewActive : classes.navItemActive) : '',
-                  ].join(' ')}
-                >
-                  <span className={classes.navItemIcon}>{item.icon}</span>
-                  <span className={classes.navItemLabel}>{item.label}</span>
-                </Link>
-              );
-            })}
+              })}
           </Fragment>
         );
       })}
@@ -613,6 +646,20 @@ function SidebarContent({
 
   const navGroups = context === 'project' && projectId ? buildProjectNavGroups(projectId) : companyNavGroups;
 
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => readCollapsedGroups());
+  const toggleGroup = useCallback((label: string) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(label)) {
+        next.delete(label);
+      } else {
+        next.add(label);
+      }
+      writeCollapsedGroups(next);
+      return next;
+    });
+  }, []);
+
   return (
     <>
       <SidebarWorkspaceSwitcher
@@ -625,7 +672,14 @@ function SidebarContent({
       />
 
       <ScrollArea className={classes.scrollArea} type="never">
-        <SidebarNav groups={navGroups} collapsed={collapsed} isAdmin={isAdmin} onNavigate={onNavigate} />
+        <SidebarNav
+          groups={navGroups}
+          collapsed={collapsed}
+          isAdmin={isAdmin}
+          collapsedGroups={collapsedGroups}
+          toggleGroup={toggleGroup}
+          onNavigate={onNavigate}
+        />
       </ScrollArea>
 
       {currentUser?.needsAgentSetup && <AgentSetupNudge collapsed={collapsed} />}


### PR DESCRIPTION
## Summary
- Work / Resources / Admin nav group headers now toggle collapsed/expanded via a caret, persisted to `localStorage` across sessions (all groups expanded by default).
- The AI Builder sidebar card is compacted to an icon+label button plus a one-line caption, keeping the card outline — reclaims vertical space so the footer/bottom nav items stay reachable.
- Icon-rail collapse width moves from 52px to 60px to match the reference design.
- In the icon rail, all items stay visible regardless of per-group collapsed state (matches reference behavior).

Reference: design/dev handoff HTML colors, spacing, sizing taken from it; adapted to the app's existing `--app-*` theme tokens for dark/light support, since the reference is dark-only).

## Test plan
- [x] `docker compose exec -T web make check_all` green (rails-test, rubocop, brakeman, eslint, typescript, vitest)
- [x] New/updated vitest coverage in `AppSidebar.test.tsx`: group collapse/expand, persistence across remount, icon-rail ignoring per-group collapse state, updated AI Builder banner copy assertion
- [ ] Manual check in browser (light/dark, narrow viewport) recommended before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)