### PR TITLE
docs(product): user guide outline and changelog product-area snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to Aixle Flow are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/) once
-tagged releases begin.
+tagged releases begin. User-visible entries are tagged with a product area from
+[docs/product/changelog-product-areas.md](docs/product/changelog-product-areas.md).
 
 > Versioning and tagged releases begin with the open-source launch. The first
 > tag will be **`v0.1.0`** (the project is pre-1.0), cut from the *Unreleased*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to Aixle Flow are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/) once
-tagged releases begin. User-visible entries are tagged with a product area from
-[docs/product/changelog-product-areas.md](docs/product/changelog-product-areas.md).
+tagged releases begin. Entries a *user* sees in the product carry a product
+area from
+[docs/product/changelog-product-areas.md](docs/product/changelog-product-areas.md)
+as their prefix; repository-level entries a *contributor* needs — licensing,
+governance, community health — carry none.
 
 > Versioning and tagged releases begin with the open-source launch. The first
 > tag will be **`v0.1.0`** (the project is pre-1.0), cut from the *Unreleased*
@@ -19,7 +22,7 @@ tagged releases begin. User-visible entries are tagged with a product area from
   inventory (`THIRD-PARTY-LICENSES.md`, `NOTICES.md`).
 - Contributor model: Contributor License Agreement (`CLA.md`) and Developer
   Certificate of Origin (`DCO`) sign-off, documented in `CONTRIBUTING.md`.
-- Public documentation portal at `/docs`.
+- **Docs**: public documentation portal at `/docs`.
 - Open-source documentation layer: README, ROADMAP, quickstart, user guide, and
   reference content.
 - Community health files: Code of Conduct, Security Policy, Governance, issue

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,11 @@ The active workflow: a research report in `research/` feeds a frozen-intent spec
   - **[implementation-artifacts/spec-session-terminal-replay.md](./implementation-artifacts/spec-session-terminal-replay.md)** — Session terminal replay
   - **[implementation-artifacts/40-1-workflow-builder-ux-redesign.md](./implementation-artifacts/40-1-workflow-builder-ux-redesign.md)** — Workflow builder full UX redesign (story 40.1, shipped): tab layout, step editor sections, Base Resources move. Older BMAD story format, moved here from the retired `ai/` tree
 
