### PR TITLE
fix(observability): clear the actionable Sentry issues

### DIFF
--- a/app/controllers/api/v1/projects/board/tasks_controller.rb
+++ b/app/controllers/api/v1/projects/board/tasks_controller.rb
@@ -78,7 +78,7 @@ module Api
           # @summary List workflow runs for a board task
           def workflow_runs
             task = current_board.board_tasks.find(params[:id])
-            runs = task.workflow_runs.includes(:workflow).order(created_at: :desc)
+            runs = task.workflow_runs.includes(:workflow, step_runs: :step).order(created_at: :desc)
             render json: runs.map { |r| TaskWorkflowRunResource.new(r).to_h }
           end
 

--- a/app/controllers/web/company/projects/boards_controller.rb
+++ b/app/controllers/web/company/projects/boards_controller.rb
@@ -82,7 +82,9 @@ class Web::Company::Projects::BoardsController < Web::Company::Projects::Applica
       },
       task_workflow_runs: -> {
         next [] unless task
-        task.workflow_runs.includes(:workflow).order(created_at: :desc)
+        # step_runs: :step because the resource renders a row per step run; without the
+        # preload a task with a run history costs two queries per run.
+        task.workflow_runs.includes(:workflow, step_runs: :step).order(created_at: :desc)
             .map { |r| TaskWorkflowRunResource.new(r).to_h }
       },
       task_statistics: -> {

--- a/app/controllers/web/company/projects/sessions_controller.rb
+++ b/app/controllers/web/company/projects/sessions_controller.rb
@@ -118,9 +118,9 @@ class Web::Company::Projects::SessionsController < Web::Company::Projects::Appli
   # The Run Workflow drawer needs each workflow's steps to render the Custom
   # execution mode, so the list is shallow-serialized with them.
   def runnable_workflows
-    Workflow.visible_for_project(current_project).includes(:steps).map do |workflow|
+    Workflow.visible_for_project(current_project).includes(steps: :sub_steps).map do |workflow|
       WorkflowResource.new(workflow).to_h.merge(
-        steps: workflow.steps.not_deleted.map { |s| StepResource.new(s).to_h }
+        steps: workflow.visible_steps.map { |s| StepResource.new(s).to_h }
       )
     end
   end

--- a/app/controllers/web/company/projects/workflows_controller.rb
+++ b/app/controllers/web/company/projects/workflows_controller.rb
@@ -2,14 +2,16 @@
 
 class Web::Company::Projects::WorkflowsController < Web::Company::Projects::ApplicationController
   def index
+    # `steps: :sub_steps` because StepResource serializes the sub-steps of every step;
+    # `visible_steps` filters in Ruby so the preload survives (see Workflow#visible_steps).
     workflows = Workflow.visible_for_project(current_project)
-                        .includes(:steps, :runs)
+                        .includes(:runs, steps: :sub_steps)
 
     render inertia: "Projects/Workflows/WorkflowsPage", props: {
       project: project_props,
       workflows: workflows.map { |w|
         WorkflowResource.new(w).to_h.merge(
-          steps: w.steps.not_deleted.map { |s| StepResource.new(s).to_h }
+          steps: w.visible_steps.map { |s| StepResource.new(s).to_h }
         )
       },
       configured_agents: current_project_membership&.configured_agents || [],
@@ -42,7 +44,7 @@ class Web::Company::Projects::WorkflowsController < Web::Company::Projects::Appl
     render inertia: "Projects/Workflows/BuilderPage", props: {
       project: project_props,
       workflow: WorkflowResource.new(workflow).to_h,
-      steps: workflow.steps.not_deleted.map { |s| StepResource.new(s).to_h },
+      steps: workflow.visible_steps.map { |s| StepResource.new(s).to_h },
       read_only: workflow.scope_type == "Company",
       board_columns: current_project.board&.board_columns&.includes(column_workflow_binding: :workflow)&.map { |c|
         { id: c.id, name: c.name, bound_workflow_name: c.column_workflow_binding&.workflow&.name }

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -40,6 +40,15 @@ class Workflow < ApplicationRecord
     active.where(scope_type: "Project", scope_id: company.project_ids)
   }
 
+  # The steps a caller should render, preload-safe. `steps.not_deleted` builds a fresh
+  # relation, which throws away a preloaded `:steps` association and re-queries — one
+  # query per workflow on any page that lists workflows, plus one per step for
+  # `sub_steps`. Filtering the loaded records in Ruby keeps the preload (and its
+  # `default_scope` position order).
+  def visible_steps
+    association(:steps).loaded? ? steps.reject(&:deleted?) : steps.not_deleted.to_a
+  end
+
   def soft_delete!
     if column_workflow_bindings.any?
       bound = column_workflow_bindings.includes(board_column: { board: :project })

--- a/app/resources/task_workflow_run_resource.rb
+++ b/app/resources/task_workflow_run_resource.rb
@@ -25,7 +25,16 @@ class TaskWorkflowRunResource < ApplicationResource
   typelize "{ name: string; state: string; startedAt: string | null; finishedAt: string | null; " \
            "durationSeconds: number | null; terminalSessionId: number | null }[]"
   attribute :steps do |run|
-    (run.step_runs || []).includes(:step).order(:created_at).map do |sr|
+    # A caller that preloaded `step_runs: :step` gets no further queries; `.includes`
+    # here would discard that preload and re-query per run (an N+1 on the board, which
+    # renders this for every run of the selected task).
+    ordered = if run.association(:step_runs).loaded?
+      run.step_runs.sort_by(&:created_at)
+    else
+      run.step_runs.includes(:step).order(:created_at).to_a
+    end
+
+    ordered.map do |sr|
       dur = sr.started_at && sr.completed_at ? (sr.completed_at - sr.started_at).round : nil
       {
         name: sr.step&.name || "Step",

--- a/app/services/cloud_auth/aws_sso_client.rb
+++ b/app/services/cloud_auth/aws_sso_client.rb
@@ -59,7 +59,7 @@ module CloudAuth
         client_secret: resp.client_secret,
         expires_at: Time.zone.at(resp.client_secret_expires_at.to_i)
       )
-    rescue ::Aws::SSOOIDC::Errors::ServiceError => e
+    rescue ::Aws::SSOOIDC::Errors::ServiceError, ::Seahorse::Client::NetworkingError => e
       raise translate(e)
     end
 
@@ -80,7 +80,7 @@ module CloudAuth
         interval: resp.interval.to_i.clamp(1, 60),
         expires_in: resp.expires_in.to_i
       )
-    rescue ::Aws::SSOOIDC::Errors::ServiceError => e
+    rescue ::Aws::SSOOIDC::Errors::ServiceError, ::Seahorse::Client::NetworkingError => e
       raise translate(e)
     end
 
@@ -96,7 +96,7 @@ module CloudAuth
       build_token(resp)
     rescue ::Aws::SSOOIDC::Errors::AuthorizationPendingException, ::Aws::SSOOIDC::Errors::SlowDownException
       nil
-    rescue ::Aws::SSOOIDC::Errors::ServiceError => e
+    rescue ::Aws::SSOOIDC::Errors::ServiceError, ::Seahorse::Client::NetworkingError => e
       raise translate(e)
     end
 
@@ -108,7 +108,7 @@ module CloudAuth
         refresh_token: refresh_token
       )
       build_token(resp)
-    rescue ::Aws::SSOOIDC::Errors::ServiceError => e
+    rescue ::Aws::SSOOIDC::Errors::ServiceError, ::Seahorse::Client::NetworkingError => e
       raise translate(e)
     end
 
@@ -121,7 +121,7 @@ module CloudAuth
             Account.new(account_id: a.account_id, account_name: a.account_name, email: a.email_address)
           end
         end
-    rescue ::Aws::SSO::Errors::ServiceError => e
+    rescue ::Aws::SSO::Errors::ServiceError, ::Seahorse::Client::NetworkingError => e
       raise translate(e)
     end
 
@@ -129,7 +129,7 @@ module CloudAuth
       each_page(:list_account_roles) do |token|
         portal.list_account_roles({ access_token: access_token, account_id: account_id, next_token: token }.compact)
       end.flat_map { |page| page.role_list.map(&:role_name) }
-    rescue ::Aws::SSO::Errors::ServiceError => e
+    rescue ::Aws::SSO::Errors::ServiceError, ::Seahorse::Client::NetworkingError => e
       raise translate(e)
     end
 
@@ -144,7 +144,7 @@ module CloudAuth
         # The portal returns epoch MILLIseconds, not seconds.
         expiration: Time.zone.at(creds.expiration.to_i / 1000)
       )
