### PR TITLE
fix(oauth): pass skew through refresh_if_expiring_soon to fresh

### DIFF
--- a/app/services/oauth/token_service.rb
+++ b/app/services/oauth/token_service.rb
@@ -78,7 +78,7 @@ module Oauth
       return unless cred.expired?(skew)
       return unless cred.refreshable?
 
-      fresh(cred)
+      fresh(cred, skew: skew)
     rescue ReauthRequired
       # Already caught by preflight — do not re-raise here, session start will
       # surface it through the normal token injection path.
@@ -86,8 +86,8 @@ module Oauth
     end
 
     # Ensure `cred` yields a fresh token; refresh under lock if near expiry.
-    def fresh(cred)
-      return cred.access_token unless cred.expired?(REFRESH_SKEW)
+    def fresh(cred, skew: REFRESH_SKEW)
+      return cred.access_token unless cred.expired?(skew)
 
       # Nothing to refresh from. Record it like any other refresh failure so the
       # credential escalates to status:error (and notifies the owner to reconnect)
@@ -103,7 +103,7 @@ module Oauth
       cred.with_lock do
         cred.reload
         # A concurrent request may have refreshed while we waited on the lock.
-        break unless cred.expired?(REFRESH_SKEW)
+        break unless cred.expired?(skew)
 
         resp = perform_refresh!(cred)
         # Never downgrade: only persist if the new expiry is >= the stored one.
@@ -111,7 +111,7 @@ module Oauth
         cred.apply_token_response!(resp) if new_exp.nil? || cred.expires_at.nil? || new_exp >= cred.expires_at
       end
 
-      raise ReauthRequired.new(cred) if cred.access_token.blank? || cred.expired?(REFRESH_SKEW)
+      raise ReauthRequired.new(cred) if cred.access_token.blank? || cred.expired?(skew)
 
       cred.access_token
     rescue ReauthRequired


### PR DESCRIPTION
## Problem

`refresh_if_expiring_soon` checked `cred.expired?(PRE_START_SKEW)` (1 hour) but then called `fresh(cred)` without passing `skew`, so `fresh` fell back to its own `REFRESH_SKEW = 10.minutes` guard:

```ruby
# Before
def refresh_if_expiring_soon(cred, skew: PRE_START_SKEW)
  return unless cred.expired?(skew)   # checks 1 hour ✅
  return unless cred.refreshable?
  fresh(cred)                         # fresh internally checks 10 minutes ❌
end

def fresh(cred)
  return cred.access_token unless cred.expired?(REFRESH_SKEW)  # 10 min guard
  ...
end
```

**Result:** any token expiring in the 10min–1h window passed the outer check but was silently skipped inside `fresh` — returning the current (soon-to-expire) token without refreshing. The pre-session 1-hour window had no practical effect.

## Fix

Propagate `skew` as a keyword argument through to `fresh` so a single threshold governs both the entry check and the refresh guard:

```ruby
def refresh_if_expiring_soon(cred, skew: PRE_START_SKEW)
  return unless cred.expired?(skew)
  return unless cred.refreshable?
  fresh(cred, skew: skew)            # ✅ same skew throughout
end

def fresh(cred, skew: REFRESH_SKEW)
  return cred.access_token unless cred.expired?(skew)
  ...
end
```

`access_token_for` and `refresh_credential` still call `fresh(cred)` without a skew argument, so they continue to use `REFRESH_SKEW = 10.minutes` — no behaviour change for on-demand per-request refreshes.

## Test plan

- [ ] Token expiring in ~30 minutes: session start now triggers a refresh (previously skipped)
- [ ] Token expiring in ~5 minutes: still refreshed as before
- [ ] Token with >1h remaining: not refreshed (no behaviour change)
- [ ] `access_token_for` / `refresh_credential`: unaffected, still use 10-minute skew