+## Product
+
+- **[product/user-guide-outline.md](./product/user-guide-outline.md)** — Outline of the end-user product guide: the board → workflow → agent → results loop, section-by-section skeleton following the product sidebar, two end-to-end stories, terminology notes (issue #550)
+- **[product/changelog-product-areas.md](./product/changelog-product-areas.md)** — Frozen user-facing product map used as the changelog taxonomy: named product areas, changelog rules, snapshot baseline (issue #551)
+
 ## Strategy
 
 - **[strategy/](./strategy/)** — Business / open-source strategy documents

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,25 @@ The active workflow: a research report in `research/` feeds a frozen-intent spec
 ## Product
 
 - **[product/user-guide-outline.md](./product/user-guide-outline.md)** — Outline of the end-user product guide: the board → workflow → agent → results loop, section-by-section skeleton following the product sidebar, two end-to-end stories, terminology notes (issue #550)
-- **[product/changelog-product-areas.md](./product/changelog-product-areas.md)** — Frozen user-facing product map used as the changelog taxonomy: named product areas, changelog rules, snapshot baseline (issue #551)
+- **[product/changelog-product-areas.md](./product/changelog-product-areas.md)** — Frozen user-facing product map used as the changelog taxonomy: named product areas, changelog rules, area → guide-chapter map, snapshot baseline (issue #551)
+
+## Operator documentation
+
+The repository mirror of the in-app portal served at `/docs`
+(`app/frontend/pages/Docs/data/pages/`). Written for people installing and
+running Flow — the product-level guide outlined above is a separate document set.
+
+- **[user-guide/index.md](./user-guide/index.md)** — Entry point: the board → workflow → agent loop and the mental model
+- **[user-guide/board.md](./user-guide/board.md)** — Projects, columns, cards, and column → workflow bindings
+- **[user-guide/workflows.md](./user-guide/workflows.md)** — DAG steps, retries, approval gates, parallel runs
+- **[user-guide/agents.md](./user-guide/agents.md)** — Personas, the container, and how session context is built
+- **[user-guide/runtimes.md](./user-guide/runtimes.md)** — The five agent CLIs, their images, credentials, and cost tracking
+- **[user-guide/tools.md](./user-guide/tools.md)** — Tool kinds, execution modes, built-in board tools, resource resolution
+- **[user-guide/mcp.md](./user-guide/mcp.md)** — MCP transports, the internal `aixle-tools` server, config-item credentials
+- **[user-guide/integrations.md](./user-guide/integrations.md)** — GitHub, GitLab, Linear, Google OAuth, and webhooks
+- **[user-guide/configuration.md](./user-guide/configuration.md)** — Env vars, OAuth, agent credentials, and other knobs
+- **[quickstart.md](./quickstart.md)** — Get a local instance running and see one card move
+- **[reference/index.md](./reference/index.md)** — Reference set: [API](./reference/api.md), [CLI](./reference/cli.md), [configuration](./reference/configuration.md)
 
 ## Strategy
 
@@ -73,4 +91,4 @@ The active workflow: a research report in `research/` feeds a frozen-intent spec
 ## Related documentation elsewhere
 
 - `references/aixle-system-reference.md` — agent-facing platform reference (domain model, runtimes, container layout)
-- `app/frontend/pages/Docs/data/pages/` — end-user product docs rendered in the app
+- `app/frontend/pages/Docs/data/pages/` — the source the `/docs` portal renders; mirrored in this tree under [user-guide/](./user-guide/) and [reference/](./reference/)

--- a/docs/product/changelog-product-areas.md
+++ b/docs/product/changelog-product-areas.md
@@ -26,14 +26,15 @@ Supported agent runtimes: Claude Code, Cursor CLI, Codex, Gemini CLI, Grok.
 ## Product areas (changelog taxonomy)
 
 Use the names in **bold** in changelog entries. They match what people see in
-the product.
+the product — or, where no single sidebar label exists (sign-in, triggers),
+they name a flow users would recognize.
 
 ### Workspace
 
 | Area | What it covers |
 | --- | --- |
 | **Companies & projects** | Workspaces, switching between companies, creating and listing projects |
-| **Sign-in & onboarding** | Login, invitations, first-run setup, role, language |
+| **Sign-in & onboarding** | Login, invitations, first-run setup: role, language, connecting an agent |
 | **Profile** | Personal agent credentials (connecting a runtime account), personal usage, personal access so Aixle can be used from an external agent |
 
 ### Project — Work
@@ -42,7 +43,7 @@ the product.
 | --- | --- |
 | **Overview** | Project home: activity, task distribution, spend, workflow run status |
 | **Tasks** | The board: columns, cards, subtasks, comments, attachments, waits, activity. Column → workflow binding (auto or manual). Board templates (Simple Kanban, Dev Team, Full SDLC) offered on an empty board |
-| **Workflows** | Named processes made of steps: instructions, which agent runs, dependencies, on-failure behaviour (fail / retry / skip), human approval, inputs/outputs. Publishing and duplicating |
+| **Workflows** | Named processes made of steps: instructions, which agent runs, dependencies, on-failure behavior (fail / retry / skip), human approval, inputs/outputs. Publishing and duplicating |
 | **Triggers & gates** | When a workflow starts (task enters column, manual run, schedule, Slack message, inbound webhook) and what can pause a run (waiting on a check or a person) |
 | **Runs** | Workflow runs, live and past: step timeline, parallel waves, approve / retry / skip, cost |
 | **Sessions** | Individual agent sessions: status, log, cost, tokens, artifacts |
@@ -63,7 +64,7 @@ the product.
 
 | Area | What it covers |
 | --- | --- |
-| **Secrets & variables** | Credentials and config values agents and connectors use |
+| **Secrets & Variables** | Credentials and config values agents and connectors use |
 | **Members** | Who is on the project and with what access (roles: Admin, Employee, Viewer) |
 | **Analytics** | Spend, sessions, tokens, success — by project, agent, and source |
 | **Settings** | Project name, language, archive, delete |
@@ -88,7 +89,7 @@ the product.
 
 | Area | What it covers |
 | --- | --- |
-| **Docs** | Product documentation at `/docs` (linked from the public site) |
+| **Docs** | The in-product documentation, linked from the public site as **Documentation** |
 
 ## How the pieces fit (for changelog writers)
 

--- a/docs/product/changelog-product-areas.md
+++ b/docs/product/changelog-product-areas.md
@@ -1,0 +1,119 @@
+# Aixle Flow Product Snapshot — Changelog Taxonomy
+
+> Deliverable for issue #551. A user-facing map of Aixle Flow as it exists
+> today, frozen as the changelog taxonomy: after a release, every user-visible
+> change is tagged with one **product area** from the tables below, so each
+> release reads as a change to a named part of the product — not as a list of
+> tickets.
+>
+> **Snapshot date:** 2026-08-17. Area names are verified against the product
+> UI (sidebar labels and page titles), not internal engineering names.
+
+## What Aixle Flow is
+
+Aixle Flow is the team layer on top of personal AI coding agents. A person puts
+work on a board. An agent picks it up, does the work, and the team sees the
+run, the output, and the cost — without anyone opening a terminal.
+
+A **Company** is the workspace. Inside it, each **Project** has one board. Move
+a card into a column that is bound to a workflow, and the workflow starts. A
+workflow is a sequence of steps; each step is one agent doing one job. Steps
+can run in parallel, wait for each other, retry, or pause for a human. Every
+run leaves a trail: status, log, artifacts, tokens, and cost.
+
+Supported agent runtimes: Claude Code, Cursor CLI, Codex, Gemini CLI, Grok.
+
+## Product areas (changelog taxonomy)
+
+Use the names in **bold** in changelog entries. They match what people see in
+the product.
+
+### Workspace
+
+| Area | What it covers |
+| --- | --- |
+| **Companies & projects** | Workspaces, switching between companies, creating and listing projects |
+| **Sign-in & onboarding** | Login, invitations, first-run setup, role, language |
+| **Profile** | Personal agent credentials (connecting a runtime account), personal usage, personal access so Aixle can be used from an external agent |
+
+### Project — Work
+
+| Area | What it covers |
+| --- | --- |
+| **Overview** | Project home: activity, task distribution, spend, workflow run status |
+| **Tasks** | The board: columns, cards, subtasks, comments, attachments, waits, activity. Column → workflow binding (auto or manual). Board templates (Simple Kanban, Dev Team, Full SDLC) offered on an empty board |
+| **Workflows** | Named processes made of steps: instructions, which agent runs, dependencies, on-failure behaviour (fail / retry / skip), human approval, inputs/outputs. Publishing and duplicating |
+| **Triggers & gates** | When a workflow starts (task enters column, manual run, schedule, Slack message, inbound webhook) and what can pause a run (waiting on a check or a person) |
+| **Runs** | Workflow runs, live and past: step timeline, parallel waves, approve / retry / skip, cost |
+| **Sessions** | Individual agent sessions: status, log, cost, tokens, artifacts |
+| **Assets** | Files the team uploads and files agents produce; versioning and review |
+
+### Project — Resources
+
+| Area | What it covers |
+| --- | --- |
+| **Agents** | Personas (who the agent is, how it talks, what rules it follows). The same persona can run on any supported runtime |
+| **Wrappers** | Custom tools the team writes so agents can call services that have no connector |
+| **Skills** | Reusable know-how installed from a catalog or written by hand |
+| **Connectors** | External tool servers agents can call, from a catalog or added by hand |
+| **Repositories** | Linked Git repos the agent can work in and push to |
+| **Integrations** | GitHub, GitLab, Linear, and similar connections |
+
+### Project — Admin
+
+| Area | What it covers |
+| --- | --- |
+| **Secrets & variables** | Credentials and config values agents and connectors use |
+| **Members** | Who is on the project and with what access (roles: Admin, Employee, Viewer) |
+| **Analytics** | Spend, sessions, tokens, success — by project, agent, and source |
+| **Settings** | Project name, language, archive, delete |
+
+### Build with AI
+
+| Area | What it covers |
+| --- | --- |
+| **Aixle Builder** | Describe a process in plain language; the product creates workflows, steps, tools, and board setup. (Sidebar entry point is labeled "AI Builder" / "Build with AI"; the feature's pages are titled "Aixle Builder" — this taxonomy uses **Aixle Builder**) |
+
+### Company library & monitoring
+
+| Area | What it covers |
+| --- | --- |
+| **Workflow Catalog** | Shared workflows the team can copy into a project |
+| **Company analytics** | Spend and activity across projects (admins) |
+| **Company sessions** | Cross-project run visibility (admins) |
+| **Company assets** | Workspace-level files (admins) |
+| **Company members** | Who belongs to the company |
+
+### Help
+
+| Area | What it covers |
+| --- | --- |
+| **Docs** | Product documentation at `/docs` (linked from the public site) |
+
+## How the pieces fit (for changelog writers)
+
+Tasks (board) → card enters a bound column → Workflow starts → each Step is one
+Agent session → results, status, and cost come back to the board, to Runs, and
+to Sessions.
+
+Agents do not work in a vacuum. A run can receive: the card (title,
+description, comments, files, column purpose), workflow instructions, skills,
+wrappers, connectors, repositories, and secrets.
+
+## Changelog rules
+
+1. One entry maps to **one product area** from the tables above. If a change
+   spans two areas, split it or pick the one users notice first.
+2. Write for a user who never opens a terminal. Say what they can do now, not
+   how it was built.
+3. Preferred shape: **Added / Changed / Fixed / Removed** × product area, e.g.
+   `Added — Tasks: attach files directly to a card`.
+4. Do not mention implementation. If the only change is internal and users
+   cannot see it, it does not belong in the product changelog.
+5. Keep this snapshot as the baseline. When a release adds a new area (a new
+   nav item or a new first-class object), update this snapshot in the same
+   change as the changelog entry.
+
+## Out of scope
+
+Internals, APIs, ops, and anything not visible in the product.

--- a/docs/product/changelog-product-areas.md
+++ b/docs/product/changelog-product-areas.md
@@ -6,8 +6,9 @@
 > release reads as a change to a named part of the product — not as a list of
 > tickets.
 >
-> **Snapshot date:** 2026-08-17. Area names are verified against the product
-> UI (sidebar labels and page titles), not internal engineering names.
+> **Snapshot date:** 2026-08-20. Area names are verified against the product
+> UI on `develop` (sidebar labels, page titles, and on-screen control copy),
+> not internal engineering names.
 
 ## What Aixle Flow is
 
@@ -44,9 +45,8 @@ they name a flow users would recognize.
 | **Overview** | Project home: activity, task distribution, spend, workflow run status |
 | **Tasks** | The board: columns, cards, subtasks, comments, attachments, waits, activity. Column → workflow binding (auto or manual). Board templates (Simple Kanban, Dev Team, Full SDLC) offered on an empty board |
 | **Workflows** | Named processes made of steps: instructions, which agent runs, dependencies, on-failure behavior (fail / retry / skip), human approval, inputs/outputs. Publishing and duplicating |
-| **Triggers & gates** | When a workflow starts (task enters column, manual run, schedule, Slack message, inbound webhook) and what can pause a run (waiting on a check or a person) |
-| **Runs** | Workflow runs, live and past: step timeline, parallel waves, approve / retry / skip, cost |
-| **Sessions** | Individual agent sessions: status, log, cost, tokens, artifacts |
+| **Triggers & gates** | When a workflow starts (task enters column, manual run, schedule, Slack message, incoming webhook) and what can pause a run: a gate waiting on CI (waiting / passed / failed / stale) or a step waiting on a person |
+| **Sessions & Runs** | One list for both: workflow runs (step timeline, parallel waves, approve / retry / skip, cost) and the agent sessions inside them (status, live terminal, log, tokens, artifacts, cost) |
 | **Assets** | Files the team uploads and files agents produce; versioning and review |
 
 ### Project — Resources
@@ -58,7 +58,7 @@ they name a flow users would recognize.
 | **Skills** | Reusable know-how installed from a catalog or written by hand |
 | **Connectors** | External tool servers agents can call, from a catalog or added by hand |
 | **Repositories** | Linked Git repos the agent can work in and push to |
-| **Integrations** | GitHub, GitLab, Linear, and similar connections |
+| **Integrations** | Connected accounts: GitHub, GitLab, Linear, Slack, Coder |
 
 ### Project — Admin
 
@@ -94,8 +94,8 @@ they name a flow users would recognize.
 ## How the pieces fit (for changelog writers)
 
 Tasks (board) → card enters a bound column → Workflow starts → each Step is one
-Agent session → results, status, and cost come back to the board, to Runs, and
-to Sessions.
+Agent session → results, status, and cost come back to the board and to
+Sessions & Runs.
 
 Agents do not work in a vacuum. A run can receive: the card (title,
 description, comments, files, column purpose), workflow instructions, skills,
@@ -111,9 +111,43 @@ wrappers, connectors, repositories, and secrets.
    `Added — Tasks: attach files directly to a card`.
 4. Do not mention implementation. If the only change is internal and users
    cannot see it, it does not belong in the product changelog.
-5. Keep this snapshot as the baseline. When a release adds a new area (a new
+5. Repository-level changes that a *contributor* must know about — licensing,
+   governance, community health files, contribution rules — stay in
+   `CHANGELOG.md` untagged. They are not product areas, and forcing one on
+   them would be a lie about where the change shows up.
+6. Keep this snapshot as the baseline. When a release adds a new area (a new
    nav item or a new first-class object), update this snapshot in the same
-   change as the changelog entry.
+   change as the changelog entry — and add the matching chapter to
+   [user-guide-outline.md](./user-guide-outline.md).
+
+## Area → guide chapter
+
+Every area above is documented in one chapter of
+[user-guide-outline.md](./user-guide-outline.md). Keep the two in step.
+
+| Area | Chapter |
+| --- | --- |
+| Companies & projects | 20. The company workspace |
+| Sign-in & onboarding | 2. Your first session |
+| Profile | 2. Your first session |
+| Overview | 4. Overview |
+| Tasks | 5. Tasks — the board |
+| Workflows | 6. Workflows |
+| Triggers & gates | 7. Triggers & gates |
+| Sessions & Runs | 8. Sessions & Runs |
+| Assets | 9. Assets |
+| Agents | 10. Agents |
+| Wrappers | 11. Wrappers |
+| Skills | 12. Skills |
+| Connectors | 13. Connectors |
+| Repositories, Integrations | 14. Repositories & Integrations |
+| Aixle Builder | 15. AI Builder |
+| Members | 16. Team |
+| Secrets & Variables | 17. Secrets & Variables |
+| Analytics | 18. Analytics |
+| Settings | 19. Settings |
+| Workflow Catalog, Company analytics / sessions / assets / members | 20. The company workspace |
+| Docs | Not a chapter — the operator portal at `/docs` is a separate document set |
 
 ## Out of scope
 

--- a/docs/product/user-guide-outline.md
+++ b/docs/product/user-guide-outline.md
@@ -15,9 +15,14 @@ they know how agents, containers, or orchestration work.
   what the person does · what they see afterwards.*
 - Use the names from the product UI, not internal engineering names
   (see [Terminology notes](#terminology-notes) at the end).
-- The existing in-app documentation (linked from the public site as
-  **Documentation**) is too technical for this guide — do not reuse its
-  structure or copy.
+- The existing documentation — the in-app portal at `/docs`, mirrored in the
+  repository as [`docs/user-guide/`](../user-guide/) — is written for people
+  installing and operating Flow: it is too technical for this guide. Do not
+  reuse its structure or copy; link to it only where a reader needs the
+  operator-level detail.
+- Every area named in
+  [changelog-product-areas.md](./changelog-product-areas.md) has a chapter
+  here. If a release adds an area, add the chapter in the same change.
 
 ---
 
@@ -46,10 +51,14 @@ The reader goes from an invite email to their first open project.
   for viewer-only users).
 - **Connect an agent.** During onboarding — or any time later in **Profile** —
   connect the account of the agent product you already use (Claude Code,
-  Cursor CLI, Codex, Gemini CLI, or Grok). Nothing can run on your behalf
-  until this is done — say this plainly and early.
-- **Your Profile.** Besides agent credentials, Profile shows your personal
-  usage and personal settings.
+  Cursor CLI, Codex, Gemini CLI, or Grok). Connecting happens in a terminal
+  embedded in the page: the product starts a session, you complete the
+  runtime's own login in it, and the credential is stored for you. Nothing can
+  run on your behalf until this is done — say this plainly and early.
+- **Your Profile.** Three tabs: **Account** (agent credentials and personal
+  settings), **Usage** (your own sessions, tokens, spend, and any limits that
+  apply to you), and **MCP** (personal access, so an agent you run outside
+  Aixle — your own Claude Code, for example — can reach your Aixle projects).
 - **Find your work.** Open **Projects**, pick a project, land on **Overview**.
 - **More than one company?** The workspace switcher moves you between
   companies; each company has its own projects, members, and analytics.
@@ -64,15 +73,27 @@ the guide hangs off this chapter.
 1. Open **Tasks** and create a card (or pick one up from the backlog).
 2. Move the card into a column bound to a workflow — the workflow starts
    automatically, or from a button if the column is set to manual.
-3. Watch progress in **Runs** and **Sessions**: live status, the log as the
-   agent works, cost accumulating.
+3. Watch progress in **Sessions & Runs**: live status, the agent's terminal as
+   it works, cost accumulating.
 4. Review what came back: files in **Assets**, results and comments on the
    card.
 5. Move the card forward — or send it back with a comment and run again.
 
 - *Afterwards:* the reader has seen the whole product once, end to end.
 
-## 4. Tasks — the board
+## 4. Overview
+
+- **What it is.** The project's home page: recent activity, how tasks are
+  distributed across the board, workflow runs, sessions launched, success rate,
+  and total spend.
+- **When to use it.** The daily "what is this project doing right now, and what
+  is it costing" check — before drilling into a specific run.
+- **What you do.** Read the tiles; follow one into Tasks, Sessions & Runs, or
+  Analytics.
+- *Afterwards:* the reader knows where the numbers on this page come from and
+  which screen answers the next question.
+
+## 5. Tasks — the board
 
 - **What it is.** The project's board: columns, cards, subtasks, comments,
   attachments.
@@ -85,10 +106,12 @@ the guide hangs off this chapter.
   **Simple Kanban** (Backlog / In Progress / Done), **Dev Team** (a
   seven-column engineering flow), or **Full SDLC** (the long form) — and
   customize columns later.
+- **Reading a card at a glance.** A card carries chips for its runs and for any
+  checks it is waiting on (see [Triggers & gates](#7-triggers--gates)).
 - *Afterwards:* cards carry their own history — comments, attachments, runs,
   and activity.
 
-## 5. Workflows
+## 6. Workflows
 
 - **What it is.** A named process made of ordered **steps**; each step is one
   agent session doing one job.
@@ -99,29 +122,45 @@ the guide hangs off this chapter.
   parallel); choose what happens on failure (fail, retry, or skip); mark where
   a person must approve before the run continues. Publish it, duplicate it, or
   copy a ready-made one from the **Workflow Catalog**.
-- **How it starts.** From the board (a card enters a bound column), from the
-  workflow itself (Run), on a schedule, from a Slack message, or from an
-  inbound webhook.
 - *Afterwards:* the workflow appears as an option when binding columns, and
   every run of it is tracked.
 
-## 6. Sessions & Runs
+## 7. Triggers & gates
 
-Two sidebar pages, one chapter: **Runs** is workflow runs; **Sessions** is
-individual agent sessions (each step of a run is one session, and sessions can
-also run on their own).
+Two halves of the same question: what starts a run, and what holds one up.
+
+- **What it is.** **Triggers** are the ways a workflow begins: a task enters a
+  bound column, someone runs it by hand, a schedule fires, a Slack message
+  matches, or an external system posts to an incoming webhook. **Gates** are
+  checks a card waits on — typically CI — before work moves on.
+- **When to use it.** Triggers: whenever a process should start without anyone
+  remembering to press a button. Gates: whenever "the tests must be green"
+  belongs in the process rather than in someone's head.
+- **What you do.** Add a trigger to a workflow and pick its kind; for a column
+  trigger, choose Auto or Manual. Watch a gate on the card: it reads
+  **waiting** while CI runs, then **passed**, **failed**, or **stale** when CI
+  never reported at all.
+- *Afterwards:* work starts on its own, and a card that is blocked says what it
+  is blocked on instead of silently sitting still.
+
+## 8. Sessions & Runs
+
+One sidebar item, one chapter. **Runs** are workflow runs; **sessions** are the
+individual agent sessions inside them (each step of a run is one session, and
+sessions can also run on their own). They share a single list.
 
 - **What it is.** Live and past agent work.
 - **When to use it.** To answer "what is happening right now?" and "what
   happened, what did it produce, what did it cost?"
 - **What you do.** Open a run to see its steps, which ran in parallel, and
-  where it is waiting; approve a step that waits for a person
-  (**Approve & Continue**); retry or skip a step; open a session to read the
-  full log.
+  where it is waiting; watch a running step's terminal live, embedded in the
+  page (it shows *Session starting…* until the agent's container is ready);
+  approve a step that waits for a person (**Approve & continue**); retry or
+  skip a step; open a finished session to read its full log.
 - *Afterwards:* every run leaves a trail — status, log, artifacts, tokens, and
   cost.
 
-## 7. Assets
+## 9. Assets
 
 - **What it is.** Files: what the team uploads and what agents produce.
 - **When to use it.** Give agents input material; collect and review what they
@@ -131,7 +170,7 @@ also run on their own).
 - *Afterwards:* outputs are reviewable in one place instead of scattered
   across runs.
 
-## 8. Agents
+## 10. Agents
 
 - **What it is.** Reusable personas: who the agent is, how it talks, what
   rules it follows. A persona is not a product choice — the same persona can
@@ -146,7 +185,7 @@ also run on their own).
 - *Afterwards:* steps reference personas by name, and changing a persona
   changes every workflow that uses it.
 
-## 9. Wrappers
+## 11. Wrappers
 
 - **What it is.** A way to turn a script or an API into something an agent can
   call, when no connector exists for that service.
@@ -156,7 +195,7 @@ also run on their own).
 - *Afterwards:* the wrapper shows up in run logs as a capability the agents
   actually called.
 
-## 10. Skills
+## 12. Skills
 
 - **What it is.** Packaged instructions an agent can load during a session —
   know-how, not tools.
@@ -166,7 +205,7 @@ also run on their own).
   attach it where it should be available.
 - *Afterwards:* agents follow the skill's instructions when the work matches.
 
-## 11. Connectors
+## 13. Connectors
 
 - **What it is.** Connections that give agents extra tools — issue trackers
   and other external services.
@@ -176,11 +215,11 @@ also run on their own).
 - *Afterwards:* the connected service's actions appear among what agents can
   do.
 
-## 12. Repositories & Integrations
+## 14. Repositories & Integrations
 
 - **What it is.** **Repositories** are the Git repos agents work in and push
-  to. **Integrations** connect GitHub, GitLab — and Linear and Slack where
-  available.
+  to. **Integrations** are the accounts Flow connects to on the team's behalf:
+  GitHub, GitLab, Linear, Slack, and Coder.
 - **When to use it.** Any workflow that should read code, open pull requests,
   or touch tickets.
 - **What you do.** Connect the integration, link the repositories the project
@@ -188,7 +227,7 @@ also run on their own).
 - *Afterwards:* runs can produce branches and pull requests in your own
   repos, and tickets can flow both ways.
 
-## 13. AI Builder
+## 15. AI Builder
 
 - **What it is.** Describe a process in plain language; the product builds the
   tasks, board setup, and workflows from that prompt. (This guide uses **AI
@@ -198,11 +237,12 @@ also run on their own).
 - **When to use it.** Setting up a new process — instead of configuring
   columns, workflows, and steps by hand.
 - **What you do.** Write what you want to automate; review what the builder
-  proposes; accept, then adjust by hand where needed.
+  proposes; accept, then adjust by hand where needed. While it works you can
+  watch its terminal, and open its workspace in an editor.
 - *Afterwards:* the board and workflows exist and are editable like anything
   built manually.
 
-## 14. Team
+## 16. Team
 
 - **What it is.** **Members** at two levels: who is in the company, and who is
   on each project.
@@ -213,7 +253,7 @@ also run on their own).
 - *Afterwards:* each person sees what their role allows — admins additionally
   see company-wide analytics and sessions.
 
-## 15. Secrets & Variables
+## 17. Secrets & Variables
 
 - **What it is.** Values agents and connectors need at runtime — credentials
   and configuration — kept out of task text and workflow instructions.
@@ -221,7 +261,7 @@ also run on their own).
 - **What you do.** Add the value once, name it, reference it where needed.
 - *Afterwards:* runs use the value without anyone pasting it into a card.
 
-## 16. Analytics
+## 18. Analytics
 
 - **What it is.** Usage and cost: spend, sessions, tokens, success — by
   project, agent, and source.
@@ -232,7 +272,18 @@ also run on their own).
 - *Afterwards:* cost conversations happen with numbers, per project and per
   company.
 