-    rescue ::Aws::SSO::Errors::ServiceError => e
+    rescue ::Aws::SSO::Errors::ServiceError, ::Seahorse::Client::NetworkingError => e
       raise translate(e)
     end
 
@@ -190,6 +190,13 @@ module CloudAuth
     # Never leak a vendor exception class to callers, and never put a response body in
     # the message — an OIDC error body can echo back the code being exchanged.
     def translate(error)
+      # A networking failure carries no service code, and the overwhelmingly common cause
+      # is a mistyped region: the endpoint host for `us-2-west` never resolves. Say that,
+      # rather than surfacing `getaddrinfo` as a 500 the user cannot act on.
+      if error.is_a?(::Seahorse::Client::NetworkingError)
+        return Error.new("Could not reach AWS in region #{@region}. Check the region is a valid AWS region.")
+      end
+
       klass =
         case error
         when ::Aws::SSOOIDC::Errors::ExpiredTokenException then ExpiredError

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -6,6 +6,10 @@ Sentry.init do |config|
   config.environment = Rails.env
   config.enabled_environments = %w[production staging]
   config.breadcrumbs_logger = [ :active_support_logger, :http_logger ]
+  # A non-zero `exit` from `rails runner`/`rails db:*` unwinds as SystemExit and lands in
+  # Sentry as an unhandled crash in `bin/rails`. The exit status is the signal to whatever
+  # ran the command; it says nothing about the app, and it carries no useful stacktrace.
+  config.excluded_exceptions += %w[SystemExit]
   config.send_default_pii = true
   config.enable_logs = !running_console
   config.enabled_patches = running_console ? [] : [ :logger ]

