### PR TITLE
feat(overview): redesign Project Overview page

### DIFF
--- a/app/frontend/pages/Projects/Overview/OverviewPage.module.css
+++ b/app/frontend/pages/Projects/Overview/OverviewPage.module.css
@@ -1,0 +1,334 @@
+/* ── Project Overview redesign (issue #522) ──────────────────────────
+ * KPI row + two-column (Recent Activity / Workflow Runs donut) + Board Task
+ * Distribution bar list. Sizes/spacing/radii are taken from the reference
+ * mockup; colors are mapped onto the app's existing --app-* theme tokens so
+ * light/dark both work (the mockup only specified a dark palette).
+ */
+
+.kpiRow {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-bottom: 22px;
+}
+
+.kpiCard {
+  background: var(--app-bg-card);
+  border: 1px solid var(--app-border-default);
+  border-radius: 8px;
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+}
+
+.kpiTop {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--app-text-tertiary);
+  margin-bottom: 14px;
+}
+
+.kpiLabel {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--app-text-secondary);
+}
+
+.kpiValue {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--app-text-primary);
+  font-family: var(--app-font-heading);
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+
+.kpiValueMono {
+  font-family: var(--app-font-mono);
+  font-weight: 600;
+}
+
+.kpiDelta {
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--app-text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.liveDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--app-warning-fg);
+  display: inline-block;
+  flex-shrink: 0;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 var(--app-warning-border);
+  }
+  70% {
+    box-shadow: 0 0 0 5px rgba(0, 0, 0, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+  }
+}
+
+.twoCol {
+  display: grid;
+  grid-template-columns: 1.7fr 1fr;
+  gap: 16px;
+  margin-bottom: 16px;
+  align-items: stretch;
+}
+
+.panel {
+  background: var(--app-bg-card);
+  border: 1px solid var(--app-border-default);
+  border-radius: 10px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+}
+
+.panelHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  gap: 12px;
+}
+
+.sectionTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--app-text-primary);
+  font-family: var(--app-font-heading);
+  letter-spacing: -0.01em;
+}
+
+/* Recent Activity list */
+.actList {
+  display: flex;
+  flex-direction: column;
+}
+
+.actItem {
+  display: flex;
+  gap: 11px;
+  padding: 11px 0;
+  border-bottom: 1px solid var(--app-border-default);
+}
+
+.actItemLast {
+  display: flex;
+  gap: 11px;
+  padding: 11px 0 0;
+}
+
+.actDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 5px;
+}
+
+.actBody {
+  flex: 1;
+  min-width: 0;
+}
+
+.actTxt {
+  font-size: 13px;
+  color: var(--app-text-primary);
+  line-height: 1.45;
+}
+
+.actMeta {
+  font-size: 11px;
+  color: var(--app-text-tertiary);
+  margin-top: 2px;
+}
+
+.emptyState {
+  font-size: 13px;
+  color: var(--app-text-tertiary);
+  padding: 10px 0;
+}
+
+/* Workflow Runs — donut + legend */
+.runsBody {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 36px;
+  padding: 8px 0;
+}
+
+.donutCenter {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.donutNum {
+  font-size: 26px;
+  font-weight: 700;
+  font-family: var(--app-font-heading);
+  color: var(--app-text-primary);
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+
+.donutCap {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--app-text-tertiary);
+  margin-top: 3px;
+}
+
+.runsInfo {
+  width: 100%;
+  max-width: 300px;
+}
+
+.rhTotal {
+  font-size: 13px;
+  color: var(--app-text-secondary);
+}
+
+.rhTotalValue {
+  color: var(--app-text-primary);
+  font-weight: 600;
+}
+
+.rhNote {
+  font-size: 12px;
+  color: var(--app-text-tertiary);
+  margin-top: 5px;
+  line-height: 1.4;
+}
+
+.legend {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.legRow {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 12px;
+}
+
+.legDot {
+  width: 9px;
+  height: 9px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.legName {
+  color: var(--app-text-secondary);
+  flex: 1;
+}
+
+.legVal {
+  color: var(--app-text-primary);
+  font-weight: 600;
+  font-family: var(--app-font-mono);
+  font-size: 12px;
+}
+
+.legPct {
+  color: var(--app-text-tertiary);
+  font-size: 11px;
+  width: 34px;
+  text-align: right;
+  font-family: var(--app-font-mono);
+}
+
+/* Board Task Distribution — horizontal bar list */
+.hbarList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hbarRow {
+  display: grid;
+  grid-template-columns: 150px 1fr 34px;
+  align-items: center;
+  gap: 14px;
+}
+
+.hbarName {
+  font-size: 12px;
+  color: var(--app-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hbarTrack {
+  height: 8px;
+  border-radius: 4px;
+  background: var(--app-bg-elevated);
+  overflow: hidden;
+}
+
+.hbarFill {
+  height: 100%;
+  border-radius: 4px;
+}
+
+.hbarCount {
+  font-family: var(--app-font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--app-text-primary);
+  text-align: right;
+}
+
+@media (max-width: 1100px) {
+  .twoCol {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .kpiRow {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .runsBody {
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .hbarRow {
+    grid-template-columns: 96px 1fr 30px;
+    gap: 10px;
+  }
+}
+
+@media (max-width: 480px) {
+  .kpiRow {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/frontend/pages/Projects/Overview/OverviewPage.test.tsx
+++ b/app/frontend/pages/Projects/Overview/OverviewPage.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom/vitest';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { renderAuthedPage, screen } from 'test/renderPage';
+import { renderAuthedPage, screen, userEvent } from 'test/renderPage';
 
 import OverviewPage from './OverviewPage';
 
@@ -9,6 +9,7 @@ interface OverviewProps extends Record<string, unknown> {
   project: { id: number; name: string };
   summary: {
     sessionsLaunched: number;
+    sessionsRunning: number;
     totalSpendCents: number;
     workflowsCount: number;
     boardTasksCount: number;
@@ -36,24 +37,25 @@ const buildProps = (overrides: Partial<OverviewProps> = {}): OverviewProps => ({
   project: { id: 42, name: 'Falcon Initiative' },
   summary: {
     sessionsLaunched: 1234,
+    sessionsRunning: 2,
     totalSpendCents: 5678,
     workflowsCount: 9,
     boardTasksCount: 17,
   },
   workflowRunStats: {
-    completed: 8,
-    inProgress: 2,
-    failed: 1,
-    queued: 3,
-    total: 14,
+    completed: 25,
+    inProgress: 6,
+    failed: 4,
+    queued: 10,
+    total: 45,
   },
   boardTaskDistribution: {
     columns: [
-      { name: 'Backlog', count: 5 },
-      { name: 'Doing', count: 3 },
-      { name: 'Shipped', count: 9 },
+      { name: 'Backlog', count: 12 },
+      { name: 'Doing', count: 14 },
+      { name: 'Shipped', count: 20 },
     ],
-    total: 17,
+    total: 46,
   },
   recentActivity: [
     {
@@ -73,19 +75,39 @@ const buildProps = (overrides: Partial<OverviewProps> = {}): OverviewProps => ({
 });
 
 describe('Projects/Overview/OverviewPage', () => {
-  it('renders the page header and the project summary stats from seeded props', () => {
+  it('renders the page header and the KPI cards from seeded props', () => {
     renderAuthedPage(<OverviewPage />, { props: buildProps() });
 
     expect(screen.getByText('Project Overview')).toBeInTheDocument();
-    expect(screen.getByText('Project activity at a glance')).toBeInTheDocument();
+    expect(screen.getByText('Current and overall project activity')).toBeInTheDocument();
 
-    // Stat labels
+    // KPI labels
     expect(screen.getByText('Sessions Launched')).toBeInTheDocument();
+    expect(screen.getByText('Total Spend')).toBeInTheDocument();
+    expect(screen.getByText('Workflows')).toBeInTheDocument();
     expect(screen.getByText('Board Tasks')).toBeInTheDocument();
 
-    // Stat values: sessionsLaunched is localized, spend is formatted as dollars.
+    // KPI values: sessionsLaunched is localized, spend is formatted as dollars.
     expect(screen.getByText('1,234')).toBeInTheDocument();
     expect(screen.getByText('$56.78')).toBeInTheDocument();
+    expect(screen.getByText('9')).toBeInTheDocument();
+    expect(screen.getByText('17')).toBeInTheDocument();
+
+    // KPI deltas
+    expect(screen.getByText(/2 running now/)).toBeInTheDocument();
+    expect(screen.getByText('All active')).toBeInTheDocument();
+  });
+
+  it('shows the avg-per-session delta when sessions have been launched', () => {
+    renderAuthedPage(<OverviewPage />, { props: buildProps() });
+    expect(screen.getByText(/avg per session/)).toBeInTheDocument();
+  });
+
+  it('omits the avg-per-session delta when no sessions have launched', () => {
+    renderAuthedPage(<OverviewPage />, {
+      props: buildProps({ summary: { ...buildProps().summary, sessionsLaunched: 0, totalSpendCents: 0 } }),
+    });
+    expect(screen.queryByText(/avg per session/)).not.toBeInTheDocument();
   });
 
   it('lists recent activity items when there is activity', () => {
@@ -103,32 +125,60 @@ describe('Projects/Overview/OverviewPage', () => {
     expect(screen.getByText('No recent activity found.')).toBeInTheDocument();
   });
 
-  it('renders the workflow run breakdown with completed/total counts', () => {
+  it('renders the workflow run donut with success rate, total and legend counts', () => {
     renderAuthedPage(<OverviewPage />, { props: buildProps() });
 
     expect(screen.getByText('Workflow Runs')).toBeInTheDocument();
+    // completed=25, failed=4 -> success rate = round(25/29 * 100) = 86%.
+    expect(screen.getByText('86%')).toBeInTheDocument();
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByText('45')).toBeInTheDocument();
+    expect(screen.getByText(/total runs/)).toBeInTheDocument();
+    expect(screen.getByText(/4 failures need review/)).toBeInTheDocument();
+
     expect(screen.getByText('Completed')).toBeInTheDocument();
     expect(screen.getByText('In Progress')).toBeInTheDocument();
     expect(screen.getByText('Failed')).toBeInTheDocument();
     expect(screen.getByText('Queued')).toBeInTheDocument();
-    // The "/ total" suffix appears once per row for total=14.
-    expect(screen.getAllByText('/ 14')).toHaveLength(4);
   });
 
-  it('renders the board task distribution columns and the total cell', () => {
+  it('omits the failures-need-review note when there are no failures', () => {
+    renderAuthedPage(<OverviewPage />, {
+      props: buildProps({
+        workflowRunStats: { completed: 8, inProgress: 2, failed: 0, queued: 3, total: 13 },
+      }),
+    });
+
+    expect(screen.queryByText(/need review/)).not.toBeInTheDocument();
+  });
+
+  it("navigates to the project's workflow runs page from the Open Runs button", async () => {
+    renderAuthedPage(<OverviewPage />, { props: buildProps() });
+    const { router } = await import('@inertiajs/react');
+
+    await userEvent.click(screen.getByRole('button', { name: /open runs/i }));
+
+    expect(vi.mocked(router.visit)).toHaveBeenCalledWith('/company/projects/42/workflow_runs');
+  });
+
+  it('renders the board task distribution as a horizontal bar list', () => {
     renderAuthedPage(<OverviewPage />, { props: buildProps() });
 
-    const heading = screen.getByText('Board Task Distribution');
-    expect(heading).toBeInTheDocument();
-
+    expect(screen.getByText('Board Task Distribution')).toBeInTheDocument();
     expect(screen.getByText('Backlog')).toBeInTheDocument();
     expect(screen.getByText('Doing')).toBeInTheDocument();
     expect(screen.getByText('Shipped')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('14')).toBeInTheDocument();
+    expect(screen.getByText('20')).toBeInTheDocument();
+  });
 
-    // The Total cell renders the board total and the literal "Total" label.
-    expect(screen.getByText('Total')).toBeInTheDocument();
-    // The total value (17) is rendered both as the "Board Tasks" stat and the
-    // board total cell, so assert there are two occurrences rather than one.
-    expect(screen.getAllByText('17').length).toBeGreaterThanOrEqual(2);
+  it("navigates to the project's board from the Open board button", async () => {
+    renderAuthedPage(<OverviewPage />, { props: buildProps() });
+    const { router } = await import('@inertiajs/react');
+
+    await userEvent.click(screen.getByRole('button', { name: /open board/i }));
+
+    expect(vi.mocked(router.visit)).toHaveBeenCalledWith('/company/projects/42/board');
   });
 });

--- a/app/frontend/pages/Projects/Overview/OverviewPage.tsx
+++ b/app/frontend/pages/Projects/Overview/OverviewPage.tsx
@@ -1,12 +1,13 @@
 import { Head, router, usePage } from '@inertiajs/react';
-import { Box, Progress, Text } from '@mantine/core';
-import { IconCoin, IconLayoutKanban, IconPlayerPlay, IconRoute } from '@tabler/icons-react';
-import type { CSSProperties } from 'react';
+import { Box, Button, RingProgress, Text } from '@mantine/core';
+import { IconArrowRight, IconChecklist, IconCoin, IconGitBranch, IconPlayerPlay } from '@tabler/icons-react';
 import { useEffect, useMemo } from 'react';
 
 import { PageHeader } from 'shared/ui/PageHeader';
 
 import { persistentProjectLayout, setPageLayout } from '../ProjectLayout';
+
+import classes from './OverviewPage.module.css';
 
 interface Project {
   id: number;
@@ -15,6 +16,7 @@ interface Project {
 
 interface Summary {
   sessionsLaunched: number;
+  sessionsRunning: number;
   totalSpendCents: number;
   workflowsCount: number;
   boardTasksCount: number;
@@ -90,175 +92,28 @@ const ACTIVITY_EVENT_COLORS: Record<string, string> = {
   gate_stale: 'var(--app-danger-fg)',
 };
 
-const WORKFLOW_STATUS_COLORS: Record<string, string> = {
-  Completed: 'var(--app-success-fg)',
-  'In Progress': 'var(--app-chart-2)',
-  Failed: 'var(--app-danger-fg)',
-  Queued: 'var(--app-warning-fg)',
-};
+// Status semantics for workflow runs (issue #522 handoff note): green = success
+// only, red = failed, amber = live/in-progress only, neutral = queued/backlog.
+const RUN_STATUS_COLOR = {
+  completed: 'var(--app-success-fg)',
+  failed: 'var(--app-danger-fg)',
+  inProgress: 'var(--app-warning-fg)',
+  queued: 'var(--app-text-tertiary)',
+} as const;
 
-const s: Record<string, CSSProperties> = {
-  pageHeader: {
-    marginBottom: 32,
-  },
-  pageTitle: {
-    fontSize: 24,
-    fontWeight: 700,
-    marginBottom: 4,
-  },
-  pageSubtitle: {
-    fontSize: 14,
-    color: 'var(--mantine-color-dimmed)',
-  },
-  sectionTitle: {
-    fontSize: 16,
-    fontWeight: 600,
-    marginBottom: 16,
-  },
-  statsGrid: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
-    gap: 16,
-    marginBottom: 32,
-  },
-  statCard: {
-    padding: 20,
-    backgroundColor: 'var(--app-bg-paper)',
-    borderRadius: 12,
-    border: '1px solid var(--app-border-default)',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 8,
-  },
-  statIconWrap: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 8,
-    marginBottom: 4,
-  },
-  statLabel: {
-    fontSize: 12,
-    color: 'var(--mantine-color-dimmed)',
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-  },
-  statValue: {
-    fontSize: 32,
-    fontWeight: 700,
-    lineHeight: 1.1,
-  },
-  twoCol: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
-    gap: 24,
-    marginBottom: 32,
-  },
-  card: {
-    padding: 24,
-    backgroundColor: 'var(--app-bg-paper)',
-    borderRadius: 12,
-    border: '1px solid var(--app-border-default)',
-  },
-  activityItem: {
-    display: 'flex',
-    alignItems: 'flex-start',
-    gap: 12,
-    padding: '10px 0',
-    borderBottom: '1px solid var(--app-border-default)',
-  },
-  activityItemLast: {
-    display: 'flex',
-    alignItems: 'flex-start',
-    gap: 12,
-    padding: '10px 0',
-  },
-  activityDot: {
-    width: 8,
-    height: 8,
-    borderRadius: '50%',
-    marginTop: 5,
-    flexShrink: 0,
-  },
-  activityText: {
-    fontSize: 13,
-    lineHeight: 1.4,
-  },
-  activityTime: {
-    fontSize: 11,
-    color: 'var(--mantine-color-dimmed)',
-    marginTop: 2,
-  },
-  progressRow: {
-    marginBottom: 16,
-  },
-  progressRowLast: {
-    marginBottom: 0,
-  },
-  progressLabel: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    marginBottom: 6,
-  },
-  progressLabelText: {
-    fontSize: 13,
-    color: 'var(--mantine-color-dimmed)',
-  },
-  progressLabelValue: {
-    fontSize: 13,
-    fontWeight: 500,
-  },
-  boardGrid: {
-    padding: 24,
-    backgroundColor: 'var(--app-bg-paper)',
-    borderRadius: 12,
-    border: '1px solid var(--app-border-default)',
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
-    gap: 16,
-  },
-  boardCell: {
-    textAlign: 'center',
-    padding: 12,
-    borderRadius: 8,
-    backgroundColor: 'var(--app-bg-elevated)',
-  },
-  boardCellValue: {
-    fontSize: 28,
-    fontWeight: 700,
-  },
-  boardCellName: {
-    fontSize: 12,
-    color: 'var(--mantine-color-dimmed)',
-    marginTop: 4,
-  },
-  boardCellTotal: {
-    textAlign: 'center',
-    padding: 12,
-    borderRadius: 8,
-    backgroundColor: 'var(--mantine-color-brand-7)',
-  },
-  boardCellTotalValue: {
-    fontSize: 28,
-    fontWeight: 700,
-    color: 'white',
-  },
-  boardCellTotalName: {
-    fontSize: 12,
-    color: 'white',
-    marginTop: 4,
-    opacity: 0.85,
-  },
-};
+// Neutral-to-green ramp for board columns, per the handoff note. Column
+// semantics are project-defined, so "Done" is detected by name; everything
+// else cycles through the warm-neutral ramp by position.
+const BOARD_NEUTRAL_RAMP = ['var(--app-chart-warm-1)', 'var(--app-chart-warm-2)', 'var(--app-chart-warm-3)'];
 
-// One muted tone for all four. These were four unrelated hues (blue, green,
-// indigo, yellow) on values that share no scale — decoration reading as
-// encoding. The number is the signal; the icon just names the metric.
-const STAT_ICONS = [
-  { Icon: IconPlayerPlay, color: 'var(--app-text-tertiary)' },
-  { Icon: IconCoin, color: 'var(--app-text-tertiary)' },
-  { Icon: IconRoute, color: 'var(--app-text-tertiary)' },
-  { Icon: IconLayoutKanban, color: 'var(--app-text-tertiary)' },
-];
+function boardColumnColor(name: string, index: number): string {
+  if (/done/i.test(name)) return 'var(--app-success-fg)';
+  return BOARD_NEUTRAL_RAMP[index % BOARD_NEUTRAL_RAMP.length];
+}
+
+// One muted tone for all four KPI icons: the number is the signal, the icon
+// just names the metric.
+const KPI_ICON_COLOR = 'var(--app-text-tertiary)';
 
 /**
  * Fold consecutive identical events into one row.
@@ -299,135 +154,192 @@ const OverviewPage = () => {
 
   const groupedActivity = useMemo(() => groupActivity(recentActivity ?? []), [recentActivity]);
 
-  const projectStats = [
-    { label: 'Sessions Launched', value: (summary.sessionsLaunched ?? 0).toLocaleString() },
-    { label: 'Total Spend', value: formatSpend(summary.totalSpendCents ?? 0) },
-    { label: 'Workflows', value: (summary.workflowsCount ?? 0).toLocaleString() },
-    { label: 'Board Tasks', value: (summary.boardTasksCount ?? 0).toLocaleString() },
+  const { completed, failed, inProgress, queued, total } = workflowRunStats;
+  // Success rate excludes runs that haven't settled yet (in-progress/queued),
+  // per the handoff note: completed ÷ (completed + failed).
+  const settled = completed + failed;
+  const successRate = settled > 0 ? Math.round((completed / settled) * 100) : 0;
+  const runSections = [
+    { value: total > 0 ? (completed / total) * 100 : 0, color: RUN_STATUS_COLOR.completed },
+    { value: total > 0 ? (failed / total) * 100 : 0, color: RUN_STATUS_COLOR.failed },
+    { value: total > 0 ? (inProgress / total) * 100 : 0, color: RUN_STATUS_COLOR.inProgress },
+    { value: total > 0 ? (queued / total) * 100 : 0, color: RUN_STATUS_COLOR.queued },
+  ];
+  const runLegend = [
+    { label: 'Completed', value: completed, color: RUN_STATUS_COLOR.completed },
+    { label: 'Failed', value: failed, color: RUN_STATUS_COLOR.failed },
+    { label: 'In Progress', value: inProgress, color: RUN_STATUS_COLOR.inProgress },
+    { label: 'Queued', value: queued, color: RUN_STATUS_COLOR.queued },
   ];
 
-  const workflowStatus = [
-    {
-      label: 'Completed',
-      value: workflowRunStats.completed ?? 0,
-      total: workflowRunStats.total ?? 0,
-      color: WORKFLOW_STATUS_COLORS['Completed'],
-    },
-    {
-      label: 'In Progress',
-      value: workflowRunStats.inProgress ?? 0,
-      total: workflowRunStats.total ?? 0,
-      color: WORKFLOW_STATUS_COLORS['In Progress'],
-    },
-    {
-      label: 'Failed',
-      value: workflowRunStats.failed ?? 0,
-      total: workflowRunStats.total ?? 0,
-      color: WORKFLOW_STATUS_COLORS['Failed'],
-    },
-    {
-      label: 'Queued',
-      value: workflowRunStats.queued ?? 0,
-      total: workflowRunStats.total ?? 0,
-      color: WORKFLOW_STATUS_COLORS['Queued'],
-    },
-  ];
+  const avgPerSessionCents = summary.sessionsLaunched > 0 ? summary.totalSpendCents / summary.sessionsLaunched : null;
+
+  const boardColumns = boardTaskDistribution.columns ?? [];
+  const maxColumnCount = Math.max(1, ...boardColumns.map((c) => c.count));
 
   return (
     <>
       <Head title={`Overview — ${project.name}`} />
       <Box>
-        <PageHeader title="Project Overview" subtitle="Project activity at a glance" />
+        <PageHeader title="Project Overview" subtitle="Current and overall project activity" />
 
-        <Text style={s.sectionTitle}>Project Summary</Text>
-        <Box style={s.statsGrid}>
-          {projectStats.map((stat, idx) => (
-            <Box key={stat.label} style={s.statCard}>
-              <Box style={s.statIconWrap}>
-                {(() => {
-                  const { Icon, color } = STAT_ICONS[idx];
-                  return <Icon size={20} color={color} />;
-                })()}
-                <Text style={s.statLabel}>{stat.label}</Text>
-              </Box>
-              <Text style={s.statValue}>{stat.value}</Text>
+        <Box className={classes.kpiRow}>
+          <Box className={classes.kpiCard}>
+            <Box className={classes.kpiTop}>
+              <IconPlayerPlay size={15} color={KPI_ICON_COLOR} />
+              <Text className={classes.kpiLabel}>Sessions Launched</Text>
             </Box>
-          ))}
-        </Box>
+            <Text className={classes.kpiValue}>{summary.sessionsLaunched.toLocaleString()}</Text>
+            <Text className={classes.kpiDelta}>
+              <span className={classes.liveDot} /> {summary.sessionsRunning} running now
+            </Text>
+          </Box>
 
-        <Box style={s.twoCol}>
-          <Box style={s.card}>
-            <Text style={s.sectionTitle}>Recent Activity</Text>
-            {groupedActivity.length === 0 ? (
-              <Text style={{ fontSize: 13, color: 'var(--mantine-color-dimmed)', padding: '10px 0' }}>
-                No recent activity found.
-              </Text>
-            ) : (
-              groupedActivity.map((item, idx) => (
-                <Box key={idx} style={idx < groupedActivity.length - 1 ? s.activityItem : s.activityItemLast}>
-                  <Box
-                    style={{
-                      ...s.activityDot,
-                      backgroundColor: ACTIVITY_EVENT_COLORS[item.eventType] ?? 'var(--app-text-tertiary)',
-                    }}
-                  />
-                  <Box>
-                    <Text style={s.activityText}>
-                      {item.description}
-                      {item.count > 1 && (
-                        <Text span style={{ color: 'var(--app-text-tertiary)', fontWeight: 600 }}>
-                          {' '}
-                          &times;{item.count}
-                        </Text>
-                      )}
-                    </Text>
-                    <Text style={s.activityTime}>
-                      {item.actorName} · {formatRelativeTime(item.occurredAt)}
-                    </Text>
-                  </Box>
-                </Box>
-              ))
+          <Box className={classes.kpiCard}>
+            <Box className={classes.kpiTop}>
+              <IconCoin size={15} color={KPI_ICON_COLOR} />
+              <Text className={classes.kpiLabel}>Total Spend</Text>
+            </Box>
+            <Text className={`${classes.kpiValue} ${classes.kpiValueMono}`}>
+              {formatSpend(summary.totalSpendCents)}
+            </Text>
+            {avgPerSessionCents != null && (
+              <Text className={classes.kpiDelta}>{formatSpend(avgPerSessionCents)} avg per session</Text>
             )}
           </Box>
 
-          <Box style={s.card}>
-            <Text style={s.sectionTitle}>Workflow Runs</Text>
-            {workflowStatus.map((item, idx) => (
-              <Box key={item.label} style={idx < workflowStatus.length - 1 ? s.progressRow : s.progressRowLast}>
-                <Box style={s.progressLabel}>
-                  <Text style={s.progressLabelText}>{item.label}</Text>
-                  <Text style={s.progressLabelValue}>
-                    {item.value}{' '}
-                    <Text span style={{ color: 'var(--mantine-color-dimmed)', fontWeight: 400 }}>
-                      / {item.total}
-                    </Text>
-                  </Text>
-                </Box>
-                <Progress
-                  value={item.total > 0 ? (item.value / item.total) * 100 : 0}
-                  color={item.color}
-                  size={6}
-                  radius={3}
-                />
-              </Box>
-            ))}
+          <Box className={classes.kpiCard}>
+            <Box className={classes.kpiTop}>
+              <IconGitBranch size={15} color={KPI_ICON_COLOR} />
+              <Text className={classes.kpiLabel}>Workflows</Text>
+            </Box>
+            <Text className={classes.kpiValue}>{summary.workflowsCount.toLocaleString()}</Text>
+            <Text className={classes.kpiDelta}>All active</Text>
+          </Box>
+
+          <Box className={classes.kpiCard}>
+            <Box className={classes.kpiTop}>
+              <IconChecklist size={15} color={KPI_ICON_COLOR} />
+              <Text className={classes.kpiLabel}>Board Tasks</Text>
+            </Box>
+            <Text className={classes.kpiValue}>{summary.boardTasksCount.toLocaleString()}</Text>
           </Box>
         </Box>
 
-        <Text style={s.sectionTitle}>Board Task Distribution</Text>
-        <Box style={s.boardGrid}>
-          {(boardTaskDistribution.columns ?? []).map((col) => (
-            <Box key={col.name} style={s.boardCell}>
-              <Text style={s.boardCellValue}>{col.count}</Text>
-              <Text style={s.boardCellName}>{col.name}</Text>
+        <Box className={classes.twoCol}>
+          <Box className={classes.panel}>
+            <Box className={classes.panelHead}>
+              <Text className={classes.sectionTitle}>Recent Activity</Text>
             </Box>
-          ))}
-          {(boardTaskDistribution.total ?? 0) > 0 && (
-            <Box style={s.boardCellTotal}>
-              <Text style={s.boardCellTotalValue}>{boardTaskDistribution.total}</Text>
-              <Text style={s.boardCellTotalName}>Total</Text>
+            {groupedActivity.length === 0 ? (
+              <Text className={classes.emptyState}>No recent activity found.</Text>
+            ) : (
+              <Box className={classes.actList}>
+                {groupedActivity.map((item, idx) => (
+                  <Box key={idx} className={idx < groupedActivity.length - 1 ? classes.actItem : classes.actItemLast}>
+                    <Box
+                      className={classes.actDot}
+                      style={{ backgroundColor: ACTIVITY_EVENT_COLORS[item.eventType] ?? 'var(--app-text-tertiary)' }}
+                    />
+                    <Box className={classes.actBody}>
+                      <Text className={classes.actTxt}>
+                        {item.description}
+                        {item.count > 1 && (
+                          <Text span c="var(--app-text-tertiary)" fw={600}>
+                            {' '}
+                            &times;{item.count}
+                          </Text>
+                        )}
+                      </Text>
+                      <Text className={classes.actMeta}>
+                        {item.actorName} · {formatRelativeTime(item.occurredAt)}
+                      </Text>
+                    </Box>
+                  </Box>
+                ))}
+              </Box>
+            )}
+          </Box>
+
+          <Box className={classes.panel}>
+            <Box className={classes.panelHead}>
+              <Text className={classes.sectionTitle}>Workflow Runs</Text>
+              <Button
+                variant="subtle"
+                size="compact-xs"
+                rightSection={<IconArrowRight size={13} />}
+                onClick={() => router.visit(`/company/projects/${project.id}/workflow_runs`)}
+              >
+                Open Runs
+              </Button>
             </Box>
-          )}
+            <Box className={classes.runsBody}>
+              <RingProgress
+                size={130}
+                thickness={13}
+                sections={runSections}
+                label={
+                  <Box className={classes.donutCenter}>
+                    <Text className={classes.donutNum}>{successRate}%</Text>
+                    <Text className={classes.donutCap}>Success</Text>
+                  </Box>
+                }
+              />
+              <Box className={classes.runsInfo}>
+                <Text className={classes.rhTotal}>
+                  <Text span className={classes.rhTotalValue}>
+                    {total}
+                  </Text>{' '}
+                  total runs
+                </Text>
+                <Text className={classes.rhNote}>
+                  Success rate is completed ÷ settled runs.
+                  {failed > 0 && ` ${failed} failure${failed === 1 ? '' : 's'} need review.`}
+                </Text>
+                <Box className={classes.legend}>
+                  {runLegend.map((item) => (
+                    <Box key={item.label} className={classes.legRow}>
+                      <span className={classes.legDot} style={{ background: item.color }} />
+                      <span className={classes.legName}>{item.label}</span>
+                      <span className={classes.legVal}>{item.value}</span>
+                      <span className={classes.legPct}>{total > 0 ? Math.round((item.value / total) * 100) : 0}%</span>
+                    </Box>
+                  ))}
+                </Box>
+              </Box>
+            </Box>
+          </Box>
+        </Box>
+
+        <Box className={classes.panel}>
+          <Box className={classes.panelHead} style={{ marginBottom: 14 }}>
+            <Text className={classes.sectionTitle}>Board Task Distribution</Text>
+            <Button
+              variant="subtle"
+              size="compact-xs"
+              rightSection={<IconArrowRight size={13} />}
+              onClick={() => router.visit(`/company/projects/${project.id}/board`)}
+            >
+              Open board
+            </Button>
+          </Box>
+          <Box className={classes.hbarList}>
+            {boardColumns.map((col, idx) => (
+              <Box key={col.name} className={classes.hbarRow}>
+                <Text className={classes.hbarName}>{col.name}</Text>
+                <Box className={classes.hbarTrack}>
+                  <Box
+                    className={classes.hbarFill}
+                    style={{
+                      width: `${(col.count / maxColumnCount) * 100}%`,
+                      background: boardColumnColor(col.name, idx),
+                    }}
+                  />
+                </Box>
+                <Text className={classes.hbarCount}>{col.count}</Text>
+              </Box>
+            ))}
+          </Box>
         </Box>
       </Box>
     </>

--- a/app/services/company_overview_service.rb
+++ b/app/services/company_overview_service.rb
@@ -2,7 +2,7 @@
 
 class CompanyOverviewService
   Result = Struct.new(
-    :sessions_launched, :total_spend_cents, :workflows_count,
+    :sessions_launched, :sessions_running, :total_spend_cents, :workflows_count,
     :board_tasks_count,
     keyword_init: true
   )
@@ -15,6 +15,7 @@ class CompanyOverviewService
   def call
     Result.new(
       sessions_launched: sessions_scope.count,
+      sessions_running: sessions_scope.where(state: %w[running ready]).count,
       total_spend_cents: sessions_scope.sum(:cost_cents),
       workflows_count: workflows_scope.count,
       board_tasks_count: board_tasks_scope.count

--- a/test/integration/web/company/projects/overview_controller_test.rb
+++ b/test/integration/web/company/projects/overview_controller_test.rb
@@ -14,4 +14,16 @@ class Web::Company::Projects::OverviewControllerTest < ActionDispatch::Integrati
     get company_project_overview_index_path(@project)
     assert_inertia_page "Projects/Overview/OverviewPage"
   end
+
+  test "summary reports the count of currently running sessions" do
+    create(:terminal_session, :agent_session, project: @project, user: @user, state: "not_started")
+    create(:terminal_session, :agent_session, project: @project, user: @user, state: "running")
+    create(:terminal_session, :agent_session, project: @project, user: @user, state: "ready")
+
+    get company_project_overview_index_path(@project)
+
+    assert_inertia_props do |props|
+      props[:summary][:sessionsLaunched] == 3 && props[:summary][:sessionsRunning] == 2
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Redesigns the Project Overview page per the mockup attached to https://github.com/palad-ai/palad-app/issues/522: KPI cards with live deltas, a Workflow Runs donut (Mantine `RingProgress`) with legend + success-rate note, and a Board Task Distribution horizontal bar list (replacing the four-row progress-bar panel and the stat-card grid).
- Colors/spacing/radii are taken from the mockup; colors are mapped onto the app's existing `--app-*` theme tokens (e.g. mockup `#cf6b4a` → `--app-accent`, `#4a9a6d` → `--app-success-fg`) so both light and dark themes render correctly — the mockup only specified a dark palette.
- Adds `sessionsRunning` to `CompanyOverviewService` to back the new "N running now" Sessions KPI delta.
- "Open Runs" and "Open board" buttons navigate to the existing workflow runs / board pages.

### Scope decisions (confirmed with the requester)
- No "View all" link on Recent Activity — there's no project-level activity feed page to link to.
- No "in progress" delta on the Board Tasks KPI — board columns are project-custom-named, so there's no reliable way to identify an "in progress" column generically.
- The "Powered by Aixle" footer in the mockup already exists in the shared `AuthLayout` — no change needed there.

## Test plan
- [x] `docker compose exec -T web make check_all` — green (backend 92.12% / frontend 81.25% coverage)
- [x] `OverviewPage.test.tsx` extended: KPI cards + deltas, donut success-rate/legend/failure-note, board bar list, and the two new navigation buttons
- [x] `overview_controller_test.rb` extended: asserts `sessionsRunning` counts only `running`/`ready` sessions
- [ ] Visual check in a running browser — not done in this session (no browser connection available); worth a manual look in both light and dark theme before merge