### PR TITLE
feat(connectors): redesign Connectors page per design handoff

### DIFF
--- a/app/frontend/shared/resources/connectors/ConnectorCatalogModal.test.tsx
+++ b/app/frontend/shared/resources/connectors/ConnectorCatalogModal.test.tsx
@@ -146,7 +146,7 @@ describe('shared/resources/connectors/ConnectorCatalogModal', () => {
     );
   });
 
-  it('disables install for a connector with no runnable target', async () => {
+  it('marks an unavailable connector with a label instead of an install button', async () => {
     const catalog = await openCatalog([
       connector({
         installable: false,
@@ -154,7 +154,21 @@ describe('shared/resources/connectors/ConnectorCatalogModal', () => {
       }),
     ]);
 
-    expect(within(catalog).getByRole('button', { name: 'Unavailable' })).toBeDisabled();
+    // "Unavailable" renders twice — the source badge and the footer label,
+    // mirroring the reference design.
+    expect(within(catalog).getAllByText('Unavailable').length).toBe(2);
+    expect(within(catalog).queryByRole('button', { name: /install/i })).not.toBeInTheDocument();
+  });
+
+  it('truncates a long connector name and description instead of breaking the card', async () => {
+    const longName = 'a'.repeat(120);
+    const longDescription = 'word-that-never-breaks-'.repeat(20);
+    const catalog = await openCatalog([connector({ pickerName: longName, description: longDescription })]);
+
+    const nameEl = within(catalog).getByText(longName);
+    const descriptionEl = within(catalog).getByText(longDescription);
+    expect(nameEl).toHaveAttribute('data-truncate', 'end');
+    expect(descriptionEl).toHaveAttribute('data-line-clamp', 'true');
   });
 
   it('marks a deprecated connector', async () => {

--- a/app/frontend/shared/resources/connectors/ConnectorCatalogModal.tsx
+++ b/app/frontend/shared/resources/connectors/ConnectorCatalogModal.tsx
@@ -2,6 +2,7 @@ import { router } from '@inertiajs/react';
 import {
   Avatar,
   Badge,
+  Box,
   Button,
   Card,
   Center,
@@ -9,7 +10,6 @@ import {
   Group,
   Loader,
   Modal,
-  SimpleGrid,
   Text,
   TextInput,
 } from '@mantine/core';
@@ -47,12 +47,17 @@ const monogram = (connector: Connector): string => {
   return (words[0][0] + words[1][0]).toUpperCase();
 };
 
+// Neutral source badges (Hosted / NPM / PyPI / …) — no color coding by
+// installability, per the design spec.
+const REGISTRY_LABELS: Record<string, string> = { hosted: 'Hosted', npm: 'NPM', pypi: 'PyPI', package: 'Package' };
+
 const transportSummary = (connector: Connector): string => {
   const supported = connector.targets.filter((t) => t.supported);
-  if (supported.length === 0) return 'unavailable';
-  return Array.from(
+  if (supported.length === 0) return 'Unavailable';
+  const kinds = Array.from(
     new Set(supported.map((t) => (t.kind === 'remote' ? 'hosted' : (t.registryType ?? 'package')))),
-  ).join(', ');
+  );
+  return kinds.map((kind) => REGISTRY_LABELS[kind] ?? kind.charAt(0).toUpperCase() + kind.slice(1)).join(' · ');
 };
 
 // Browsing the public connector catalog: the same MCP servers the manual form
@@ -99,7 +104,7 @@ export const ConnectorCatalogModal: FC<ConnectorCatalogModalProps> = ({
 
   return (
     <>
-      <Modal opened={opened} onClose={onClose} title="Connectors" size="90%">
+      <Modal opened={opened} onClose={onClose} title="Browse connectors" fullScreen>
         <TextInput
           placeholder="Search connectors — try 'issue tracker' or 'database'"
           aria-label="Search connectors"
@@ -113,6 +118,7 @@ export const ConnectorCatalogModal: FC<ConnectorCatalogModalProps> = ({
               search && <CloseButton size="sm" aria-label="Clear search" onClick={() => changeSearch('')} />
             )
           }
+          maw={480}
           mb="md"
         />
 
@@ -142,19 +148,22 @@ export const ConnectorCatalogModal: FC<ConnectorCatalogModalProps> = ({
             )}
           </Center>
         ) : (
-          <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="sm">
+          <Box style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: 14 }}>
             {connectors.map((connector) => (
               <Card
                 key={connector.id}
                 padding="md"
                 radius="md"
                 withBorder
+                onClick={connector.installable ? () => setInstalling(connector) : undefined}
                 style={{
                   borderColor: 'var(--app-border-default)',
                   backgroundColor: 'var(--app-bg-paper)',
                   display: 'flex',
                   flexDirection: 'column',
                   minHeight: 150,
+                  cursor: connector.installable ? 'pointer' : 'default',
+                  opacity: connector.installable ? 1 : 0.55,
                 }}
               >
                 <Group justify="space-between" align="flex-start" wrap="nowrap" mb={6}>
@@ -172,7 +181,7 @@ export const ConnectorCatalogModal: FC<ConnectorCatalogModalProps> = ({
                         deprecated
                       </Badge>
                     )}
-                    <Badge size="xs" variant="light" color={connector.installable ? 'teal' : 'gray'}>
+                    <Badge size="xs" variant="light" color="gray">
                       {transportSummary(connector)}
                     </Badge>
                   </Group>
@@ -188,7 +197,7 @@ export const ConnectorCatalogModal: FC<ConnectorCatalogModalProps> = ({
                       heading already IS the registry name — printing it twice
                       just wastes the row. */}
                   {connector.pickerName !== connector.name && (
-                    <Text fz={11} c="dimmed" ff="JetBrains Mono, monospace" truncate>
+                    <Text fz={11} c="dimmed" truncate>
                       {connector.name}
                     </Text>
                   )}
@@ -202,18 +211,26 @@ export const ConnectorCatalogModal: FC<ConnectorCatalogModalProps> = ({
                   <Text fz={11} c="dimmed">
                     {connector.version ? `v${connector.version}` : ''}
                   </Text>
-                  <Button
-                    size="xs"
-                    variant="light"
-                    disabled={!connector.installable}
-                    onClick={() => setInstalling(connector)}
-                  >
-                    {connector.installable ? 'Install' : 'Unavailable'}
-                  </Button>
+                  {connector.installable ? (
+                    <Button
+                      size="xs"
+                      variant="light"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setInstalling(connector);
+                      }}
+                    >
+                      Install
+                    </Button>
+                  ) : (
+                    <Text fz={12} c="dimmed">
+                      Unavailable
+                    </Text>
+                  )}
                 </Group>
               </Card>
             ))}
-          </SimpleGrid>
+          </Box>
         )}
 
         {catalogSyncedAt && (

--- a/app/frontend/shared/resources/connectors/ConnectorInstallModal.tsx
+++ b/app/frontend/shared/resources/connectors/ConnectorInstallModal.tsx
@@ -1,5 +1,5 @@
 import { router } from '@inertiajs/react';
-import { Alert, Badge, Button, Code, Group, Modal, Radio, Stack, Text } from '@mantine/core';
+import { Alert, Badge, Button, Code, Drawer, Group, Radio, Stack, Text } from '@mantine/core';
 import { IconAlertTriangle, IconLock } from '@tabler/icons-react';
 import { useEffect, useMemo, useState, type FC } from 'react';
 
@@ -68,7 +68,13 @@ export const ConnectorInstallModal: FC<ConnectorInstallModalProps> = ({
   const blockedReason = connector?.targets.find((t) => !t.supported)?.unsupportedReason;
 
   return (
-    <Modal opened={!!connector} onClose={onClose} title={`Install ${connector?.pickerName ?? ''}`} size="lg">
+    <Drawer
+      opened={!!connector}
+      onClose={onClose}
+      title={`Install · ${connector?.pickerName ?? ''}`}
+      position="right"
+      size={460}
+    >
       {connector && (
         <Stack gap="md">
           {connector.description && (
@@ -185,6 +191,6 @@ export const ConnectorInstallModal: FC<ConnectorInstallModalProps> = ({
           </Group>
         </Stack>
       )}
-    </Modal>
+    </Drawer>
   );
 };

--- a/app/frontend/shared/resources/mcp-servers/McpServerFormModal.tsx
+++ b/app/frontend/shared/resources/mcp-servers/McpServerFormModal.tsx
@@ -5,8 +5,8 @@ import {
   Badge,
   Box,
   Button,
+  Drawer,
   Group,
-  Modal,
   NativeSelect,
   PasswordInput,
   Stack,
@@ -246,7 +246,13 @@ export const McpServerFormModal: FC<McpServerFormModalProps> = ({
   };
 
   return (
-    <Modal opened={opened} onClose={onClose} title={isEdit ? 'Edit MCP Server' : 'Add MCP Server'} size="lg">
+    <Drawer
+      opened={opened}
+      onClose={onClose}
+      title={isEdit ? 'Edit MCP Server' : 'Add MCP Server'}
+      position="right"
+      size={460}
+    >
       <form onSubmit={form.onSubmit(handleSubmit)}>
         <Stack gap="md">
           <TextInput
@@ -505,6 +511,6 @@ export const McpServerFormModal: FC<McpServerFormModalProps> = ({
           </Group>
         </Stack>
       </form>
-    </Modal>
+    </Drawer>
   );
 };

--- a/app/frontend/shared/resources/mcp-servers/McpServersContent.test.tsx
+++ b/app/frontend/shared/resources/mcp-servers/McpServersContent.test.tsx
@@ -358,6 +358,47 @@ describe('McpServersContent', () => {
     expect(screen.queryByText('Company')).not.toBeInTheDocument();
   });
 
+  it('shows a photo placeholder icon for a catalog-installed row and a plug icon for a hand-added row', () => {
+    renderPage(
+      <McpServersContent
+        {...baseProps}
+        mcpServers={[
+          makeServer({ id: 1, name: 'From catalog', connectorName: 'io.github.acme/mcp' }),
+          makeServer({ id: 2, name: 'Hand added', connectorName: null }),
+        ]}
+      />,
+    );
+
+    const catalogRow = screen.getByText('From catalog').closest('tr') as HTMLElement;
+    const manualRow = screen.getByText('Hand added').closest('tr') as HTMLElement;
+    expect(catalogRow.querySelector('.tabler-icon-photo')).not.toBeNull();
+    expect(catalogRow.querySelector('.tabler-icon-plug')).toBeNull();
+    expect(manualRow.querySelector('.tabler-icon-plug')).not.toBeNull();
+    expect(manualRow.querySelector('.tabler-icon-photo')).toBeNull();
+  });
+
+  it('truncates a very long name and URL instead of breaking the row layout', () => {
+    const longName = 'a'.repeat(120);
+    const longUrl = `https://mcp.example.com/${'segment-'.repeat(30)}`;
+    renderPage(<McpServersContent {...baseProps} mcpServers={[makeServer({ id: 1, name: longName, url: longUrl })]} />);
+
+    const nameEl = screen.getByText(longName);
+    const urlEl = screen.getByText(longUrl);
+    expect(nameEl).toHaveAttribute('data-truncate', 'end');
+    expect(urlEl).toHaveAttribute('data-truncate', 'end');
+  });
+
+  it('shows a pluralized connector count in the toolbar', () => {
+    renderPage(
+      <McpServersContent
+        {...baseProps}
+        mcpServers={[makeServer({ id: 1, name: 'playwright' }), makeServer({ id: 2, name: 'context7' })]}
+      />,
+    );
+
+    expect(screen.getByText('2 connectors')).toBeInTheDocument();
+  });
+
   it('renders edit and delete icons for every custom server', () => {
     const { container } = renderPage(
       <McpServersContent

--- a/app/frontend/shared/resources/mcp-servers/McpServersContent.tsx
+++ b/app/frontend/shared/resources/mcp-servers/McpServersContent.tsx
@@ -1,7 +1,6 @@
 import {
   ActionIcon,
   Alert,
-  Badge,
   Box,
   Button,
   Group,
@@ -14,6 +13,7 @@ import {
 import {
   IconAlertTriangle,
   IconEdit,
+  IconPhoto,
   IconPlug,
   IconPlugConnected,
   IconPlus,
@@ -25,6 +25,7 @@ import { useMemo, useState } from 'react';
 import { useProjectPermissions } from 'shared/lib/hooks/useProjectPermissions';
 import { EmptyState } from 'shared/ui/EmptyState';
 import { PageHeader } from 'shared/ui/PageHeader';
+import { ResourceCount, ResourceTableShell, ResourceTh } from 'shared/ui/ResourceTable';
 import { StatusBadge, type StatusTone } from 'shared/ui/StatusBadge';
 
 import { ConnectorCatalogModal } from '../connectors/ConnectorCatalogModal';
@@ -179,14 +180,14 @@ export function McpServersContent({
         actions={
           canExecute && (
             <>
+              <Button variant="default" leftSection={<IconPlus size={16} />} onClick={() => setFormModalOpen(true)}>
+                Add manually
+              </Button>
               {catalogAvailable && (
                 <Button leftSection={<IconPlugConnected size={16} />} onClick={() => setCatalogOpen(true)}>
                   Browse connectors
                 </Button>
               )}
-              <Button variant="default" leftSection={<IconPlus size={16} />} onClick={() => setFormModalOpen(true)}>
-                Add manually
-              </Button>
             </>
           )
         }
@@ -233,6 +234,9 @@ export function McpServersContent({
             { label: 'Custom', value: 'custom' },
           ]}
         />
+        <ResourceCount>
+          {filtered.length} {filtered.length === 1 ? 'connector' : 'connectors'}
+        </ResourceCount>
       </Group>
 
       {filtered.length === 0 ? (
@@ -258,96 +262,98 @@ export function McpServersContent({
           />
         </Box>
       ) : (
-        <Box
-          style={{
-            border: '1px solid var(--app-border-default)',
-            borderRadius: 'var(--mantine-radius-md)',
-            overflow: 'hidden',
-          }}
-        >
-          <Table highlightOnHover>
+        <ResourceTableShell>
+          <Table highlightOnHover layout="fixed">
             <Table.Thead style={{ backgroundColor: 'var(--app-bg-deep)' }}>
               <Table.Tr>
-                <Table.Th>
-                  <Text fz={12} fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: 0.5 }}>
-                    Name
-                  </Text>
-                </Table.Th>
-                <Table.Th>
-                  <Text fz={12} fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: 0.5 }}>
-                    URL
-                  </Text>
-                </Table.Th>
-                <Table.Th>
-                  <Text fz={12} fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: 0.5 }}>
-                    Transport
-                  </Text>
-                </Table.Th>
-                <Table.Th>
-                  <Text fz={12} fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: 0.5 }}>
-                    Scope
-                  </Text>
-                </Table.Th>
-                <Table.Th>
-                  <Text fz={12} fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: 0.5 }}>
-                    Status
-                  </Text>
-                </Table.Th>
-                <Table.Th>
-                  <Text fz={12} fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: 0.5 }}>
-                    Connection
-                  </Text>
-                </Table.Th>
-                <Table.Th w={100}>
-                  <Text fz={12} fw={600} c="dimmed" tt="uppercase" ta="right" style={{ letterSpacing: 0.5 }}>
-                    Actions
-                  </Text>
-                </Table.Th>
+                {/* Fixed layout, with every other column pinned to a width — Name is
+                    the one column whose content is genuinely unbounded (long server
+                    names, long URLs), so it is the one left to claim the remainder
+                    and truncate in place instead of squeezing its neighbors. */}
+                <ResourceTh>Name</ResourceTh>
+                <ResourceTh w={110}>Transport</ResourceTh>
+                <ResourceTh w={110}>Scope</ResourceTh>
+                <ResourceTh w={120}>Status</ResourceTh>
+                <ResourceTh w={140}>Connection</ResourceTh>
+                <ResourceTh align="right" w={100}>
+                  Actions
+                </ResourceTh>
               </Table.Tr>
             </Table.Thead>
             <Table.Tbody>
               {filtered.map((server) => {
                 const canEdit = canExecute && canEditServer(server);
+                // A row installed from the catalog gets the shared placeholder tile —
+                // the same frame the browse cards use, until real logos are wired in
+                // there too. A hand-authored server gets a plain plug glyph instead,
+                // since there is no publisher icon to stand in for.
+                const fromCatalog = !!server.connectorName;
                 return (
                   <Table.Tr key={server.id}>
                     <Table.Td>
-                      <Group gap={6} wrap="nowrap">
-                        <Text fz={14} fw={500} c="var(--app-text-primary)">
-                          {server.name}
-                        </Text>
-                        <ServerHealthIcons
-                          server={server}
-                          onReviewDrift={setDriftServer}
-                          onReviewUpdate={canEdit ? setUpdateServer : undefined}
-                        />
+                      <Group gap={11} wrap="nowrap" style={{ minWidth: 0 }}>
+                        <Box
+                          w={30}
+                          h={30}
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            backgroundColor: 'var(--app-bg-deep)',
+                            borderRadius: 'var(--mantine-radius-sm)',
+                            color: 'var(--app-text-secondary)',
+                            flexShrink: 0,
+                          }}
+                        >
+                          {fromCatalog ? <IconPhoto size={15} /> : <IconPlug size={15} />}
+                        </Box>
+                        <Box style={{ minWidth: 0 }}>
+                          <Group gap={6} wrap="nowrap">
+                            <Text fz={14} fw={500} c="var(--app-text-primary)" truncate style={{ minWidth: 0 }}>
+                              {server.name}
+                            </Text>
+                            <ServerHealthIcons
+                              server={server}
+                              onReviewDrift={setDriftServer}
+                              onReviewUpdate={canEdit ? setUpdateServer : undefined}
+                            />
+                          </Group>
+                          <Text fz={12} c="var(--app-text-tertiary)" truncate maw={300}>
+                            {server.url || '—'}
+                          </Text>
+                        </Box>
                       </Group>
                     </Table.Td>
                     <Table.Td>
-                      <Text
-                        fz={13}
-                        c="dimmed"
-                        maw={300}
-                        style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-                      >
-                        {server.url || '—'}
-                      </Text>
-                    </Table.Td>
-                    <Table.Td>
-                      <Badge variant="outline" size="sm">
+                      <StatusBadge tone="neutral" size="sm">
                         {server.transport.toUpperCase()}
-                      </Badge>
+                      </StatusBadge>
                     </Table.Td>
                     <Table.Td>
-                      <Badge color={server.scopeIndicator === 'internal' ? 'violet' : 'teal'} size="sm" variant="light">
+                      <StatusBadge tone="neutral" size="sm">
                         {server.scopeIndicator === 'internal' ? 'System' : 'Project'}
-                      </Badge>
+                      </StatusBadge>
                     </Table.Td>
                     {/* Status is what the server IS; Connection is what YOU
                         still have to do about it. They used to share one column,
                         so an "Enabled" green sat next to a "Connected" green
                         meaning two different things. */}
                     <Table.Td>
-                      <StatusBadge state={server.enabled ? 'enabled' : 'disabled'} size="sm" />
+                      <StatusBadge
+                        state={server.enabled ? 'enabled' : 'disabled'}
+                        size="sm"
+                        leftSection={
+                          <Box
+                            style={{
+                              width: 6,
+                              height: 6,
+                              borderRadius: '50%',
+                              background: 'currentColor',
+                              flexShrink: 0,
+                            }}
+                          />
+                        }
+                      />
                     </Table.Td>
                     <Table.Td>
                       <Group gap={4}>
@@ -420,7 +426,7 @@ export function McpServersContent({
               })}
             </Table.Tbody>
           </Table>
-        </Box>
+        </ResourceTableShell>
       )}
 
       <McpServerFormModal


### PR DESCRIPTION
## Summary

Implements the design handoff in palad-ai/palad-app#521 for the project **Connectors** page (`shared/resources/mcp-servers/McpServersContent.tsx` and its catalog/drawer components).

- Table: merges Name+URL into one column (URL as a sans subline, catalog vs. manual row icon), and switches Transport/Scope to neutral tags (no color). Kept the "Connection" column that the reference dropped — it's where OAuth Connect/Reconnect/Connected currently lives for oauth-authenticated servers, and dropping it silently would have hidden that flow.
- Browse connectors: switched from a 90%-width modal to a true full-screen popup, source badges (Hosted/NPM/PyPI/…) recolored neutral, unavailable catalog entries render a plain "Unavailable" label + non-clickable dimmed card instead of a disabled button, grid now uses `auto-fill`/`minmax(320px, 1fr)` for real responsiveness. Kept the existing real logo/monogram avatars rather than switching to the reference's placeholder tile — no reason to regress a working feature.
- Add manually / Install: converted both from centered modals to the app's existing 460px right-side `Drawer` pattern (same shape Agents/Tools/Repositories/Members already use). All existing fields and logic (OAuth advanced options + credential scope, stdio command/env vars, multi-target catalog install picker, per-input secret/config-item fields, version-pin warnings) are unchanged — only the container moved.
- Colors/spacing come from the app's existing `--app-*` design tokens. The reference mockup's dark palette turned out to be a 1:1 copy of the app's existing dark theme (confirmed by direct value comparison against `mantineTheme.ts`), so no new tokens were introduced and light mode is correct for free.
- Fixed a real overflow bug found during manual QA: an unbounded Name column could steal width from the other columns when a name/URL was very long, truncating "Project"/"Enabled" badges. Table now uses `layout="fixed"` with explicit column widths, so only the Name column truncates.

## Test plan
- [x] `docker compose exec -T web make check_all` — green (rails-test, rubocop, brakeman, system-test, eslint, typescript, vitest)
- [x] Added tests: catalog-vs-manual row icon, connector count in toolbar, long-name/URL truncation (table row + catalog card), unavailable-card now shows a label instead of a disabled button
- [x] Manual QA in Chrome against seeded dev data: table, full-screen catalog (real ~20k-row catalog), install drawer stacked over the catalog, add-manually drawer, narrow-viewport responsiveness (table scrolls, catalog grid collapses to 1 column, drawer caps to 100% width), and confirmed light-mode token values resolve correctly (Chrome's OS-level dark filter made it hard to *see* light mode, but computed styles matched the light theme exactly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)