--- a/test/integration/web/company/projects/workflows_controller_test.rb
+++ b/test/integration/web/company/projects/workflows_controller_test.rb
@@ -17,6 +17,31 @@ class Web::Company::Projects::WorkflowsControllerTest < ActionDispatch::Integrat
     assert_inertia_page "Projects/Workflows/WorkflowsPage"
   end
 
+  # This page reported an N+1 from production: the steps of every workflow, plus the
+  # sub-steps of every step, were fetched one query at a time. The preload makes it two
+  # queries whatever the workflow count, so the assertion is on the shape of the load,
+  # not on a total that any unrelated change would move.
+  test "index loads steps and sub steps in a fixed number of queries" do
+    create_list(:workflow, 3, scope: @project).each do |workflow|
+      create_list(:step, 2, workflow: workflow).each { |step| create(:sub_step, step: step) }
+    end
+
+    queries = []
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      queries << payload[:sql]
+    end
+
+    begin
+      get company_project_workflows_path(@project)
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    assert_response :success
+    assert_equal 1, queries.count { |sql| sql.match?(/FROM "steps"/) }, queries.grep(/FROM "steps"/).inspect
+    assert_equal 1, queries.count { |sql| sql.match?(/FROM "sub_steps"/) }, queries.grep(/FROM "sub_steps"/).inspect
+  end
+
   test "builder renders workflow builder" do
     wf = create(:workflow, scope: @project)
 

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -102,4 +102,27 @@ class WorkflowTest < ActiveSupport::TestCase
     wf = create(:workflow, scope: @project)
     assert_equal({}, wf.config)
   end
