### PR TITLE
fix(sessions): fix new-session drawer stuck on loading spinner

### DIFF
--- a/app/frontend/pages/Projects/Sessions/NewSessionDrawer.tsx
+++ b/app/frontend/pages/Projects/Sessions/NewSessionDrawer.tsx
@@ -39,6 +39,7 @@ export function NewSessionDrawer({ projectId, opened, onClose }: Props) {
           mcpServers={options.mcpServers}
           repositories={options.repositories}
           assets={options.assets}
+          configItems={options.configItems}
           costHint={options.costHint}
           onCreatedPath={(sessionId, id) => `/company/projects/${id}/sessions/${sessionId}`}
           fallbackPath={`/company/projects/${projectId}/sessions`}

--- a/app/frontend/pages/Projects/Sessions/useCreateOptions.test.ts
+++ b/app/frontend/pages/Projects/Sessions/useCreateOptions.test.ts
@@ -1,0 +1,53 @@
+import '@testing-library/jest-dom/vitest';
+import { router } from '@inertiajs/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { inertiaState } from 'test/inertiaMock';
+import { renderHook, waitFor } from 'test/renderPage';
+
+import { useCreateOptions } from './useCreateOptions';
+
+describe('useCreateOptions', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    inertiaState.pageProps = {};
+  });
+
+  it('calls router.reload with the snake_case prop key when opened without createOptions', async () => {
+    inertiaState.pageProps = {};
+
+    renderHook(() => useCreateOptions(true));
+
+    await waitFor(() => expect(router.reload).toHaveBeenCalledWith({ only: ['create_options'] }));
+  });
+
+  it('does not call router.reload when opened is false', async () => {
+    inertiaState.pageProps = {};
+
+    renderHook(() => useCreateOptions(false));
+
+    await waitFor(() => expect(router.reload).not.toHaveBeenCalled());
+  });
+
+  it('does not call router.reload when createOptions is already present', async () => {
+    inertiaState.pageProps = {
+      createOptions: {
+        agents: [],
+        tools: [],
+        skills: [],
+        mcpServers: [],
+        assets: [],
+        repositories: [],
+        agentModels: [],
+        configuredAgents: [],
+        defaultAgentRuntime: null,
+        workflows: [],
+        configItems: [],
+      },
+    };
+
+    renderHook(() => useCreateOptions(true));
+
+    await waitFor(() => expect(router.reload).not.toHaveBeenCalled());
+  });
+});

--- a/app/frontend/pages/Projects/Sessions/useCreateOptions.ts
+++ b/app/frontend/pages/Projects/Sessions/useCreateOptions.ts
@@ -1,6 +1,8 @@
 import { router, usePage } from '@inertiajs/react';
 import { useEffect } from 'react';
 
+import { ConfigItemOption } from 'shared/components/SessionNewForm';
+
 export interface NamedItem {
   id: number;
   name: string;
@@ -29,6 +31,7 @@ export interface CreateOptions {
   configuredAgents: string[];
   defaultAgentRuntime: string | null;
   workflows: WorkflowOption[];
+  configItems: ConfigItemOption[];
   costHint?: { avgCostCentsByRuntime: Record<string, number>; monthToDateCents: number };
 }
 
@@ -43,7 +46,7 @@ export function useCreateOptions(opened: boolean): CreateOptions | null {
 
   useEffect(() => {
     if (!opened || createOptions) return;
-    router.reload({ only: ['createOptions'] });
+    router.reload({ only: ['create_options'] });
   }, [opened, createOptions]);
 
   return createOptions ?? null;


### PR DESCRIPTION
## Summary

When a user opens the **New Session** drawer on the Sessions & Runs page, the panel was stuck on a loading spinner indefinitely because `useCreateOptions.ts` was calling `router.reload({ only: ['createOptions'] })` with a camelCase key. Inertia matches partial-reload keys against the raw Ruby prop name (`create_options` in snake_case), so the optional prop was never returned and `createOptions` stayed `undefined` on the client forever.

Two changes:
1. **`useCreateOptions.ts`** — fix partial-reload key from `createOptions` to `create_options`; add `configItems: ConfigItemOption[]` to the `CreateOptions` interface (backend already returns it, the interface just didn't declare it).
2. **`NewSessionDrawer.tsx`** — pass `configItems={options.configItems}` to `SessionNewForm`, matching what the full-page `/sessions/new` form already does.

## Type of change

- [x] Bug fix

## How was this tested?

- Code review of the partial-reload key mismatch against existing snake_case usages.
- Added `useCreateOptions.test.ts` covering the snake_case key fix, the no-op when closed, and the no-op when options are already present.

## Checklist

- [x] All commits are clear and descriptive.
- [x] Tests added for the partial-reload key fix.

---

Ported from [palad-ai/palad-app#562](https://github.com/palad-ai/palad-app/pull/562).