### PR TITLE
docs(portal): publish the product user guide at /docs

### DIFF
--- a/app/controllers/web/docs_controller.rb
+++ b/app/controllers/web/docs_controller.rb
@@ -22,7 +22,10 @@ class Web::DocsController < Web::ApplicationController
   private
 
   def page_exists?(slug)
-    %w[user-guide quick-start agents runtimes tools mcp board workflows
+    %w[using-flow getting-started project-home tasks running-workflows starting-work
+       sessions-and-runs assets personas agent-capabilities repositories ai-builder
+       people-and-access secrets analytics company-workspace examples
+       user-guide quick-start agents runtimes tools mcp board workflows
        triggers-and-gates integrations configuration reference cli-ref api-guide
        config-schema].include?(slug)
   end

--- a/app/frontend/pages/Docs/data/navStructure.test.ts
+++ b/app/frontend/pages/Docs/data/navStructure.test.ts
@@ -16,13 +16,20 @@ describe('findNavSection', () => {
   it('returns the section that contains the slug', () => {
     expect(findNavSection('api-guide')?.label).toBe('Reference');
     expect(findNavSection('agents')?.label).toBe('User guide');
+    expect(findNavSection('tasks')?.label).toBe('Using Flow');
   });
 });
 
 describe('getPrevNext', () => {
   it('first item has no prev', () => {
-    const { prev, next } = getPrevNext('user-guide');
+    const { prev, next } = getPrevNext('using-flow');
     expect(prev).toBeNull();
+    expect(next?.slug).toBe('getting-started');
+  });
+
+  it('walks from the end of the product guide into the operator guide', () => {
+    const { prev, next } = getPrevNext('user-guide');
+    expect(prev?.slug).toBe('examples');
     expect(next?.slug).toBe('quick-start');
   });
 

--- a/app/frontend/pages/Docs/data/navStructure.ts
+++ b/app/frontend/pages/Docs/data/navStructure.ts
@@ -11,6 +11,30 @@ export interface NavSection {
 }
 
 export const NAV_STRUCTURE: NavSection[] = [
+  // The product guide comes first: most readers arrive wanting to use Flow, not to
+  // install it. The operator sections below keep their slugs so existing links hold.
+  {
+    label: 'Using Flow',
+    items: [
+      { slug: 'using-flow', label: 'What Flow is' },
+      { slug: 'getting-started', label: 'Getting started' },
+      { slug: 'project-home', label: 'Project home & settings' },
+      { slug: 'tasks', label: 'Tasks & the board' },
+      { slug: 'running-workflows', label: 'Building workflows' },
+      { slug: 'starting-work', label: 'Triggers & gates' },
+      { slug: 'sessions-and-runs', label: 'Sessions & Runs' },
+      { slug: 'assets', label: 'Assets' },
+      { slug: 'personas', label: 'Agent personas' },
+      { slug: 'agent-capabilities', label: 'Wrappers, Skills & Connectors' },
+      { slug: 'repositories', label: 'Repositories & Integrations' },
+      { slug: 'ai-builder', label: 'AI Builder' },
+      { slug: 'people-and-access', label: 'Team & access' },
+      { slug: 'secrets', label: 'Secrets & Variables' },
+      { slug: 'analytics', label: 'Analytics & cost' },
+      { slug: 'company-workspace', label: 'Company workspace' },
+      { slug: 'examples', label: 'Worked examples' },
+    ],
+  },
   {
     label: 'User guide',
     items: [

--- a/app/frontend/pages/Docs/data/pages/agent-capabilities.md
+++ b/app/frontend/pages/Docs/data/pages/agent-capabilities.md
@@ -1,0 +1,47 @@
+# Wrappers, Skills & Connectors
+
+Three ways to give agents more than their own reasoning. They are easy to
+confuse, so start here:
+
+| | It gives the agent | Use when |
+| --- | --- | --- |
+| **Wrappers** | An action *you* define — a script or API turned into a callable tool | You have an internal service with no ready-made integration |
+| **Skills** | Know-how — packaged instructions loaded during a session | The same expertise keeps being retyped into prompts |
+| **Connectors** | Tools from an external server, ready-made | The agent must act on a system someone else built |
+
+## Wrappers
+
+The **Wrappers** page lists the project's custom tools. Each row shows how it
+runs — a container image you specify, or one of Flow's built-ins — and the list
+filters by name.
+
+Define a wrapper once, attach it to the steps that need it, and it becomes a
+capability the agent can call during a run. Deleting one asks for confirmation
+first, because a step that expects it will notice.
+
+## Skills
+
+The **Skills** page has two ways in:
+
+- **Catalog** — browse what is published, install what fits. Each entry shows
+  how many times it has been installed.
+- **Write one by hand** — the authoring form from the page header, for
+  know-how that is specific to your team: "how we write migrations", "our
+  review checklist", "our commit conventions".
+
+Installed skills are listed with their install counts. Attach a skill where it
+should apply, and agents follow it when the work matches.
+
+## Connectors
+
+The **Connectors** page manages external tool servers. Add one from the
+catalog, or by hand when you know the server you want. Servers you added
+yourself can be edited; the list filters by name.
+
+Credentials belong in [Secrets & Variables](/docs/secrets), not in the
+connector's own fields or in a task description — that is what keeps them out
+of prompts and logs.
+
+> tip If you are unsure which of the three you need: it is a **connector** if
+> someone else already runs it, a **wrapper** if you have to write it, and a
+> **skill** if there is nothing to call at all — only knowledge to apply.

--- a/app/frontend/pages/Docs/data/pages/ai-builder.md
+++ b/app/frontend/pages/Docs/data/pages/ai-builder.md
@@ -1,0 +1,39 @@
+# AI Builder
+
+Describe a process in plain language and let Flow build it: board columns,
+workflows, steps, and the tools they need. The sidebar entry is **AI Builder**
+with a **Build with AI** button; inside, the feature calls itself **Aixle
+Builder**.
+
+## Before you start
+
+The builder runs on a real agent, so the project needs at least one configured
+runtime — it says so plainly if none is connected. Viewers do not get the start
+control, since they cannot execute work in the project.
+
+## A builder session
+
+1. **Say what you want.** "When a card lands in Triage, summarise it, label it,
+   and draft a reply for review." Pick the model, and attach project assets if
+   the builder should read something first.
+2. **Watch it work.** The session shows its terminal live and an activity feed
+   naming each thing it creates as it creates it.
+3. **Check what it made.** The **Workflows** and **Board** tabs show the result
+   — workflows with their steps, columns with their auto-trigger bindings —
+   while the session is still open.
+4. **Finish Session** when it looks right.
+
+Previous builder sessions stay in a list; an unfinished one offers to continue
+where it stopped. A session that ended badly keeps its error, so you can see
+what it failed on rather than guessing.
+
+## Afterwards
+
+Everything the builder made is ordinary: the workflows open in the
+[workflow editor](/docs/running-workflows), the columns behave like any other
+[board](/docs/tasks) columns. Adjust by hand — the builder is a starting point,
+not a black box you have to accept whole.
+
+> tip The builder is at its best on a process you can describe in a paragraph.
+> For a seven-stage release pipeline, build the first two stages with it and
+> extend by hand.

--- a/app/frontend/pages/Docs/data/pages/analytics.md
+++ b/app/frontend/pages/Docs/data/pages/analytics.md
@@ -1,0 +1,41 @@
+# Analytics & Cost
+
+Agent work costs money per run, so Flow counts it everywhere: per card, per
+project, per company.
+
+## Project analytics
+
+The project's **Analytics** page answers "what did this cost us, and where did
+it go?"
+
+- **Period** — pick the window; every panel follows it.
+- **Scope** — switch between all sessions and workflow-driven ones, so ad-hoc
+  experiments do not muddy the numbers for an automated process.
+- **Participant** — narrow to one person's work.
+- **Cost & token usage** — spend and tokens over the period.
+- **Agent activity** — sessions and cost per runtime, so you can see what your
+  Claude Code and Codex usage actually cost side by side.
+- **Workflow breakdown** — per workflow, which is how you find the process that
+  is quietly expensive.
+- **Contribution heatmap** — activity over time at a glance.
+
+## Company analytics
+
+Admins get the same questions asked across every project: a per-project
+breakdown, and a **sources** panel showing where sessions came from — the
+board, a schedule, Slack, a webhook, a person — each as a share of the total.
+
+Large numbers are abbreviated (thousands of tokens, thousands of dollars) so a
+row stays readable.
+
+## Where else cost shows up
+
+- On a **card**, in its Analytics tab — what this one piece of work cost.
+- On a **run**, in the header totals and per step.
+- In your **Profile → Usage** — your own consumption, and the time left on any
+  usage window that applies to you.
+
+> tip Two numbers explain most surprises: cost per session on
+> [Overview](/docs/project-home), and the workflow breakdown here. A workflow
+> with a retry loop shows up in the second long before anyone notices in the
+> first.

--- a/app/frontend/pages/Docs/data/pages/assets.md
+++ b/app/frontend/pages/Docs/data/pages/assets.md
@@ -1,0 +1,30 @@
+# Assets
+
+**Assets** is the project's file shelf: what people upload for agents to work
+from, and what agents produce.
+
+## Uploading
+
+**Upload** takes files from your machine into the project. Anything here can be
+handed to a step as an input in the workflow editor's Data Flow section, or
+attached to a card so the agent working that card sees it.
+
+## What agents produce
+
+A run's output starts inside the run. Two ways it reaches the project:
+
+1. **Promote** a file from the run's Assets tab — a deliberate "this one
+   matters" gesture.
+2. **Review outputs** on the run in the list, keeping what you select.
+
+That two-step shape is on purpose: a long run can touch dozens of files, and
+most of them are scratch.
+
+## Finding and versioning
+
+Search narrows the list by name. Every asset keeps its **version history** —
+open it to see the earlier revisions and where each came from, which matters
+when the same report is regenerated weekly by the same workflow.
+
+> info Assets are per project. Files the whole company should reach live in
+> **Company Assets** — see [Company workspace](/docs/company-workspace).

--- a/app/frontend/pages/Docs/data/pages/company-workspace.md
+++ b/app/frontend/pages/Docs/data/pages/company-workspace.md
@@ -1,0 +1,37 @@
+# Company Workspace
+
+Above projects sits the company: the shared layer where things that should not
+be reinvented per project live.
+
+## Projects
+
+The **Projects** page lists what you have access to and is where new ones are
+created. If you belong to more than one company, a switcher on the far left
+moves between workspaces — each with its own projects, members, and numbers.
+
+## Workflow Catalog
+
+Workflows published from a project land in the catalog, with their publisher
+named. Anyone can search it and **Copy & Configure** one into a project of
+their choice — the copy is theirs to edit, so adjusting the steps does not
+touch the original.
+
+If you are not on any project yet, the catalog says so instead of offering a
+project to copy into.
+
+## Company-wide monitoring (admins)
+
+- **Analytics** — spend and activity across every project, with a per-project
+  breakdown and where sessions originate.
+- **Sessions** — every session in the workspace, with the same review controls
+  as a project's list: keep the artifacts worth keeping, dismiss the rest.
+
+## Company Assets and Members
+
+- **Assets** — files that belong to the workspace rather than to one project.
+  Upload and search work as they do in a project.
+- **Members** — everyone in the company, searchable, with role changes
+  available to admins. See [Team & access](/docs/people-and-access).
+
+> info Company analytics, sessions, and assets are admin-only. Members is not —
+> everyone can see who they work with.

--- a/app/frontend/pages/Docs/data/pages/examples.md
+++ b/app/frontend/pages/Docs/data/pages/examples.md
@@ -1,0 +1,50 @@
+# Worked Examples
+
+Two end-to-end stories. Each names every screen it touches, so you can replay
+it in your own workspace.
+
+## Drop a card, get a pull request back
+
+**The setup.** A lead connects the GitHub integration and links the service's
+repository ([Repositories & Integrations](/docs/repositories)). The board uses
+the **Dev Team** template, and its *Implementation* column is bound to an
+implementation workflow in board settings, set to **Auto**.
+
+**The work.** They write a card describing a small feature and drag it into
+*Implementation*.
+
+1. The run starts on its own. In [Sessions & Runs](/docs/sessions-and-runs) it
+   shows four steps: one plans, two run in parallel — implementation and tests
+   — and a final step waits for a person.
+2. The lead watches the implementing step's terminal live on the run page.
+3. The agent posts a summary of the diff to the card as a comment; the card's
+   CI gate goes to **waiting** while the pipeline runs, then **passed**.
+4. The waiting step shows **Approve & continue**. The lead approves, and the
+   final step opens the pull request in the team's own repo.
+5. The card moves to *Code Review*. Its Analytics tab shows what the whole
+   thing cost.
+
+**What made it work.** The column's purpose told the agent what
+*Implementation* means here; the persona told it how the team reviews; the
+repository resource is what let it push at all.
+
+## Build a workflow from one prompt
+
+**The setup.** An operator has a support inbox landing on the board and no
+process for it yet.
+
+1. They open [AI Builder](/docs/ai-builder) and type: *"When a card lands in
+   Triage, summarise it, label it, and draft a reply for review."*
+2. The builder proposes a *Triage* column with an auto binding, a three-step
+   workflow, and the connector it needs to read the ticketing system. The
+   Workflows and Board tabs show all of it before anything is final.
+3. The operator finishes the session, adds the connector's credential in
+   [Secrets & Variables](/docs/secrets), and drops a test card into *Triage*.
+4. The run appears in Sessions & Runs; the draft reply lands on the card as a
+   comment.
+5. They edit the second step by hand — the label set was too broad — and leave
+   the rest as generated.
+
+**What made it work.** The builder produced ordinary objects. Nothing about the
+workflow it wrote is special: it is edited, run, and measured like anything
+built by hand.

--- a/app/frontend/pages/Docs/data/pages/getting-started.md
+++ b/app/frontend/pages/Docs/data/pages/getting-started.md
@@ -1,0 +1,53 @@
+# Getting Started
+
+From an invitation to your first running workflow.
+
+## Sign in
+
+Accept the invitation you were emailed, or sign in if an account already exists
+for you. Flow supports email sign-in and Google.
+
+## Onboarding
+
+First-run onboarding is two steps and takes a minute.
+
+**1. About you.** Pick the role card that matches how you will work, and choose
+the language you want agents to write in — task summaries, review notes, and
+generated documents follow it. Continue stays disabled until both are set.
+
+**2. Connect agents.** Five cards, one per supported runtime: Claude Code,
+Cursor CLI, Codex, Gemini CLI, and Grok. Click **Connect** on the one whose
+account you already have. A terminal opens inline, the runtime's own login runs
+in it, and Flow keeps the resulting credential for you.
+
+You need at least one connected agent to finish onboarding — nothing can run on
+your behalf until then.
+
+> info Invited as a **viewer**? The connect step is replaced by a short tour.
+> Viewers read boards, runs and results; they do not start work, so they do not
+> need a credential.
+
+## Your profile
+
+Everything personal lives in **Profile**, on three tabs.
+
+| Tab | What is there |
+| --- | --- |
+| **Account** | Your display name, your connected agent credentials, default models, and the companies you belong to |
+| **Usage** | Your own sessions, tokens and spend — plus any usage window that applies to you, with the time left on it |
+| **MCP** | Personal access: generate a token so an agent you run *outside* Flow (your own Claude Code, for example) can reach your Aixle projects |
+
+Credentials expire the way the underlying product's do. Reconnect from the same
+place — the Account tab — and runs pick the new credential up.
+
+## Open your first project
+
+Go to **Projects**, pick one, and you land on its **Overview**: recent
+activity, how tasks are spread across the board, runs, sessions, success rate,
+and spend. From there, **Tasks** is the board where work actually happens.
+
+## What to read next
+
+1. [Tasks & the board](/docs/tasks) — where work enters and results land
+2. [Building workflows](/docs/running-workflows) — turning a process into steps
+3. [Sessions & Runs](/docs/sessions-and-runs) — watching and steering a run

--- a/app/frontend/pages/Docs/data/pages/index.ts
+++ b/app/frontend/pages/Docs/data/pages/index.ts
@@ -1,17 +1,34 @@
+import agentCapabilities from './agent-capabilities.md?raw';
 import agents from './agents.md?raw';
+import aiBuilder from './ai-builder.md?raw';
+import analytics from './analytics.md?raw';
 import apiGuide from './api-guide.md?raw';
+import assets from './assets.md?raw';
 import board from './board.md?raw';
 import cliRef from './cli-ref.md?raw';
+import companyWorkspace from './company-workspace.md?raw';
 import configSchema from './config-schema.md?raw';
 import configuration from './configuration.md?raw';
+import examples from './examples.md?raw';
+import gettingStarted from './getting-started.md?raw';
 import integrations from './integrations.md?raw';
 import mcp from './mcp.md?raw';
+import peopleAndAccess from './people-and-access.md?raw';
+import personas from './personas.md?raw';
+import projectHome from './project-home.md?raw';
 import quickStart from './quick-start.md?raw';
 import reference from './reference.md?raw';
+import repositories from './repositories.md?raw';
+import runningWorkflows from './running-workflows.md?raw';
 import runtimes from './runtimes.md?raw';
+import secrets from './secrets.md?raw';
+import sessionsAndRuns from './sessions-and-runs.md?raw';
+import startingWork from './starting-work.md?raw';
+import tasks from './tasks.md?raw';
 import tools from './tools.md?raw';
 import triggersAndGates from './triggers-and-gates.md?raw';
 import userGuide from './user-guide.md?raw';
+import usingFlow from './using-flow.md?raw';
 import workflows from './workflows.md?raw';
 
 export interface TocItem {
@@ -52,6 +69,108 @@ function slugify(text: string): string {
 }
 
 export const DOC_PAGES: Record<string, DocPage & { toc: TocItem[] }> = {
+  'using-flow': {
+    title: 'What Flow is',
+    section: 'Using Flow',
+    content: usingFlow,
+    toc: extractToc(usingFlow),
+  },
+  'getting-started': {
+    title: 'Getting started',
+    section: 'Using Flow',
+    content: gettingStarted,
+    toc: extractToc(gettingStarted),
+  },
+  'project-home': {
+    title: 'Project home & settings',
+    section: 'Using Flow',
+    content: projectHome,
+    toc: extractToc(projectHome),
+  },
+  tasks: {
+    title: 'Tasks & the board',
+    section: 'Using Flow',
+    content: tasks,
+    toc: extractToc(tasks),
+  },
+  'running-workflows': {
+    title: 'Building workflows',
+    section: 'Using Flow',
+    content: runningWorkflows,
+    toc: extractToc(runningWorkflows),
+  },
+  'starting-work': {
+    title: 'Triggers & gates',
+    section: 'Using Flow',
+    content: startingWork,
+    toc: extractToc(startingWork),
+  },
+  'sessions-and-runs': {
+    title: 'Sessions & Runs',
+    section: 'Using Flow',
+    content: sessionsAndRuns,
+    toc: extractToc(sessionsAndRuns),
+  },
+  assets: {
+    title: 'Assets',
+    section: 'Using Flow',
+    content: assets,
+    toc: extractToc(assets),
+  },
+  personas: {
+    title: 'Agent personas',
+    section: 'Using Flow',
+    content: personas,
+    toc: extractToc(personas),
+  },
+  'agent-capabilities': {
+    title: 'Wrappers, Skills & Connectors',
+    section: 'Using Flow',
+    content: agentCapabilities,
+    toc: extractToc(agentCapabilities),
+  },
+  repositories: {
+    title: 'Repositories & Integrations',
+    section: 'Using Flow',
+    content: repositories,
+    toc: extractToc(repositories),
+  },
+  'ai-builder': {
+    title: 'AI Builder',
+    section: 'Using Flow',
+    content: aiBuilder,
+    toc: extractToc(aiBuilder),
+  },
+  'people-and-access': {
+    title: 'Team & access',
+    section: 'Using Flow',
+    content: peopleAndAccess,
+    toc: extractToc(peopleAndAccess),
+  },
+  secrets: {
+    title: 'Secrets & Variables',
+    section: 'Using Flow',
+    content: secrets,
+    toc: extractToc(secrets),
+  },
+  analytics: {
+    title: 'Analytics & cost',
+    section: 'Using Flow',
+    content: analytics,
+    toc: extractToc(analytics),
+  },
+  'company-workspace': {
+    title: 'Company workspace',
+    section: 'Using Flow',
+    content: companyWorkspace,
+    toc: extractToc(companyWorkspace),
+  },
+  examples: {
+    title: 'Worked examples',
+    section: 'Using Flow',
+    content: examples,
+    toc: extractToc(examples),
+  },
   'user-guide': {
     title: 'User Guide',
     section: 'User guide',

--- a/app/frontend/pages/Docs/data/pages/people-and-access.md
+++ b/app/frontend/pages/Docs/data/pages/people-and-access.md
@@ -1,0 +1,35 @@
+# Team & Access
+
+Membership has two levels, and they answer different questions: *who belongs to
+the company* and *who works on this project*.
+
+## Roles
+
+| Role | Can |
+| --- | --- |
+| **Admin** | Everything an employee can, plus members, integrations, settings, and the company-wide analytics, sessions, and assets |
+| **Employee** | Work inside the projects they are on: cards, workflows, runs, resources |
+| **Viewer** | Read. Boards, runs and results are visible; nothing is started or changed |
+
+A role is per company. Being a viewer in one workspace and an employee in
+another is normal, and onboarding adapts: a viewer is never asked to connect an
+agent.
+
+## Company members
+
+**Members** under the company lists everyone in the workspace, searchable by
+name. An admin can promote an employee to admin from the row menu.
+
+## Project members
+
+A project's **Members** page controls who is on this project. **Add
+Collaborator** opens a picker listing only company users who are not already
+here, so you cannot add someone twice. The project owner is badged and cannot
+be removed; removing anyone else asks first.
+
+Members are matched by name *and* email when you search, which is the quicker
+route in a company where several people share a first name.
+
+> info Adding someone to a project does not give them a credential. They still
+> connect their own agent in [Profile](/docs/getting-started) before they can
+> run anything.

--- a/app/frontend/pages/Docs/data/pages/personas.md
+++ b/app/frontend/pages/Docs/data/pages/personas.md
@@ -1,0 +1,31 @@
+# Agent Personas
+
+**Agents** in the sidebar is not a list of running agents — it is the personas
+your team has defined. A persona says *who* the agent is: how it works, what
+tone it takes, what rules it must follow.
+
+## Why personas exist
+
+Without them, every workflow step carries its own copy of "review this code
+carefully, be strict about tests, comment in English". Personas let you say it
+once: "our reviewer", "our implementer", "our release writer". Change the
+persona, and every workflow step that references it changes with it.
+
+## A persona is not a product
+
+A persona is independent of the runtime. The same "our reviewer" can run on
+Claude Code today and on Codex tomorrow — the step's Execution section decides
+that, not the persona.
+
+## Working with them
+
+- **Create** a persona, give it a name and its instructions.
+- **Search** the list by name.
+- Each persona carries a **scope badge**: defined in this project, or shared
+  from the company.
+- Pick one in a workflow step's Resources section.
+
+> info A persona describes behaviour, not permission. What an agent can reach —
+> repositories, connectors, secrets — comes from the step's resources, and the
+> credential it runs under comes from the person who connected it in
+> [Profile](/docs/getting-started).

--- a/app/frontend/pages/Docs/data/pages/project-home.md
+++ b/app/frontend/pages/Docs/data/pages/project-home.md
@@ -1,0 +1,37 @@
+# Project Home & Settings
+
+## Overview
+
+**Overview** is the project's front page and the fastest answer to "what is
+this project doing, and what is it costing?"
+
+- **KPI cards** — board tasks, sessions launched, workflow runs, total spend,
+  each with a delta against the previous period, plus an average cost per
+  session once sessions have run.
+- **Workflow Runs** — a donut of run outcomes with a success rate, total, and a
+  legend; failures that need a look are called out rather than buried.
+- **Board Task Distribution** — how many cards sit in each column, as a bar
+  list. A long bar on one column is usually a queue, not progress.
+- **Recent Activity** — the latest things people and agents did in this
+  project, newest first.
+
+Each block links to the screen that explains it: the board, Sessions & Runs, or
+Analytics.
+
+## Settings
+
+**Settings** holds the few project-level things that are not resources.
+
+- **Project name** and **description** — Save stays disabled until you actually
+  change something, and a *Saved* chip confirms the write.
+- **Artifacts Language** — the language agents write their output in. New
+  projects default to English.
+- **Danger Zone** — **Archive** takes a finished project out of the way but
+  keeps its history; **Delete** removes it. Both ask for confirmation first,
+  and both return you to the projects list when they succeed.
+
+> warning Delete is not archive. If you only want the project out of the daily
+> list, archive it — an archived project keeps its board, runs, and numbers.
+
+Whether you see the delete control at all depends on your role; see
+[Team & access](/docs/people-and-access).

--- a/app/frontend/pages/Docs/data/pages/repositories.md
+++ b/app/frontend/pages/Docs/data/pages/repositories.md
@@ -1,0 +1,38 @@
+# Repositories & Integrations
+
+Two pages that together decide what an agent can touch outside Flow.
+
+## Integrations
+
+An **integration** is an account Flow connects to on the team's behalf:
+GitHub, GitLab, Linear, Slack, and Coder. Connect one from the page's
+**Connect** menu — GitHub through its app install, GitLab with a token, and so
+on.
+
+The table lists project integrations and company-wide ones together, each with
+a **Scope** badge, so it is always clear whether a connection is yours alone or
+inherited from the company. Removing one asks for confirmation.
+
+## Repositories
+
+A **repository** is a Git repo agents can read, work in, and push to. Each row
+shows the branch the project works from, and company-wide repositories appear
+in the same table with their scope marked.
+
+Link the repos a project actually needs — not every repo the company owns. A
+step only reaches the repositories its Resources section lists.
+
+## What this unlocks
+
+With a repository linked and an integration connected, a run can:
+
+- read the codebase it is asked about,
+- push a branch and open a pull request in your own remote,
+- move the ticket that started the work.
+
+Nothing in Flow rewrites your Git history behind your back: agents work on
+branches, and what lands is what your review process lets land.
+
+> warning Access is inherited by every step that lists the repository. If a
+> workflow should not be able to push, do not give its steps the repo — that is
+> the control, not an agent instruction asking it politely.

--- a/app/frontend/pages/Docs/data/pages/running-workflows.md
+++ b/app/frontend/pages/Docs/data/pages/running-workflows.md
@@ -1,0 +1,52 @@
+# Building Workflows
+
+A **workflow** is a named process made of ordered **steps**. Each step is one
+agent session doing one job. Write the process once, and every card that enters
+the bound column is handled the same way.
+
+## Create a workflow
+
+**Workflows → New Workflow**, give it a name and a description. Then add steps.
+An empty name is rejected, and cancelling posts nothing.
+
+Steps show up as a tree on the left: the run order top to bottom, with
+sub-steps nested underneath a step that needs breaking down. Click a step to
+open its editor on the right.
+
+## What a step holds
+
+The step editor is grouped into sections. Most steps only need the first two.
+
+| Section | What you set |
+| --- | --- |
+| **Definition** | The step's name and its instructions — what the agent is being asked to do |
+| **Execution** | The runtime the step must run on, and optionally a preferred model. Changing the runtime resets the model choice, since model names are per-product |
+| **Resources** | What the agent gets: an agent persona, assets, skills, wrappers, connectors, repositories, and secrets & variables. A step can inherit everything the project has, or take a named subset |
+| **Data Flow** | Input and output asset specs — the files this step expects, and the files it is expected to leave behind, matched by pattern |
+| **Dependencies** | Which other steps must finish first. Steps with no dependency between them run at the same time |
+| **Behavior** | **On Failure**: Fail, Retry, or Skip. **Skip Policy**: Never, If outputs exist, or Manual. Whether the step waits for a person before the run continues |
+
+> info Dependencies are what make a run parallel. Two steps that both depend
+> only on "plan" will run side by side, and the run detail shows both consoles
+> at once.
+
+## Approval steps
+
+Mark a step as needing a person, and the run stops there and waits. The waiting
+step shows **Approve & continue** in [Sessions & Runs](/docs/sessions-and-runs).
+Use it where the cost of being wrong is higher than the cost of waiting:
+merging, releasing, anything that touches customers.
+
+## Reusing a workflow
+
+- **Duplicate** — copy it inside the project and edit the copy.
+- **Publish to the catalog** — offer it to the whole company. It then appears
+  in the [Workflow Catalog](/docs/company-workspace) with a **Copy & Configure**
+  action, so another project can take it and adjust the details.
+- **Run it by hand** — **Run workflow** starts a run without a card moving.
+
+## Starting it automatically
+
+Binding it to a board column is the common case, but a workflow can also start
+on a schedule, from a Slack message, or from an incoming webhook. That is the
+subject of [Triggers & gates](/docs/starting-work).

--- a/app/frontend/pages/Docs/data/pages/secrets.md
+++ b/app/frontend/pages/Docs/data/pages/secrets.md
@@ -1,0 +1,31 @@
+# Secrets & Variables
+
+Values a run needs at the moment it runs: API keys, tokens, endpoints, flags.
+They live here instead of in task descriptions and workflow instructions.
+
+## How it works
+
+Add an item, name it, and attach it to the steps that need it. During a run the
+agent receives the value through the session's own channel — it never has to
+appear in a prompt, and a secret's value is masked in the list.
+
+Search narrows the list by name. Deleting an item goes through the row menu and
+asks for confirmation, because a step that expects it will fail without it.
+
+## What belongs here
+
+- Credentials for [connectors](/docs/agent-capabilities) and
+  [wrappers](/docs/agent-capabilities)
+- Tokens for services a workflow calls
+- Configuration that differs between projects — an environment name, a base URL
+
+## What does not
+
+- Your personal agent credential. That is connected in
+  [Profile](/docs/getting-started) and belongs to you, not to the project.
+- Anything you would not want an agent to be able to read. A step that lists a
+  secret can use it.
+
+> warning Pasting a key into a card description or a step's instructions puts
+> it in the prompt, the run log, and everyone's screen. Put it here instead —
+> that is the whole point of the page.

--- a/app/frontend/pages/Docs/data/pages/sessions-and-runs.md
+++ b/app/frontend/pages/Docs/data/pages/sessions-and-runs.md
@@ -1,0 +1,67 @@
+# Sessions & Runs
+
+One sidebar item, one list. A **run** is one execution of a workflow; a
+**session** is one agent working. Every step of a run is a session, and a
+session can also stand on its own, with no workflow behind it.
+
+## The list
+
+Three tabs:
+
+- **All** — everything, and both create actions: **New Session** and
+  **Run workflow**.
+- **Standalone** — sessions started by hand. Only **New Session** here.
+- **Workflow runs** — runs. Only **Run workflow** here.
+
+Filter by agent, status, type, or the person who started it, or search by name.
+A workflow-step session links back to the run it belongs to; a standalone
+session has nothing to expand.
+
+Sessions someone kept private show as locked. You can see that they exist and
+what they cost; you cannot read them.
+
+## Starting a session by hand
+
+**New Session** asks for a name and an agent runtime — the Start control stays
+disabled until you pick one you actually have a credential for — and drops you
+straight into the session it creates. Finished a session and want another like
+it? A finished session offers to start a fresh one from the same setup.
+
+## Watching a run
+
+Open a run and you get one card per step, in run order, with the run's status,
+id, and totals in the header.
+
+- A **running step shows its terminal live**, embedded in the page. Before the
+  container is ready it reads *Session starting…*, then *Connecting to
+  terminal…*, then you are watching the agent work.
+- A **parallel run shows every active step at once**, each with its own console
+  and its own action bar.
+- Expand a step card for its prompt, its sub-steps, and the note it left
+  behind. A failed step shows its error there, and the header names *where* the
+  run stopped rather than when it started.
+
+## Steering a run
+
+| Action | When |
+| --- | --- |
+| **Approve & continue** | A step is waiting for a person. This is the approval you set on the step |
+| **Retry** | A step failed, or is waiting on input and should have another go |
+| **Skip** | A step should not run. You are asked for a reason, which stays on the record |
+| **Cancel run** | The whole run should stop. Offered only while it is still active |
+
+If a run stopped because the workspace hit a usage limit, the run says so in a
+banner and offers to run it again once there is room.
+
+## What a run leaves behind
+
+The **Assets** tab of a run lists the files the agents produced, with download
+and **promote** controls — promoting lifts a file out of the run and into the
+project's [Assets](/docs/assets), where the rest of the team can find it.
+
+Back in the list, a run with unreviewed output offers **Review outputs**: tick
+what to keep and **Save selected**, or **Dismiss all** if the run produced
+nothing worth keeping.
+
+Every run keeps its status, log, artifacts, tokens, and cost — including the
+runs that failed. That record is what [Analytics](/docs/analytics) counts.

--- a/app/frontend/pages/Docs/data/pages/starting-work.md
+++ b/app/frontend/pages/Docs/data/pages/starting-work.md
@@ -1,0 +1,43 @@
+# Triggers & Gates
+
+Two halves of one question: what starts a run, and what holds one up.
+
+## Triggers
+
+A trigger is attached to a workflow. Add one from the workflow's Triggers
+panel, pick its kind, and fill in what that kind needs. Any trigger can be
+switched off with **Enabled** without deleting it.
+
+| Kind | Fires when | Worth knowing |
+| --- | --- | --- |
+| **Task enters column** | A card lands in the chosen column | The mode decides whether it runs on its own (**Auto**) or offers a button (**Manual**) |
+| **On schedule** | A cron expression matches, in the timezone you pick | Use it for recurring work with no card behind it — a nightly report, a weekly sweep |
+| **Slack message** | A message in a channel matches your text pattern | Optionally limited to one channel; a cooldown stops a busy channel from starting a run per message |
+| **Incoming webhook** | An external system posts to the trigger's request URL | The workflow becomes a start API for anything that can send an HTTP request |
+
+Triggers that create a card as they fire let you template its title and give
+the run a subject, so the board does not fill up with rows called *Run 41*.
+
+> tip Manual mode on a column trigger is the safest way to introduce
+> automation: the process is bound and visible, but a person still decides when
+> a card is ready for it.
+
+## Gates
+
+A **gate** is a check a card waits on before work moves on — usually CI. The
+card shows a compact chip:
+
+| Chip | Meaning |
+| --- | --- |
+| **waiting** | The check is still running. The chip pulses like a live run |
+| **passed** | The check reported success |
+| **failed** | The check reported failure — a verdict, so fix the code |
+| **stale** | No verdict ever arrived. Something never reported; a tooltip explains why and offers to clear the gate |
+
+**failed** and **stale** need different reactions, which is why they do not
+share a colour. A failure means the work is wrong; a stale gate means you do
+not know yet, and should look at why CI went quiet.
+
+A collapsed column keeps this visible: a card that is gated shows as waiting
+rather than as its running run, so a blocked card cannot hide behind a busy
+one.

--- a/app/frontend/pages/Docs/data/pages/tasks.md
+++ b/app/frontend/pages/Docs/data/pages/tasks.md
@@ -1,0 +1,72 @@
+# Tasks & the Board
+
+**Tasks** in the sidebar opens the project's board. This is where work enters
+Flow and where results come back, so most people spend their day here.
+
+## Columns
+
+A board is ordered columns. Each column has a **purpose** — a sentence saying
+what happens to a card while it sits there. That sentence is not decoration:
+when a workflow runs from this column, the agent receives it as context.
+
+A new project's board is empty and offers three templates:
+
+| Template | Columns |
+| --- | --- |
+| **Simple Kanban** | Backlog · In Progress · Done |
+| **Dev Team** | Backlog · Tech Design · Implementation · Code Review · QA · Ready for Release · Done |
+| **Full SDLC** | The long form — design, tech design, development, QA, UAT, release, each with its own waiting column |
+
+Pick one with **Use this template**, then add, rename, reorder, or remove
+columns as the team's process changes. Columns collapse individually from the
+header toggle or the column's ⋯ menu, and all at once with **Collapse all** —
+a collapsed column still shows its cards as chips, coloured by their latest run.
+
+## Cards
+
+Create a card from a column's **+** button, or press **n** anywhere on the
+board. A card carries a title, a description, a type, an assignee, tags, an
+optional parent epic, subtasks, comments, and attachments.
+
+Open a card and the detail drawer has tabs:
+
+- **Details** — description, assignee, tags, the column it sits in (moving it
+  from the **Column** select is the same as dragging it), and a *Latest run*
+  tile.
+- **Runs** — every workflow run this card has triggered, newest first. Click
+  one to jump into the session.
+- **Comments** — the conversation. Agents comment here too, so you can filter
+  by author type to read only what people wrote, or only what agents produced.
+- **Analytics** — what this single card has cost: run time, tokens, spend.
+
+**Activity** (top of the board) opens a slide-over with everything that has
+happened on the board recently — it stays open while you keep working.
+
+## Finding things
+
+- **Search** — press **/** to jump into it; it searches the whole board, not
+  just loaded cards.
+- **Type**, **Assignee**, **Tags** — filters that narrow the board; clicking a
+  tag on a card filters by it, clicking again clears it.
+- **Archived** — hidden by default, revealed with the toggle.
+- **Presets** — saved views. Two are built in: **My Work** (only your cards)
+  and **All Bugs**. Save your own filter combination as a preset and share it
+  with the team, or keep it to yourself.
+
+## Starting work from the board
+
+Binding a column to a workflow is what turns a board into an assembly line.
+Board settings (the toolbar's settings button, or a column's ⋯ menu) is where a
+column gets its workflow and whether it fires **automatically** on entry or
+waits for a person to press **Run workflow** on the card.
+
+Once bound:
+
+- Dropping a card into the column starts the run (auto), or offers the button
+  (manual).
+- A failed run offers **Retry run** from the card.
+- The card's chips show the state of its latest runs and of any CI gate it is
+  waiting on — see [Triggers & gates](/docs/starting-work).
+
+> tip A column with no binding is still useful. Plenty of teams automate two
+> columns out of seven and leave the rest as an ordinary Kanban board.

--- a/app/frontend/pages/Docs/data/pages/user-guide.md
+++ b/app/frontend/pages/Docs/data/pages/user-guide.md
@@ -1,5 +1,9 @@
 # User Guide
 
+> info Using Flow rather than installing it? Start with
+> [What Flow is](/docs/using-flow). This section describes how Flow works
+> underneath — containers, DAGs, credentials — for the people who run it.
+
 Aixle Flow turns AI coding agents into a team workflow. The pieces fit
 together like this:
 

--- a/app/frontend/pages/Docs/data/pages/using-flow.md
+++ b/app/frontend/pages/Docs/data/pages/using-flow.md
@@ -1,0 +1,73 @@
+# What Flow Is
+
+Aixle Flow is the team layer on top of personal AI coding agents. One person
+puts work on a board. An agent picks it up, does the work, and the whole team
+sees the run, the output, and the cost — without anyone opening a terminal.
+
+If you are installing or operating Flow, read the [User Guide](/docs/user-guide)
+instead. This section is for people who *use* the product.
+
+## The loop
+
+```
+Board ── card enters a bound column ──► Workflow ── step by step ──► Agent
+  ▲                                                                    │
+  └──────────── status, files, comments and cost come back ◄───────────┘
+```
+
+1. A card moves into a column that is bound to a workflow.
+2. The workflow starts — automatically, or from a button if the column is set
+   to manual.
+3. Each step of the workflow is one agent session doing one job. Independent
+   steps run at the same time.
+4. Results come back: files in Assets, comments and status on the card, a full
+   trail in Sessions & Runs, and cost in Analytics.
+
+Nothing in that loop asks you to run a command yourself. Your part is writing
+the card, deciding the process once, and reviewing what comes back.
+
+## Company, project, profile
+
+Flow has exactly three levels, and almost every question about "where does this
+setting live?" is answered by one of them.
+
+| Level | Holds | Example |
+| --- | --- | --- |
+| **Company** | The shared workspace: projects, members, catalog, company-wide analytics | Your organisation |
+| **Project** | One board, its workflows, and its own resources and access | "Billing service" |
+| **Profile** | What is personal: your agent credentials, your usage, your personal access | You |
+
+You can belong to more than one company. A switcher on the far left moves you
+between them; each company has its own projects, members, and numbers.
+
+## What actually runs the work
+
+Flow does not ship its own model. It runs the agent products people already
+use, each in an isolated container:
+
+- Claude Code
+- Cursor CLI
+- Codex
+- Gemini CLI
+- Grok
+
+An agent runs under a credential *a person connected*, which is why
+[getting started](/docs/getting-started) begins with connecting one. A persona
+you define (see [Agent personas](/docs/personas)) is not tied to a product —
+the same persona can run on any of the five.
+
+## Where things live
+
+- **Work** — [Tasks](/docs/tasks), [Workflows](/docs/running-workflows),
+  [Sessions & Runs](/docs/sessions-and-runs), [Assets](/docs/assets)
+- **Resources** — [Agent personas](/docs/personas),
+  [Wrappers, Skills & Connectors](/docs/agent-capabilities),
+  [Repositories & Integrations](/docs/repositories)
+- **Admin** — [Secrets & Variables](/docs/secrets),
+  [Team & access](/docs/people-and-access),
+  [Analytics](/docs/analytics), [project settings](/docs/project-home)
+- **Company** — [the workspace above projects](/docs/company-workspace)
+
+> tip New to Flow? Read [Getting started](/docs/getting-started), then
+> [Tasks & the board](/docs/tasks), then the
+> [worked examples](/docs/examples). Everything else is reference.

--- a/app/frontend/pages/Docs/data/registration.test.ts
+++ b/app/frontend/pages/Docs/data/registration.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { NAV_STRUCTURE } from './navStructure';
+import { DOC_PAGES } from './pages';
+import { SEARCH_INDEX } from './searchIndex';
+
+// A docs page is registered in three places: the page registry (content + title),
+// the nav (where it appears), and the search index (how it is found). A page missing
+// from any one of them is invisible in a way no page-level test would catch — the
+// portal simply never links to it. These tests keep the three in step.
+
+const navSlugs = NAV_STRUCTURE.flatMap((section) =>
+  section.items.flatMap((item) => [item.slug, ...(item.children ?? []).map((child) => child.slug)]),
+);
+
+describe('docs page registration', () => {
+  it('gives every nav entry a page to render', () => {
+    const missing = navSlugs.filter((slug) => !(slug in DOC_PAGES));
+    expect(missing).toEqual([]);
+  });
+
+  it('puts every page in the nav', () => {
+    const missing = Object.keys(DOC_PAGES).filter((slug) => !navSlugs.includes(slug));
+    expect(missing).toEqual([]);
+  });
+
+  it('makes every page findable through search', () => {
+    const indexed = SEARCH_INDEX.map((entry) => entry.slug);
+    const missing = Object.keys(DOC_PAGES).filter((slug) => !indexed.includes(slug));
+    expect(missing).toEqual([]);
+  });
+
+  it('files each page under the section its nav entry lives in', () => {
+    const mismatched = NAV_STRUCTURE.flatMap((section) =>
+      section.items.filter((item) => DOC_PAGES[item.slug]?.section !== section.label).map((item) => item.slug),
+    );
+    expect(mismatched).toEqual([]);
+  });
+
+  it('describes every page in the search index it indexes', () => {
+    const unknown = SEARCH_INDEX.filter((entry) => !(entry.slug in DOC_PAGES)).map((e) => e.slug);
+    expect(unknown).toEqual([]);
+  });
+});

--- a/app/frontend/pages/Docs/data/searchIndex.ts
+++ b/app/frontend/pages/Docs/data/searchIndex.ts
@@ -7,6 +7,108 @@ export interface SearchResult {
 
 export const SEARCH_INDEX: SearchResult[] = [
   {
+    slug: 'using-flow',
+    title: 'What Flow is',
+    section: 'Using Flow',
+    desc: 'What Aixle Flow does for a team: the board → workflow → agent loop, the company/project/profile levels, and the supported agent runtimes.',
+  },
+  {
+    slug: 'getting-started',
+    title: 'Getting started',
+    section: 'Using Flow',
+    desc: 'From an invitation to a running workflow: onboarding, connecting an agent, and the Account, Usage and MCP tabs of your profile.',
+  },
+  {
+    slug: 'project-home',
+    title: 'Project home & settings',
+    section: 'Using Flow',
+    desc: 'The Overview page KPIs, run donut and task distribution, plus project name, artifacts language, archive and delete.',
+  },
+  {
+    slug: 'tasks',
+    title: 'Tasks & the board',
+    section: 'Using Flow',
+    desc: 'Columns and their purpose, board templates, cards and their tabs, filters and view presets, and binding a column to a workflow.',
+  },
+  {
+    slug: 'running-workflows',
+    title: 'Building workflows',
+    section: 'Using Flow',
+    desc: 'Creating a workflow, what a step holds, dependencies and parallel steps, on-failure behaviour, approval steps, and publishing to the catalog.',
+  },
+  {
+    slug: 'starting-work',
+    title: 'Triggers & gates',
+    section: 'Using Flow',
+    desc: 'The four ways a workflow starts — column, schedule, Slack, incoming webhook — and CI gates: waiting, passed, failed, stale.',
+  },
+  {
+    slug: 'sessions-and-runs',
+    title: 'Sessions & Runs',
+    section: 'Using Flow',
+    desc: 'The unified list of runs and agent sessions, the live step terminal, approve, retry, skip and cancel, and reviewing what a run produced.',
+  },
+  {
+    slug: 'assets',
+    title: 'Assets',
+    section: 'Using Flow',
+    desc: 'Uploading files for agents, promoting what a run produced into the project, search and version history.',
+  },
+  {
+    slug: 'personas',
+    title: 'Agent personas',
+    section: 'Using Flow',
+    desc: 'Reusable agent personas: what they define, why they are independent of the runtime, and how steps reference them.',
+  },
+  {
+    slug: 'agent-capabilities',
+    title: 'Wrappers, Skills & Connectors',
+    section: 'Using Flow',
+    desc: 'The three ways to extend an agent: wrappers you write, skills as packaged know-how, and connectors to external tool servers.',
+  },
+  {
+    slug: 'repositories',
+    title: 'Repositories & Integrations',
+    section: 'Using Flow',
+    desc: 'Linking the Git repositories agents work in, connecting the accounts a project needs, and what that lets a run do.',
+  },
+  {
+    slug: 'ai-builder',
+    title: 'AI Builder',
+    section: 'Using Flow',
+    desc: 'Describe a process in plain language and let the builder create the board columns, workflows and steps, then adjust them by hand.',
+  },
+  {
+    slug: 'people-and-access',
+    title: 'Team & access',
+    section: 'Using Flow',
+    desc: 'Admin, employee and viewer roles, company members, project collaborators, and what each role can see.',
+  },
+  {
+    slug: 'secrets',
+    title: 'Secrets & Variables',
+    section: 'Using Flow',
+    desc: 'Credentials and configuration a run needs, kept out of prompts, task text and logs.',
+  },
+  {
+    slug: 'analytics',
+    title: 'Analytics & cost',
+    section: 'Using Flow',
+    desc: 'Spend, tokens, sessions and success by project, agent, workflow and source — and where cost shows up elsewhere.',
+  },
+  {
+    slug: 'company-workspace',
+    title: 'Company workspace',
+    section: 'Using Flow',
+    desc: 'Projects, the Workflow Catalog, company-wide analytics and sessions, company assets and members, and switching companies.',
+  },
+  {
+    slug: 'examples',
+    title: 'Worked examples',
+    section: 'Using Flow',
+    desc: 'Two end-to-end stories: a card that comes back as a pull request, and a workflow built from a single prompt.',
+  },
+  {
     slug: 'user-guide',
     title: 'User Guide',
     section: 'User guide',

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,4 +68,8 @@ The active workflow: a research report in `research/` feeds a frozen-intent spec
 ## Related documentation elsewhere
 
 - `references/aixle-system-reference.md` — agent-facing platform reference (domain model, runtimes, container layout)
-- `app/frontend/pages/Docs/data/pages/` — end-user product docs rendered in the app
+- `app/frontend/pages/Docs/data/pages/` — the markdown the `/docs` portal renders. Two sections:
+  **Using Flow** (the product guide: what a user does on each screen) and **User guide /
+  Reference** (operator material: install, runtimes, MCP, API). Adding a page there means
+  registering it in `navStructure.ts`, `data/pages/index.ts`, `data/searchIndex.ts`, and the
+  allow-list in `Web::DocsController`

--- a/test/integration/web/docs_render_test.rb
+++ b/test/integration/web/docs_render_test.rb
@@ -36,4 +36,33 @@ class Web::DocsRenderTest < ActionDispatch::IntegrationTest
       props[:slug] == "agents"
     end
   end
+
+  # The product guide is a second, user-facing section of the same portal. Its slugs
+  # are registered in three places that can drift apart (the controller allow-list,
+  # the page registry, and the nav); the frontend guards its own two, this covers
+  # the controller's.
+  PRODUCT_GUIDE_SLUGS = %w[
+    using-flow getting-started project-home tasks running-workflows starting-work
+    sessions-and-runs assets personas agent-capabilities repositories ai-builder
+    people-and-access secrets analytics company-workspace examples
+  ].freeze
+
+  test "show renders every product guide page" do
+    PRODUCT_GUIDE_SLUGS.each do |slug|
+      get docs_page_path(slug)
+      assert_response :success, "expected /docs/#{slug} to render"
+      assert_inertia_page "Docs/DocsPage"
+      assert_inertia_props do |props|
+        props[:slug] == slug
+      end
+    end
+  end
+
+  test "show answers 404 for a slug the portal does not publish" do
+    get docs_page_path("no-such-page")
+    assert_response :not_found
+    # Still the docs page, so the reader lands on the portal's own not-found view
+    # rather than the generic error page.
+    assert_inertia_component "Docs/DocsPage"
+  end
 end


### PR DESCRIPTION
## Why

The `/docs` portal shipped with one audience: people installing and running Flow. Its "User guide" section explains containers, DAGs, credentials and env vars — correct, and useless to the person who just wants to know what a column binding does, what a gate chip means, or why their run is sitting there waiting.

There was no product documentation anywhere. #130 landed the *outline* of one under `docs/product/`; this PR writes it and publishes it.

## What

A new **Using Flow** section on the portal — seventeen pages, first in the nav, since most readers arrive wanting to use Flow rather than install it:

| Page | Covers |
| --- | --- |
| What Flow is | The loop, the company / project / profile levels, the five runtimes |
| Getting started | Invitation → onboarding → connecting an agent → the Profile tabs |
| Project home & settings | Overview KPIs, run donut, task distribution; name, language, archive, delete |
| Tasks & the board | Columns and their purpose, templates, cards and their tabs, filters and presets, binding a column |
| Building workflows | Steps, the editor's sections, dependencies and parallelism, on-failure behaviour, approvals, catalog |
| Triggers & gates | The four trigger kinds and their fields; gate states waiting / passed / failed / stale |
| Sessions & Runs | The unified list, the live step terminal, approve / retry / skip / cancel, reviewing output |
| Assets | Upload, promote from a run, search, version history |
| Agent personas | What a persona defines and why it is independent of the runtime |
| Wrappers, Skills & Connectors | The three ways to extend an agent, and how to tell them apart |
| Repositories & Integrations | Linked repos, connected accounts, scope badges, what a run can then do |
| AI Builder | Building a process from a prompt and adjusting what comes out |
| Team & access | Admin / employee / viewer, company members, project collaborators |
| Secrets & Variables | What belongs there and what does not |
| Analytics & cost | Project and company views, and everywhere else cost surfaces |
| Company workspace | Projects, Workflow Catalog, company monitoring, assets, members |
| Worked examples | Two end-to-end stories naming every screen they touch |

Screen names, control copy and states are taken from the UI as it reads today — board presets and **Use this template**, the card's Details / Runs / Comments / Analytics tabs, the `/` and `n` hotkeys, the built-in **My Work** and **All Bugs** presets, the step editor's Definition / Execution / Resources / Data Flow / Dependencies / Behavior sections, **Task enters column** / **On schedule** / **Slack message** / **Incoming webhook**, the gate chip's four states, the All / Standalone / Workflow runs tabs, the live step terminal and its *Session starting…* state, **Approve & continue**, skip-with-a-reason, asset promote, **Review outputs** / **Save selected** / **Dismiss all**, the scope badges on repositories and integrations, the Account / Usage / MCP profile tabs, and Settings' Danger Zone.

The operator sections keep their slugs, so every existing link holds; their overview page now points across to the product guide.

## Registration is the fragile part

A docs page is registered in four places that can silently disagree: `navStructure.ts`, `data/pages/index.ts`, `data/searchIndex.ts`, and the allow-list in `Web::DocsController`. Miss one and the page is unreachable, unsearchable, or a 404 — with nothing failing.

- `data/registration.test.ts` asserts the three TypeScript sources cover each other (nav ⊆ pages, pages ⊆ nav, pages ⊆ search, section labels agree).
- `docs_render_test.rb` renders every published product-guide slug and asserts an unknown slug still lands on the portal's own not-found view.

## Noticed, not touched

`app/frontend/pages/Docs/data/pages/what-is-aixle.md` and `install-guide.md` are not imported by anything — dead files that predate this change. Left alone deliberately; worth a follow-up decision (delete, or publish them).

## Checks

`docker compose exec -T web make check_all` — green in full:

```
  [OK]   brakeman      [OK]   rails-test
  [OK]   eslint        [OK]   rubocop
  [OK]   fe-test       [OK]   system-test
  [OK]   typescript    [OK]   vite-build

  backend  coverage: 92.13%
  frontend coverage: 81.25%
```

Related: #130 (the outline these pages were written from).
