### PR TITLE
fix(sessions): show steps before prompt in session card

### DIFF
--- a/app/frontend/shared/ui/sessions/SessionCard.tsx
+++ b/app/frontend/shared/ui/sessions/SessionCard.tsx
@@ -112,13 +112,6 @@ export function SessionCard({ data, sessionHref, defaultOpen = false, live = fal
 
       {open && (
         <div className={classes.expand}>
-          {data.prompt && (
-            <section className={classes.section}>
-              <h4 className={classes.sectionHead}>Prompt</h4>
-              <p className={classes.prompt}>{data.prompt}</p>
-            </section>
-          )}
-
           {data.steps.length > 0 && (
             <section className={classes.section}>
               <h4 className={classes.sectionHead}>
@@ -138,6 +131,13 @@ export function SessionCard({ data, sessionHref, defaultOpen = false, live = fal
                   </span>
                 </div>
               ))}
+            </section>
+          )}
+
+          {data.prompt && (
+            <section className={classes.section}>
+              <h4 className={classes.sectionHead}>Prompt</h4>
+              <p className={classes.prompt}>{data.prompt}</p>
             </section>
           )}
 


### PR DESCRIPTION
## Summary
- On the active run page, expanded session cards showed the Prompt section above the Steps section; reordered so Steps renders first, then Prompt.

## Test plan
- [x] `docker compose exec -T web make check_all` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)