### PR TITLE
fix(workflow-runs): stop footer overlap on the run detail page

### DIFF
--- a/app/frontend/pages/Projects/WorkflowRuns/ShowPage.module.css
+++ b/app/frontend/pages/Projects/WorkflowRuns/ShowPage.module.css
@@ -10,7 +10,6 @@
 .root {
   display: flex;
   flex-direction: column;
-  min-height: 0;
 }
 
 .body {


### PR DESCRIPTION
## Summary
- The workflow run detail page's `.root` set `min-height: 0`, letting `<main>` shrink below its natural content height whenever page content exceeded the viewport (e.g. a single-session run). The "Powered by Aixle" footer then laid out against that collapsed box instead of the page's true height, while the sticky console panel kept rendering at full size and visually overlapped it.
- Removed `min-height: 0` from `ShowPage.module.css`'s `.root`. Scoped to this page only — `AuthLayout`'s shared `<main>` keeps `min-height: 0`, since `SessionShowContent`'s full-height iframe view (`Company/Sessions/Show.tsx`) genuinely needs that shrink chain to fill the viewport.
- Verified against the reported production bug (flow.aixle.com workflow run page) before and after the fix, including confirming in the browser inspector that toggling this property resolves the overlap.

## Test plan
- [x] `docker compose exec -T web make check_all` — all green (rails-test, rubocop, brakeman, system-test, eslint, typescript, fe-test, vite-build)
- [ ] Reviewer: reload a running workflow with a single/short session list and confirm the footer renders below the console panel with no overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)