-## 17. The company workspace
+## 19. Settings
+
+- **What it is.** The project's own settings: its name, its language, and the
+  end of its life — archive or delete.
+- **When to use it.** Renaming a project, changing the language agents write
+  in, retiring a project that is finished.
+- **What you do.** Edit and save; archive when work stops; delete when nothing
+  should remain. Say plainly what delete takes with it.
+- *Afterwards:* an archived project is out of the way without losing its
+  history.
+
+## 20. The company workspace
 
 Round off with the shared layer above projects.
 
@@ -258,9 +309,11 @@ A lead links a repository (Integrations → Repositories), binds the
 and writes a card describing a small feature. They drag the card into the
 column. The workflow starts: one step plans, two parallel steps implement and
 write tests, a final step waits for a human. The lead watches the run in
-**Runs**, reads the diff summary the agent posted to the card, approves the
-waiting step — and a pull request appears in the linked repo. The cost of the
-whole run is on the card and in Analytics.
+**Sessions & Runs** — the implementing step's terminal live on the page — reads
+the diff summary the agent posted to the card, approves the waiting step, and a
+pull request appears in the linked repo. The card's CI gate goes from
+**waiting** to **passed**. The cost of the whole run is on the card and in
+Analytics.
 
 ### Story 2 — build a workflow from one prompt
 
