### PR TITLE
fix(builder): hide main panel empty state during session finish overlay

### DIFF
--- a/app/frontend/pages/Projects/AixleBuilder/SessionPage.test.tsx
+++ b/app/frontend/pages/Projects/AixleBuilder/SessionPage.test.tsx
@@ -176,7 +176,7 @@ describe('Projects/AixleBuilder/SessionPage', () => {
     expect(screen.getByText('Starting container...')).toBeInTheDocument();
   });
 
-  it('shows the session-state line and error message in the main panel when not active and not terminal', () => {
+  it('hides the main panel empty state while the finishing overlay is shown', () => {
     renderAuthedPage(<SessionPage />, {
       props: {
         project,
@@ -193,8 +193,8 @@ describe('Projects/AixleBuilder/SessionPage', () => {
       },
     });
 
-    expect(screen.getByText('Session finishing')).toBeInTheDocument();
-    expect(screen.getByText('Container exited unexpectedly')).toBeInTheDocument();
+    expect(screen.queryByText('Session finishing')).not.toBeInTheDocument();
+    expect(screen.queryByText('Container exited unexpectedly')).not.toBeInTheDocument();
   });
 
   it('shows the finishing overlay when the session state is finishing', () => {

--- a/app/frontend/pages/Projects/AixleBuilder/SessionPage.tsx
+++ b/app/frontend/pages/Projects/AixleBuilder/SessionPage.tsx
@@ -178,6 +178,8 @@ const SessionPage = () => {
   // ── Render: Terminal panel ─────────────────────
 
   const renderMainPanel = () => {
+    if (finishRequested || isFinishing) return null;
+
     if (!canShowTerminal) {
       return (
         <div className={classes.mainPanel}>


### PR DESCRIPTION
## Summary
- When a session's state is `finishing`, the full-page "Finishing session…" overlay and `SessionPage`'s main-panel empty state (which fell into its "not active" branch and rendered "Session finishing") both rendered at once, producing a duplicated loader/text in the UI (reported via a user screenshot).
- `SessionShowContent.tsx` already guards this exact case (`if (finishRequested || isFinishing) return null;`); applied the same guard to `renderMainPanel` in `SessionPage.tsx`.

## Test plan
- [x] Updated `SessionPage.test.tsx` to assert the main-panel empty state is hidden while finishing, instead of asserting the old (buggy) duplicated text
- [x] `docker compose exec -T web make check_all` green (rails-test, rubocop, brakeman, system-test, eslint, typescript, fe-test, vite-build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)