### PR TITLE
fix(workflow-runs): gate terminal/ide URL on session ready, not active

### DIFF
--- a/app/resources/step_run_resource.rb
+++ b/app/resources/step_run_resource.rb
@@ -60,7 +60,11 @@ class StepRunResource < ApplicationResource
   typelize :string?
   attribute :terminal_url do |sr|
     ts = sr.terminal_session
-    next nil unless ts&.route_token.present? && ts.active?
+    # Gated on `ready?`, not the looser `active?` — the container only registers
+    # its traefik route inside `exec`, which is what flips the session to
+    # "ready". Handing out the URL any earlier (e.g. "not_started"/"running")
+    # points the iframe at a route that doesn't exist yet and it 404s.
+    next nil unless ts&.route_token.present? && ts.ready?
 
     ws_base = params.dig(:traefik, :ws_base)
     "#{ws_base}/t/#{ts.route_token}/tty/ws"
@@ -71,7 +75,7 @@ class StepRunResource < ApplicationResource
   typelize :string?
   attribute :ide_url do |sr|
     ts = sr.terminal_session
-    next nil unless ts&.route_token.present? && ts.active?
+    next nil unless ts&.route_token.present? && ts.ready?
     next nil if ts.mode == "non_interactive"
 
     http_base = params.dig(:traefik, :http_base)


### PR DESCRIPTION
## Summary

Root cause: `StepRunResource#terminal_url` (and `#ide_url`) gated on `terminal_session.active?`, which is true for **`not_started`** and `running`, not just `ready`. The container only registers its traefik route inside `AgentBaseStrategy#exec`, which is exactly what flips the session to `ready` (`mark_session_ready`). So right after a manual workflow run starts, the frontend briefly had a `terminalUrl` pointing at a route that didn't exist yet — the iframe loaded that URL and rendered the proxy's 404 page in place of the "Session starting…" loader. A page refresh "fixed" it only because by then the session had reached `ready`.

Fix: `app/resources/step_run_resource.rb:61-84` — gate `terminal_url`/`ide_url` on `ts.ready?` instead of `ts.active?`. Until then, `StepConsole` (`ShowPage.tsx`) already falls back to its "Session starting…" loader since `terminalUrl` is `nil`, so no frontend change was needed. Ran `rubocop` (clean) and the workflow-run integration/render test suites (21/21 passing) to confirm no regressions.

## Test plan

- [x] `docker compose exec -T web make check_all` — all green (backend, frontend, rubocop, brakeman, eslint, typescript, vitest)
- [x] `docker compose exec -T web bin/rails test test/integration/web/company/projects/workflow_runs_render_test.rb test/integration/web/company/projects/workflow_runs_controller_test.rb` — 21/21 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)