@@ -268,8 +321,8 @@ An operator opens **AI Builder** and types: "When a card lands in *Triage*,
 summarize it, label it, and draft a reply for review." The builder proposes a
 board column, a three-step workflow, and the connector it needs. The operator
 accepts, adds the connector credential in **Secrets & Variables**, and drops a
-test card into *Triage*. The run appears in **Runs**; the draft reply lands on
-the card as a comment — written by an agent, reviewed by a person.
+test card into *Triage*. The run appears in **Sessions & Runs**; the draft reply
+lands on the card as a comment — written by an agent, reviewed by a person.
 
 ---
 
@@ -281,10 +334,13 @@ from each other. Verified against the product as of 2026-08.
 | Guide term | On screen |
 | --- | --- |
 | Tasks | Sidebar item **Tasks**; the page itself is titled **Board** |
-| Sessions & Runs | Two sidebar items: **Runs** and **Sessions** |
-| AI Builder | Sidebar banner **AI Builder** with button **Build with AI**; the feature's own pages are titled **Aixle Builder** |
+| Sessions & Runs | One sidebar item, **Sessions & Runs**: agent sessions and workflow runs share a single list. The standalone **Sessions** item in the company nav is the cross-project, admin-only view |
+| AI Builder | Sidebar card **AI Builder** with button **Build with AI**; the feature's own pages are titled **Aixle Builder** |
 | Board templates | Offered on an empty board (not at project creation); UI says "template" (**Use this template**), preset names **Simple Kanban**, **Dev Team**, **Full SDLC** |