+
+  test "visible_steps drops soft-deleted steps in position order" do
+    wf = create(:workflow, scope: @project)
+    first = create(:step, workflow: wf, position: 1)
+    create(:step, workflow: wf, position: 2).soft_delete!
+    third = create(:step, workflow: wf, position: 3)
+
+    assert_equal [ first.id, third.id ], wf.reload.visible_steps.map(&:id)
+  end
+
+  test "visible_steps reads a preloaded association instead of re-querying it" do
+    wf = create(:workflow, scope: @project)
+    kept = create(:step, workflow: wf, position: 1)
+    create(:step, workflow: wf, position: 2).soft_delete!
+    create(:sub_step, step: kept)
+
+    preloaded = Workflow.where(id: wf.id).includes(steps: :sub_steps).first
+
+    assert_no_queries do
+      assert_equal [ kept.id ], preloaded.visible_steps.map(&:id)
+      assert_equal 1, preloaded.visible_steps.first.sub_steps.size
+    end
+  end
 end

--- a/test/resources/task_workflow_run_resource_test.rb
+++ b/test/resources/task_workflow_run_resource_test.rb
@@ -31,6 +31,17 @@ class TaskWorkflowRunResourceTest < ActiveSupport::TestCase
     assert_nil steps.first["terminalSessionId"]
   end
 
+  test "steps serialize a preloaded run without querying step_runs again" do
+    step = create(:step, workflow: @workflow, name: "Implementation")
+    create(:step_run, workflow_run: @run, step: step)
+
+    preloaded = WorkflowRun.where(id: @run.id).includes(:workflow, step_runs: :step).first
+
+    assert_no_queries do
+      assert_equal [ "Implementation" ], TaskWorkflowRunResource.new(preloaded).to_h["steps"].map { |s| s["name"] }
+    end
+  end
+
   test "steps keep creation order so the drawer can pick the most recent session" do
     first = create(:step_run, workflow_run: @run, step: create(:step, workflow: @workflow, name: "Analysis"),
                               terminal_session: create(:terminal_session, project: @project, user: @user))

--- a/test/services/cloud_auth/aws_sso_client_contract_test.rb
+++ b/test/services/cloud_auth/aws_sso_client_contract_test.rb
@@ -96,6 +96,20 @@ module CloudAuth
       assert_equal %w[sso:account:access], AwsSsoClient::SCOPES
     end
 
+    # A mistyped region (`us-2-west`) makes the endpoint host unresolvable, so the SDK
+    # raises a networking error rather than a service error. That must still arrive as a
+    # CloudAuth error naming the region — it used to escape as a 500 with `getaddrinfo`
+    # in it, which tells the user nothing about what they typed wrong.
+    test "an unreachable endpoint becomes a CloudAuth error naming the region" do
+      stub_request(:post, %r{oidc\.us-east-1\.amazonaws\.com}).to_raise(SocketError)
+
+      error = assert_raises(CloudAuth::Error) { client.register_client(client_name: "aixle") }
+
+      assert_match(/us-east-1/, error.message)
+      assert_match(/region/i, error.message)
+      assert_no_match(/getaddrinfo|Seahorse/, error.message)
+    end
+
     # -- portal pagination -----------------------------------------------------
     #
     # An organisation whose user is assigned to more accounts than one page holds gets a


### PR DESCRIPTION
Triage pass over the production Sentry queue (11 unresolved issues). This PR fixes the four with one obvious cause each; the remaining ones need a product/infra decision and are listed at the bottom.

## Fixed

| Issue | Symptom | Cause | Fix |
|---|---|---|---|
| [PALAD-AI-RAILS-2J](https://aixle-flow.sentry.io/issues/PALAD-AI-RAILS-2J) | N+1 on `WorkflowsController#index` (steps per workflow, sub-steps per step) | `w.steps.not_deleted` builds a fresh relation, discarding the preloaded `:steps`; `sub_steps` was never preloaded | `Workflow#visible_steps` filters loaded records in Ruby; preload widened to `steps: :sub_steps`. Same bug fixed in `#builder` and the Run Workflow drawer (`SessionsController#runnable_workflows`) |
| [PALAD-AI-RAILS-2D](https://aixle-flow.sentry.io/issues/PALAD-AI-RAILS-2D), [-2H](https://aixle-flow.sentry.io/issues/PALAD-AI-RAILS-2H) (601 events) | N+1 on `BoardsController#show`: `step_runs` + `steps` per workflow run | `TaskWorkflowRunResource` called `.includes(:step)` on each run's `step_runs`, so no caller could preload it away | Resource reads the preloaded association when there is one; both callers preload `step_runs: :step` |
| [PALAD-AI-RAILS-2B](https://aixle-flow.sentry.io/issues/PALAD-AI-RAILS-2B) | 500 on `POST /api/v1/cloud/aws_connection` — `getaddrinfo: oidc.us-2-west.amazonaws.com` | The user typed `us-2-west`. An unresolvable endpoint raises `Seahorse::Client::NetworkingError`, not a `ServiceError`, so it escaped the translation seam | Networking errors translate to `CloudAuth::Error` naming the region, and the existing `rescue_from` renders it as 422 |
| [PALAD-AI-RAILS-24](https://aixle-flow.sentry.io/issues/PALAD-AI-RAILS-24) | `SystemExit: exit` in `bin/rails` | A non-zero `exit` from `rails runner`/`rails db:*` unwinds as an unhandled exception | `SystemExit` added to `excluded_exceptions` |

## Tests

- `Workflow#visible_steps`: filtering, plus `assert_no_queries` on a preloaded workflow (steps *and* sub-steps)
- `TaskWorkflowRunResource`: `assert_no_queries` when the run was preloaded
- `WorkflowsController#index`: exactly one `steps` and one `sub_steps` query for 3 workflows x 2 steps — asserts the shape of the load, so it fails again if a preload is dropped
- `AwsSsoClient`: WebMock contract test that an unreachable endpoint raises `CloudAuth::Error` naming the region, with no `getaddrinfo`/`Seahorse` in the message

`docker compose exec -T web make check_all` — green (backend 92.15%, frontend 81.17%).

## Rest of the queue (no code change needed)

- **`ActiveRecord::ConnectionTimeoutError`** ([-25](https://aixle-flow.sentry.io/issues/PALAD-AI-RAILS-25), 64 events / 9 users; [-2E](https://aixle-flow.sentry.io/issues/PALAD-AI-RAILS-2E), 3 events) — **already fixed in infra, resolved in Sentry.** Every event predates `aixle-infra` 36ba1f4 (`RAILS_MAX_THREADS=10` on the Puma workloads, so the pool is 13 instead of a default 5 under 10 threads), deployed 2026-08-07 14:25 UTC. The last burst is 2026-08-07 10:10 UTC; nothing in the 11 days since.
- **[-2F](https://aixle-flow.sentry.io/issues/PALAD-AI-RAILS-2F) / [-2G](https://aixle-flow.sentry.io/issues/PALAD-AI-RAILS-2G)** (`Integration#scope_type`, `workflows.project_id`) — ad-hoc `rails runner` scripts written against columns that do not exist. Not app bugs; **resolved in Sentry.**
- **`Oauth::ReauthRequired` killing container phases** ([TEMPORAL-J](https://aixle-flow.sentry.io/issues/PALAD-AI-TEMPORAL-J) "connect required", [-K](https://aixle-flow.sentry.io/issues/PALAD-AI-TEMPORAL-K) "reauthorization required") — 3 events total, all on 2026-08-06, one release. A dead or missing MCP OAuth credential fails the session at `before_exec`, after session-start preflight already passed. Decision: **keep hard-failing for now**; revisit if it recurs at volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