-| Workflow start | Trigger labels on screen: **Task enters column** (Auto or Manual mode), **On schedule**, **Slack message**, **Inbound webhook** — plus running by hand from the workflow or task |
+| Workflow start | Trigger labels on screen: **Task enters column** (Auto or Manual mode), **On schedule**, **Slack message**, **Incoming webhook** — plus running by hand from the workflow or task |
+| Gates | On a card, a gate chip reads **waiting**, **passed**, **failed**, or **stale** (CI never reported) |
 | Step failure options | **On Failure**: Fail / Retry / Skip; **Skip Policy**: Never / If outputs exist / Manual |
-| Human approval | A waiting step shows **Approve & Continue** |
-| Docs | Reachable from the public site (**Documentation**); there is no docs item in the app sidebar |
+| Human approval | A waiting step shows **Approve & continue** |
+| Live terminal | A running step embeds the agent's terminal; before the container is ready it reads **Session starting…**, then **Connecting to terminal…** |
+| Profile | Tabs **Account**, **Usage**, **MCP** — the last is personal access for agents run outside Aixle |
+| Docs | The operator documentation portal at `/docs`, reachable from the public site (**Documentation**); there is no docs item in the app sidebar |

--- a/docs/product/user-guide-outline.md
+++ b/docs/product/user-guide-outline.md
@@ -1,0 +1,284 @@
+# Aixle Flow User Guide — Outline
+
+> Deliverable for issue #550. This is the outline of the end-user product guide —
+> the skeleton a writer expands into full chapters. It follows the product
+> sidebar, uses the names a person sees on screen, and stays at product level:
+> no architecture, no APIs, no configuration, no file paths.
+
+**Audience.** People who will run work in Aixle Flow: engineering leads,
+developers, and operators. Assume they know Git and task boards. Do not assume
+they know how agents, containers, or orchestration work.
+
+**Rules for the writer.**
+
+- Every section answers four questions: *what this is · when to use it ·
+  what the person does · what they see afterwards.*
+- Use the names from the product UI, not internal engineering names
+  (see [Terminology notes](#terminology-notes) at the end).
+- The existing in-app docs at `/docs` are too technical for this guide — do not
+  reuse their structure or copy.
+
+---
+
+## 1. What Aixle Flow is
+
+Open with the loop, not a feature list.
+
+- **What it is.** The team layer above personal AI coding agents — Claude Code,
+  Cursor CLI, Codex, Gemini CLI, and Grok. Not a personal chat with an agent:
+  team control of AI coding work.
+- **The loop.** A person moves a card on the board into a column that is bound
+  to a workflow. Agents start working. When the run finishes, status, files,
+  and cost come back to the board. The team sees what is running, what it
+  produced, and what it cost — without anyone opening a terminal.
+- **The three levels.** A **company** is the shared workspace. Inside it, each
+  **project** has a board and its own resources. Your **profile** holds what is
+  personal: your agent credentials and your usage.
+- One diagram: board → workflow → agent → results back to the board.
+
+## 2. Your first session
+
+The reader goes from an invite email to their first open project.
+
+- **Getting in.** Accept an invitation or sign in. First-run onboarding: role
+  and language.
+- **Connect an agent.** In **Profile**, connect the account of the agent
+  product you already use (Claude Code, Cursor CLI, Codex, Gemini CLI, or
+  Grok). Nothing can run on your behalf until this is done — say this plainly
+  and early.
+- **Find your work.** Open **Projects**, pick a project, land on **Overview**.
+- **More than one company?** The workspace switcher moves you between
+  companies; each company has its own projects, members, and analytics.
+- *Afterwards:* you are inside a project, an agent is connected, and the board
+  is one click away.
+
+## 3. The main loop
+
+A single guided walkthrough, before any reference material. Everything later in
+the guide hangs off this chapter.
+
+1. Open **Tasks** and create a card (or pick one up from the backlog).
+2. Move the card into a column bound to a workflow — the workflow starts
+   automatically, or from a button if the column is set to manual.
+3. Watch progress in **Runs** and **Sessions**: live status, the log as the
+   agent works, cost accumulating.
+4. Review what came back: files in **Assets**, results and comments on the
+   card.
+5. Move the card forward — or send it back with a comment and run again.
+
+- *Afterwards:* the reader has seen the whole product once, end to end.
+
+## 4. Tasks — the board
+
+- **What it is.** The project's board: columns, cards, subtasks, comments,
+  attachments.
+- **When to use it.** This is where work enters the system and where results
+  land; most people live here.
+- **What you do.** Create and move cards; comment; attach files; bind a column
+  to a workflow so that entering the column starts it (automatically or from a
+  button).
+- **Board templates.** A new project's board starts empty; pick a template —
+  **Simple Kanban** (Backlog / In Progress / Done), **Dev Team** (a
+  seven-column engineering flow), or **Full SDLC** (the long form) — and
+  customize columns later.
+- *Afterwards:* cards carry their own history — comments, attachments, runs,
+  and activity.
+
+## 5. Workflows
+
+- **What it is.** A named process made of ordered **steps**; each step is one
+  agent session doing one job.
+- **When to use it.** Whenever the same kind of work should run the same way
+  every time.
+- **What you do.** Create a workflow; add steps with instructions and an
+  assigned agent; set what each step depends on (independent steps run in
+  parallel); choose what happens on failure (fail, retry, or skip); mark where
+  a person must approve before the run continues. Publish it, duplicate it, or
+  copy a ready-made one from the **Workflow Catalog**.
+- **How it starts.** From the board (a card enters a bound column), from the
+  workflow itself (Run), on a schedule, from a Slack message, or from an
+  inbound webhook.
+- *Afterwards:* the workflow appears as an option when binding columns, and
+  every run of it is tracked.
+
+## 6. Sessions & Runs
+
+Two sidebar pages, one chapter: **Runs** is workflow runs; **Sessions** is
+individual agent sessions (each step of a run is one session, and sessions can
+also run on their own).
+
+- **What it is.** Live and past agent work.
+- **When to use it.** To answer "what is happening right now?" and "what
+  happened, what did it produce, what did it cost?"
+- **What you do.** Open a run to see its steps, which ran in parallel, and
+  where it is waiting; approve a step that waits for a person
+  (**Approve & Continue**); retry or skip a step; open a session to read the
+  full log.
+- *Afterwards:* every run leaves a trail — status, log, artifacts, tokens, and
+  cost.
+
+## 7. Assets
+
+- **What it is.** Files: what the team uploads and what agents produce.
+- **When to use it.** Give agents input material; collect and review what they
+  made.
+- **What you do.** Upload files; attach them to tasks; open what a run
+  produced; track versions.
+- *Afterwards:* outputs are reviewable in one place instead of scattered
+  across runs.
+
+## 8. Agents
+
+- **What it is.** Reusable personas: who the agent is, how it talks, what
+  rules it follows. A persona is not a product choice — the same persona can
+  run on any of the supported runtimes (Claude Code, Cursor CLI, Codex, Gemini
+  CLI, Grok).
+- **When to use it.** To make agent behaviour consistent across workflows —
+  "our reviewer", "our implementer" — instead of re-writing instructions per
+  step.
+- **What you do.** Create a persona, write its instructions and rules, pick it
+  in workflow steps. Remind: runs happen under credentials people connect in
+  **Profile**.
+- *Afterwards:* steps reference personas by name, and changing a persona
+  changes every workflow that uses it.
+
+## 9. Wrappers
+
+- **What it is.** A way to turn a script or an API into something an agent can
+  call, when no connector exists for that service.
+- **When to use it.** Your internal service, an odd API, a one-off script.
+- **What you do.** Define the wrapper once; agents in this project can then
+  call it during runs.
+- *Afterwards:* the wrapper shows up as a capability agents actually use in
+  their logs.
+
+## 10. Skills
+
+- **What it is.** Packaged instructions an agent can load during a session —
+  know-how, not tools.
+- **When to use it.** Recurring expertise: "how we write migrations", "our
+  review checklist".
+- **What you do.** Install a skill from the catalog or write one by hand;
+  attach it where it should be available.
+- *Afterwards:* agents follow the skill's instructions when the work matches.
+
+## 11. Connectors
+
+- **What it is.** Connections that give agents extra tools — issue trackers
+  and other external services.
+- **When to use it.** The agent needs to act on a system outside the codebase.
+- **What you do.** Add a connector from the catalog (or by hand); supply its
+  credentials via **Secrets & Variables**.
+- *Afterwards:* the connected service's actions appear among what agents can
+  do.
+
+## 12. Repositories & Integrations
+
+- **What it is.** **Repositories** are the Git repos agents work in and push
+  to. **Integrations** connect GitHub, GitLab — and Linear and Slack where
+  available.
+- **When to use it.** Any workflow that should read code, open pull requests,
+  or touch tickets.
+- **What you do.** Connect the integration, link the repositories the project
+  needs.
+- *Afterwards:* runs can produce branches and pull requests in your own
+  repos, and tickets can flow both ways.
+
+## 13. AI Builder
+
+- **What it is.** Describe a process in plain language; the product builds the
+  tasks, board setup, and workflows from that prompt. (The sidebar button says
+  **AI Builder / Build with AI**; the builder's own pages are titled **Aixle
+  Builder** — the guide should show both once, then stick to one.)
+- **When to use it.** Setting up a new process — instead of configuring
+  columns, workflows, and steps by hand.
+- **What you do.** Write what you want to automate; review what the builder
+  proposes; accept, then adjust by hand where needed.
+- *Afterwards:* the board and workflows exist and are editable like anything
+  built manually.
+
+## 14. Team
+
+- **What it is.** **Members** at two levels: who is in the company, and who is
+  on each project.
+- **Roles.** **Admin** manages members, integrations, and settings;
+  **Employee** works within projects; **Viewer** looks without touching.
+- **What you do.** Invite people by email, set their role, add them to
+  projects.
+- *Afterwards:* each person sees what their role allows — admins additionally
+  see company-wide analytics and sessions.
+
+## 15. Secrets & Variables
+
+- **What it is.** Values agents and connectors need at runtime — credentials
+  and configuration — kept out of task text and workflow instructions.
+- **When to use it.** Any time a run needs a key, token, or setting.
+- **What you do.** Add the value once, name it, reference it where needed.
+- *Afterwards:* runs use the value without anyone pasting it into a card.
+
+## 16. Analytics
+
+- **What it is.** Usage and cost: spend, sessions, tokens, success — by
+  project, agent, and source.
+- **Two levels.** Project **Analytics** for the team; company **Analytics**
+  and company **Sessions** for admins, across all projects.
+- **What you do.** Answer "what did this cost us?", "which workflows work?",
+  "where does agent time go?"
+- *Afterwards:* cost conversations happen with numbers, per project and per
+  company.
+
+## 17. The company workspace
+
+Round off with the shared layer above projects.
+
+- **Projects** — create and switch between them.
+- **Workflow Catalog** — reusable workflows the team can copy into any
+  project.
+- **Company Assets** and **Company Members** — workspace-level files and
+  people.
+- Switching companies when you belong to more than one workspace.
+
+---
+
+## End-to-end stories
+
+Two closing chapters that retell the loop as narratives. Each one names every
+screen it touches, so the reader can replay it.
+
+### Story 1 — drop a card, get a pull request back
+
+A lead links a repository (Integrations → Repositories), binds the
+"Implementation" column of a **Dev Team** board to an implementation workflow,
+and writes a card describing a small feature. They drag the card into the
+column. The workflow starts: one step plans, a parallel pair implements and
+writes tests, a final step waits for a human. The lead watches the run in
+**Runs**, reads the diff summary the agent posted to the card, approves the
+waiting step — and a pull request appears in the linked repo. Cost of the whole
+run is on the card and in Analytics.
+
+### Story 2 — build a workflow from one prompt
+
+An operator opens **AI Builder** and types: "When a card lands in *Triage*,
+summarize it, label it, and draft a reply for review." The builder proposes a
+board column, a three-step workflow, and the connector it needs. The operator
+accepts, adds the connector credential in **Secrets & Variables**, and drops a
+test card into *Triage*. The run appears in **Runs**; the draft reply lands on
+the card as a comment — written by an agent, reviewed by a person.
+
+---
+
+## Terminology notes
+
+For guide writers — where the UI's names differ from what you might expect, or
+from each other. Verified against the product as of 2026-08.
+
+| Guide term | On screen |
+| --- | --- |
+| Tasks | Sidebar item **Tasks**; the page itself is titled **Board** |
+| Sessions & Runs | Two sidebar items: **Runs** and **Sessions** |
+| AI Builder | Sidebar banner **AI Builder** with button **Build with AI**; the feature's own pages are titled **Aixle Builder** |
+| Board templates | Offered on an empty board (not at project creation); UI says "template" (**Use this template**), preset names **Simple Kanban**, **Dev Team**, **Full SDLC** |
+| Workflow start | Trigger labels on screen: **Task enters column** (Auto or Manual mode), **On schedule**, **Slack message**, **Inbound webhook** — plus running by hand from the workflow or task |
+| Step failure options | **On Failure**: Fail / Retry / Skip; **Skip Policy**: Never / If outputs exist / Manual |
+| Human approval | A waiting step shows **Approve & Continue** |
+| Docs | Reachable from the public site (**Documentation**); there is no docs item in the app sidebar |

--- a/docs/product/user-guide-outline.md
+++ b/docs/product/user-guide-outline.md
@@ -15,8 +15,9 @@ they know how agents, containers, or orchestration work.
   what the person does · what they see afterwards.*
 - Use the names from the product UI, not internal engineering names
   (see [Terminology notes](#terminology-notes) at the end).
-- The existing in-app docs at `/docs` are too technical for this guide — do not
-  reuse their structure or copy.
+- The existing in-app documentation (linked from the public site as
+  **Documentation**) is too technical for this guide — do not reuse its
+  structure or copy.
 
 ---
 
@@ -40,12 +41,15 @@ Open with the loop, not a feature list.
 
 The reader goes from an invite email to their first open project.
 
-- **Getting in.** Accept an invitation or sign in. First-run onboarding: role
-  and language.
-- **Connect an agent.** In **Profile**, connect the account of the agent
-  product you already use (Claude Code, Cursor CLI, Codex, Gemini CLI, or
-  Grok). Nothing can run on your behalf until this is done — say this plainly
-  and early.
+- **Getting in.** Accept an invitation or sign in. First-run onboarding walks
+  through role, language, and connecting an agent (the agent step is skipped
+  for viewer-only users).
+- **Connect an agent.** During onboarding — or any time later in **Profile** —
+  connect the account of the agent product you already use (Claude Code,
+  Cursor CLI, Codex, Gemini CLI, or Grok). Nothing can run on your behalf
+  until this is done — say this plainly and early.
+- **Your Profile.** Besides agent credentials, Profile shows your personal
+  usage and personal settings.
 - **Find your work.** Open **Projects**, pick a project, land on **Overview**.
 - **More than one company?** The workspace switcher moves you between
   companies; each company has its own projects, members, and analytics.
@@ -133,7 +137,7 @@ also run on their own).
   rules it follows. A persona is not a product choice — the same persona can
   run on any of the supported runtimes (Claude Code, Cursor CLI, Codex, Gemini
   CLI, Grok).
-- **When to use it.** To make agent behaviour consistent across workflows —
+- **When to use it.** To make agent behavior consistent across workflows —
   "our reviewer", "our implementer" — instead of re-writing instructions per
   step.
 - **What you do.** Create a persona, write its instructions and rules, pick it
@@ -149,8 +153,8 @@ also run on their own).
 - **When to use it.** Your internal service, an odd API, a one-off script.
 - **What you do.** Define the wrapper once; agents in this project can then
   call it during runs.
-- *Afterwards:* the wrapper shows up as a capability agents actually use in
-  their logs.
+- *Afterwards:* the wrapper shows up in run logs as a capability the agents
+  actually called.
 
 ## 10. Skills
 
@@ -187,9 +191,10 @@ also run on their own).
 ## 13. AI Builder
 
 - **What it is.** Describe a process in plain language; the product builds the
-  tasks, board setup, and workflows from that prompt. (The sidebar button says
-  **AI Builder / Build with AI**; the builder's own pages are titled **Aixle
-  Builder** — the guide should show both once, then stick to one.)
+  tasks, board setup, and workflows from that prompt. (This guide uses **AI
+  Builder**, matching the sidebar entry point; the builder's own pages — and
+  the changelog taxonomy — say **Aixle Builder**. Show both names once, then
+  stick to AI Builder.)
 - **When to use it.** Setting up a new process — instead of configuring
   columns, workflows, and steps by hand.
 - **What you do.** Write what you want to automate; review what the builder
@@ -235,7 +240,8 @@ Round off with the shared layer above projects.
 - **Workflow Catalog** — reusable workflows the team can copy into any
   project.
 - **Company Assets** and **Company Members** — workspace-level files and
-  people.
+  people. Company Assets, like company Analytics and Sessions, is visible to
+  admins only.
 - Switching companies when you belong to more than one workspace.
 
 ---
@@ -250,11 +256,11 @@ screen it touches, so the reader can replay it.
 A lead links a repository (Integrations → Repositories), binds the
 "Implementation" column of a **Dev Team** board to an implementation workflow,
 and writes a card describing a small feature. They drag the card into the
-column. The workflow starts: one step plans, a parallel pair implements and
-writes tests, a final step waits for a human. The lead watches the run in
+column. The workflow starts: one step plans, two parallel steps implement and
+write tests, a final step waits for a human. The lead watches the run in
 **Runs**, reads the diff summary the agent posted to the card, approves the
-waiting step — and a pull request appears in the linked repo. Cost of the whole
-run is on the card and in Analytics.
+waiting step — and a pull request appears in the linked repo. The cost of the
+whole run is on the card and in Analytics.
 
 ### Story 2 — build a workflow from one prompt
 


### PR DESCRIPTION
> Ported from palad-ai/palad-app#552 (original issues: palad-ai/palad-app#550, palad-ai/palad-app#551).

## What

Two product-level documentation deliverables under `docs/product/`:

- **`user-guide-outline.md`** (#550) — the outline of the end-user guide: opens with the board → workflow → agent → results loop, follows the product sidebar IA (company / project / profile), each section answers *what it is · when to use it · what you do · what you see afterwards*, two end-to-end stories, and a terminology-notes table for guide writers.
- **`changelog-product-areas.md`** (#551) — a frozen user-facing product map used as the changelog taxonomy: named product areas per the sidebar, changelog rules (Added/Changed/Fixed/Removed × area), an area → guide-chapter map, snapshot baseline dated 2026-08-20.

Also: `docs/index.md` gets a new **Product** section plus an **Operator documentation** section that finally indexes the existing `docs/user-guide/`, `quickstart.md`, and `reference/` tree (repo rule), and `CHANGELOG.md` points at the taxonomy.

## Deviations from the issue text (matched to the real UI)

All names are verified against the UI code on `develop` (`AppSidebar.tsx`, page titles, `board_presets.rb`, `TriggerFormPanel.tsx`, `WorkflowRuns/ShowPage.tsx`, role/runtime enums):

- The sidebar has a single **Sessions & Runs** item — agent sessions and workflow runs share one list (merged in #93). The standalone **Sessions** item is the company-level, admin-only cross-project view. Docs describe one project area and one chapter.
- The sidebar entry point is **AI Builder / Build with AI**, while the feature's pages are titled **Aixle Builder**; the guide uses AI Builder, the taxonomy uses Aixle Builder, both note the other.
- Board presets (**Simple Kanban / Dev Team / Full SDLC**) are offered as *templates* on an empty board, not at project creation.
- Onboarding does include a Connect Agents step (skipped for viewer-only users), with Profile as the ongoing home for credentials.
- On-screen control copy is quoted as it reads: **Incoming webhook** (trigger option), **Approve & continue** (waiting step).

## Coverage

The outline now has a chapter for every area in the taxonomy, including the ones an earlier draft named but never documented — **Overview**, **Triggers & gates** (CI gate states: waiting / passed / failed / stale), and **Settings** — plus the live step terminal, the Profile tabs (Account / Usage / MCP), and personal MCP access. The taxonomy carries the area → chapter map so the two documents cannot drift apart silently.

`CHANGELOG.md` previously declared that entries carry a product area while none did, and most existing entries are repository-level work that the taxonomy's own rules exclude from a product changelog. The rule now describes what the file actually does — product entries carry an area, contributor-facing entries carry none — and the one user-visible entry is tagged.

## Checks

Docs-only change: Markdown under `docs/` plus `CHANGELOG.md`. No Ruby, TS, CSS, or fixtures are touched, so nothing in `check_all` (rails test, rubocop, brakeman, eslint, tsc, vitest) reads any changed file; the suite was not re-run for this revision. Relative links in the changed documents were resolved against the working tree.
