### PR TITLE
feat(board): bulk actions — select multiple tasks and delete, archive, or move

### DIFF
--- a/app/controllers/api/v1/projects/board/tasks_controller.rb
+++ b/app/controllers/api/v1/projects/board/tasks_controller.rb
@@ -106,12 +106,6 @@ module Api
                 render json: { errors: [ "Column not found" ] }, status: :not_found and return
               end
               col
-            when :move_to_done
-              done_col = current_board.board_columns.order(:position).last
-              unless done_col
-                render json: { errors: [ "Board has no Done column" ] }, status: :unprocessable_entity and return
-              end
-              done_col
             end
 
             result = TaskService.bulk_action(action: action, tasks: tasks, actor: current_user, to_column: to_column)

--- a/app/controllers/api/v1/projects/board/tasks_controller.rb
+++ b/app/controllers/api/v1/projects/board/tasks_controller.rb
@@ -77,7 +77,12 @@ module Api
 
           # @summary Apply a bulk action to multiple board tasks
           def bulk_actions
-            action = params[:action_type].to_sym
+            action_type = params[:action_type]
+            unless action_type.present?
+              render json: { errors: ["action_type is required"] }, status: :bad_request and return
+            end
+
+            action = action_type.to_sym
 
             unless TaskService::BULK_ACTIONS.include?(action)
               render json: { errors: ["Unknown action"] }, status: :bad_request and return

--- a/app/controllers/api/v1/projects/board/tasks_controller.rb
+++ b/app/controllers/api/v1/projects/board/tasks_controller.rb
@@ -108,7 +108,12 @@ module Api
               col
             end
 
-            result = TaskService.bulk_action(action: action, tasks: tasks, actor: current_user, to_column: to_column)
+            extra_params = {
+              priority: params[:priority],
+              assignee_id: params[:assignee_id].present? ? params[:assignee_id].to_i : nil,
+              tag: params[:tag]
+            }
+            result = TaskService.bulk_action(action: action, tasks: tasks, actor: current_user, to_column: to_column, extra_params: extra_params)
             render json: result
           end
 

--- a/app/controllers/api/v1/projects/board/tasks_controller.rb
+++ b/app/controllers/api/v1/projects/board/tasks_controller.rb
@@ -79,18 +79,18 @@ module Api
           def bulk_actions
             action_type = params[:action_type]
             unless action_type.present?
-              render json: { errors: ["action_type is required"] }, status: :bad_request and return
+              render json: { errors: [ "action_type is required" ] }, status: :bad_request and return
             end
 
             action = action_type.to_sym
 
             unless TaskService::BULK_ACTIONS.include?(action)
-              render json: { errors: ["Unknown action"] }, status: :bad_request and return
+              render json: { errors: [ "Unknown action" ] }, status: :bad_request and return
             end
 
             task_ids = Array(params[:task_ids]).map(&:to_i)
             if task_ids.empty?
-              render json: { errors: ["task_ids is required"] }, status: :bad_request and return
+              render json: { errors: [ "task_ids is required" ] }, status: :bad_request and return
             end
 
             tasks = current_board.board_tasks.where(id: task_ids)
@@ -99,17 +99,17 @@ module Api
             when :move_to_column
               col_id = params[:column_id]
               unless col_id.present?
-                render json: { errors: ["column_id is required"] }, status: :bad_request and return
+                render json: { errors: [ "column_id is required" ] }, status: :bad_request and return
               end
               col = current_board.board_columns.find_by(id: col_id)
               unless col
-                render json: { errors: ["Column not found"] }, status: :not_found and return
+                render json: { errors: [ "Column not found" ] }, status: :not_found and return
               end
               col
             when :move_to_done
               done_col = current_board.board_columns.order(:position).last
               unless done_col
-                render json: { errors: ["Board has no Done column"] }, status: :unprocessable_entity and return
+                render json: { errors: [ "Board has no Done column" ] }, status: :unprocessable_entity and return
               end
               done_col
             end

--- a/app/controllers/api/v1/projects/board/tasks_controller.rb
+++ b/app/controllers/api/v1/projects/board/tasks_controller.rb
@@ -75,6 +75,44 @@ module Api
             render json: BoardTaskResource.new(task).to_h
           end
 
+          # @summary Apply a bulk action to multiple board tasks
+          def bulk_actions
+            action = params[:action_type].to_sym
+
+            unless TaskService::BULK_ACTIONS.include?(action)
+              render json: { errors: ["Unknown action"] }, status: :bad_request and return
+            end
+
+            task_ids = Array(params[:task_ids]).map(&:to_i)
+            if task_ids.empty?
+              render json: { errors: ["task_ids is required"] }, status: :bad_request and return
+            end
+
+            tasks = current_board.board_tasks.where(id: task_ids)
+
+            to_column = case action
+            when :move_to_column
+              col_id = params[:column_id]
+              unless col_id.present?
+                render json: { errors: ["column_id is required"] }, status: :bad_request and return
+              end
+              col = current_board.board_columns.find_by(id: col_id)
+              unless col
+                render json: { errors: ["Column not found"] }, status: :not_found and return
+              end
+              col
+            when :move_to_done
+              done_col = current_board.board_columns.order(:position).last
+              unless done_col
+                render json: { errors: ["Board has no Done column"] }, status: :unprocessable_entity and return
+              end
+              done_col
+            end
+
+            result = TaskService.bulk_action(action: action, tasks: tasks, actor: current_user, to_column: to_column)
+            render json: result
+          end
+
           # @summary List workflow runs for a board task
           def workflow_runs
             task = current_board.board_tasks.find(params[:id])

--- a/app/frontend/pages/Projects/Board/BoardPage.module.css
+++ b/app/frontend/pages/Projects/Board/BoardPage.module.css
@@ -148,6 +148,18 @@
   color: var(--mantine-color-red-6) !important;
 }
 
+/* Selection checkbox on task cards — fades in on hover or when any card is selected */
+.selectionCheckboxWrapper {
+  flex-shrink: 0;
+  margin-top: 2px;
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+
+.selectionCheckboxWrapper.selectionCheckboxVisible {
+  opacity: 1;
+}
+
 /* Task detail panel — title ghost input */
 .ptTitle {
   width: 100%;

--- a/app/frontend/pages/Projects/Board/BoardPage.module.css
+++ b/app/frontend/pages/Projects/Board/BoardPage.module.css
@@ -148,16 +148,106 @@
   color: var(--mantine-color-red-6) !important;
 }
 
-/* Selection checkbox on task cards — fades in on hover or when any card is selected */
-.selectionCheckboxWrapper {
-  flex-shrink: 0;
-  margin-top: 2px;
-  opacity: 0;
-  transition: opacity 0.12s;
+/* Task card — position relative so the absolutely-placed checkbox can anchor to it */
+.taskCard {
+  position: relative;
 }
 
-.selectionCheckboxWrapper.selectionCheckboxVisible {
+/* Title row — gains left padding when card is hovered or in selection mode */
+.taskCardTop {
+  transition: padding-left 0.12s;
+}
+
+.taskCard:hover .taskCardTop,
+.taskCardSelectionMode .taskCardTop {
+  padding-left: 24px;
+}
+
+/* Checkbox — 16×16 native square, absolutely positioned, hidden at rest */
+.taskCardCheck {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  border: 1px solid var(--app-border-strong);
+  background: var(--app-bg-default);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: transparent;
+  font-size: 11px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.12s, background 0.12s, border-color 0.12s, color 0.12s;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.taskCard:hover .taskCardCheck,
+.taskCardSelectionMode .taskCardCheck {
   opacity: 1;
+  pointer-events: auto;
+}
+
+.taskCardCheck:hover {
+  border-color: var(--app-text-secondary);
+}
+
+/* Selected state */
+.taskCardCheckSelected {
+  opacity: 1 !important;
+  pointer-events: auto !important;
+  background: var(--mantine-color-brand-6) !important;
+  border-color: var(--mantine-color-brand-6) !important;
+  color: #fff !important;
+}
+
+/* Selected card accent tint */
+.taskCardSelected {
+  border-color: var(--mantine-color-brand-5) !important;
+  background-color: color-mix(in srgb, var(--mantine-color-brand-5) 8%, var(--app-bg-elevated)) !important;
+}
+
+/* Column tri-state checkbox in header */
+.colHeaderCheck {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  border: 1px solid var(--app-border-strong);
+  background: var(--app-bg-default);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: transparent;
+  font-size: 11px;
+  cursor: pointer;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.12s, background 0.12s, border-color 0.12s, color 0.12s;
+  pointer-events: none;
+}
+
+.colHeaderCheckVisible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.colHeaderCheck:hover {
+  border-color: var(--app-text-secondary);
+}
+
+.colHeaderCheckOn {
+  background: var(--mantine-color-brand-6) !important;
+  border-color: var(--mantine-color-brand-6) !important;
+  color: #fff !important;
+}
+
+.colHeaderCheckSome {
+  background: color-mix(in srgb, var(--mantine-color-brand-6) 20%, var(--app-bg-default)) !important;
+  border-color: var(--mantine-color-brand-5) !important;
+  color: var(--mantine-color-brand-5) !important;
 }
 
 /* Task detail panel — title ghost input */

--- a/app/frontend/pages/Projects/Board/BoardPage.module.css
+++ b/app/frontend/pages/Projects/Board/BoardPage.module.css
@@ -165,6 +165,8 @@
 
 /* Checkbox — 16×16 native square, absolutely positioned, hidden at rest */
 .taskCardCheck {
+  appearance: none;
+  -webkit-appearance: none;
   position: absolute;
   top: 12px;
   left: 12px;
@@ -183,6 +185,7 @@
   transition: opacity 0.12s, background 0.12s, border-color 0.12s, color 0.12s;
   pointer-events: none;
   z-index: 3;
+  padding: 0;
 }
 
 .taskCard:hover .taskCardCheck,
@@ -201,7 +204,7 @@
   pointer-events: auto !important;
   background: var(--mantine-color-brand-6) !important;
   border-color: var(--mantine-color-brand-6) !important;
-  color: #fff !important;
+  color: #0a0908 !important;
 }
 
 /* Selected card accent tint */
@@ -212,6 +215,8 @@
 
 /* Column tri-state checkbox in header */
 .colHeaderCheck {
+  appearance: none;
+  -webkit-appearance: none;
   width: 16px;
   height: 16px;
   border-radius: 4px;
@@ -227,6 +232,7 @@
   opacity: 0;
   transition: opacity 0.12s, background 0.12s, border-color 0.12s, color 0.12s;
   pointer-events: none;
+  padding: 0;
 }
 
 .colHeaderCheckVisible {
@@ -241,7 +247,7 @@
 .colHeaderCheckOn {
   background: var(--mantine-color-brand-6) !important;
   border-color: var(--mantine-color-brand-6) !important;
-  color: #fff !important;
+  color: #0a0908 !important;
 }
 
 .colHeaderCheckSome {

--- a/app/frontend/pages/Projects/Board/BoardPage.test.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.test.tsx
@@ -2278,7 +2278,7 @@ describe('Projects/Board/BoardPage', () => {
     expect(await screen.findByText('1 selected')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Archive' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Move to column' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Move to/i })).toBeInTheDocument();
   });
 
   it('clears selection when the × button in SelectionBar is clicked', async () => {

--- a/app/frontend/pages/Projects/Board/BoardPage.test.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.test.tsx
@@ -2278,7 +2278,7 @@ describe('Projects/Board/BoardPage', () => {
     expect(await screen.findByText('1 selected')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Archive' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Move to Done' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Move to column' })).toBeInTheDocument();
   });
 
   it('clears selection when the × button in SelectionBar is clicked', async () => {

--- a/app/frontend/pages/Projects/Board/BoardPage.test.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.test.tsx
@@ -2252,4 +2252,113 @@ describe('Projects/Board/BoardPage', () => {
     // No modal overlay backdrop rendered (withOverlay=false means no .mantine-Overlay-root).
     expect(document.querySelector('.mantine-Overlay-root')).toBeNull();
   });
+
+  // --- bulk selection ---
+
+  it('shows selection checkboxes for non-view-only users', () => {
+    renderAuthedPage(<BoardPage />, { props: populatedProps });
+
+    expect(screen.getByRole('checkbox', { name: 'Select Wire up authentication' })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Select Render dashboard charts' })).toBeInTheDocument();
+  });
+
+  it('does not show selection checkboxes for view-only users', () => {
+    renderAuthedPage(<BoardPage />, {
+      props: { ...populatedProps, projectPermissions: { canExecute: false, canManage: false } },
+    });
+
+    expect(screen.queryByRole('checkbox', { name: /Select/ })).not.toBeInTheDocument();
+  });
+
+  it('shows SelectionBar after selecting a task card', async () => {
+    renderAuthedPage(<BoardPage />, { props: populatedProps });
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Select Wire up authentication' }));
+
+    expect(await screen.findByText('1 selected')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Archive' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Move to Done' })).toBeInTheDocument();
+  });
+
+  it('clears selection when the × button in SelectionBar is clicked', async () => {
+    renderAuthedPage(<BoardPage />, { props: populatedProps });
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Select Wire up authentication' }));
+    expect(await screen.findByText('1 selected')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Clear selection' }));
+
+    await waitFor(() => expect(screen.queryByText('1 selected')).not.toBeInTheDocument());
+  });
+
+  it('opens a confirm modal when Delete is clicked in the SelectionBar', async () => {
+    renderAuthedPage(<BoardPage />, { props: populatedProps });
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Select Wire up authentication' }));
+    await screen.findByText('1 selected');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    const modal = await screen.findByRole('dialog', { name: /delete tasks/i });
+    expect(within(modal).getByText(/Delete 1 task\? This cannot be undone/i)).toBeInTheDocument();
+  });
+
+  it('POSTs to bulk_actions when delete is confirmed and shows success notification', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      if (String(input).includes('bulk_actions')) {
+        return new Response(JSON.stringify({ succeeded: [1], skipped: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('{}', { status: 200 });
+    });
+
+    renderAuthedPage(<BoardPage />, { props: populatedProps });
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Select Wire up authentication' }));
+    await screen.findByText('1 selected');
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    const modal = await screen.findByRole('dialog', { name: /delete tasks/i });
+    await userEvent.click(within(modal).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining('bulk_actions'),
+        expect.objectContaining({ method: 'POST' }),
+      ),
+    );
+    expect(await screen.findByText(/Deleted 1 task/)).toBeInTheDocument();
+
+    fetchSpy.mockRestore();
+  });
+
+  it('shows a partial-success notification when some tasks are skipped', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      if (String(input).includes('bulk_actions')) {
+        return new Response(
+          JSON.stringify({ succeeded: [2], skipped: [{ task_id: 1, reason: 'active_run' }] }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response('{}', { status: 200 });
+    });
+
+    renderAuthedPage(<BoardPage />, { props: populatedProps });
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Select Wire up authentication' }));
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Select Render dashboard charts' }));
+    await screen.findByText('2 selected');
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    const modal = await screen.findByRole('dialog', { name: /delete tasks/i });
+    await userEvent.click(within(modal).getByRole('button', { name: 'Delete' }));
+
+    expect(await screen.findByText(/Partial success/i)).toBeInTheDocument();
+    expect(await screen.findByText(/1 skipped/i)).toBeInTheDocument();
+
+    fetchSpy.mockRestore();
+  });
 });

--- a/app/frontend/pages/Projects/Board/BoardPage.test.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.test.tsx
@@ -2338,10 +2338,10 @@ describe('Projects/Board/BoardPage', () => {
   it('shows a partial-success notification when some tasks are skipped', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
       if (String(input).includes('bulk_actions')) {
-        return new Response(
-          JSON.stringify({ succeeded: [2], skipped: [{ task_id: 1, reason: 'active_run' }] }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        );
+        return new Response(JSON.stringify({ succeeded: [2], skipped: [{ task_id: 1, reason: 'active_run' }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
       }
       return new Response('{}', { status: 200 });
     });

--- a/app/frontend/pages/Projects/Board/BoardPage.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.tsx
@@ -150,11 +150,11 @@ import styles from './BoardPage.module.css';
 import { CHIP_TOOLTIP_PROPS } from './chipTooltip';
 import { GATE_CHIP_WIDTH, GateStatusChip } from './GateStatusChip';
 import { LatestRunTile } from './LatestRunTile';
+import { SelectionBar } from './SelectionBar';
 import { WORKFLOW_ACTIVE_STATES, type TaskWorkflowRun } from './taskRuns';
 import { TaskRunsPanel } from './TaskRunsPanel';
 import { useBoardDnd } from './useBoardDnd';
 import { useBoardTaskPages } from './useBoardTaskPages';
-import { SelectionBar } from './SelectionBar';
 import { useBulkActions } from './useBulkActions';
 
 const COMMENT_TAG_SUGGESTIONS = ['feedback', 'tech_design', 'code_review', 'qa_report', 'implementation_notes'];
@@ -4450,7 +4450,6 @@ const BoardPage = () => {
     },
     [project.id, closeTask],
   );
-
 
   // Drag-and-drop (task moves + column reorder) lives in useBoardDnd so its behaviour is
   // testable without element geometry, which jsdom cannot provide for dnd-kit's sensors.

--- a/app/frontend/pages/Projects/Board/BoardPage.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.tsx
@@ -154,6 +154,8 @@ import { WORKFLOW_ACTIVE_STATES, type TaskWorkflowRun } from './taskRuns';
 import { TaskRunsPanel } from './TaskRunsPanel';
 import { useBoardDnd } from './useBoardDnd';
 import { useBoardTaskPages } from './useBoardTaskPages';
+import { SelectionBar } from './SelectionBar';
+import { useBulkActions } from './useBulkActions';
 
 const COMMENT_TAG_SUGGESTIONS = ['feedback', 'tech_design', 'code_review', 'qa_report', 'implementation_notes'];
 const AUTHOR_TYPES = [
@@ -379,6 +381,9 @@ function SortableTaskCard({
   onRetry,
   onTagClick,
   activeTags,
+  isSelected,
+  onToggleSelect,
+  selectionMode,
 }: {
   task: Task;
   href?: string;
@@ -386,6 +391,9 @@ function SortableTaskCard({
   onRetry?: (task: Task) => void;
   onTagClick?: (tag: string) => void;
   activeTags?: string[];
+  isSelected?: boolean;
+  onToggleSelect?: (id: number, checked: boolean) => void;
+  selectionMode?: boolean;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: `task-${task.id}`,
@@ -412,6 +420,9 @@ function SortableTaskCard({
         onRetry={onRetry}
         onTagClick={onTagClick}
         activeTags={activeTags}
+        isSelected={isSelected}
+        onToggleSelect={onToggleSelect}
+        selectionMode={selectionMode}
       />
     </Box>
   );
@@ -614,6 +625,8 @@ function TaskCardUI({
   onRetry,
   onTagClick,
   activeTags,
+  isSelected,
+  onToggleSelect,
 }: {
   task: Task;
   href?: string;
@@ -622,7 +635,12 @@ function TaskCardUI({
   onRetry?: (task: Task) => void;
   onTagClick?: (tag: string) => void;
   activeTags?: string[];
+  isSelected?: boolean;
+  onToggleSelect?: (id: number, checked: boolean) => void;
+  selectionMode?: boolean;
 }) {
+  const [cardHovered, setCardHovered] = useState(false);
+
   // A card shows at most three tags. Whichever ones the board is filtered by come first, so the
   // filter that put this card on screen is always the one you can click to take it back off.
   const cardTags = (activeTags ?? []).length
@@ -688,14 +706,36 @@ function TaskCardUI({
       onMouseEnter={(e: React.MouseEvent<HTMLElement>) => {
         (e.currentTarget as HTMLElement).style.borderColor = 'var(--mantine-color-brand-4)';
         (e.currentTarget as HTMLElement).style.backgroundColor = 'var(--app-bg-paper)';
+        setCardHovered(true);
       }}
       onMouseLeave={(e: React.MouseEvent<HTMLElement>) => {
         (e.currentTarget as HTMLElement).style.borderColor = 'var(--app-border-strong)';
         (e.currentTarget as HTMLElement).style.backgroundColor = 'var(--app-bg-elevated)';
+        setCardHovered(false);
       }}
     >
-      {/* Title row with priority dot */}
+      {/* Title row with selection checkbox, priority dot */}
       <Group gap={4} align="flex-start" wrap="nowrap">
+        {onToggleSelect && (
+          <Box
+            className={[
+              styles.selectionCheckboxWrapper,
+              isSelected || selectionMode || cardHovered ? styles.selectionCheckboxVisible : '',
+            ].join(' ')}
+            onPointerDown={(e: React.PointerEvent) => e.stopPropagation()}
+            onClick={(e: React.MouseEvent) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+          >
+            <Checkbox
+              size="xs"
+              checked={!!isSelected}
+              onChange={(e) => onToggleSelect(task.id, e.currentTarget.checked)}
+              aria-label={`Select ${task.title}`}
+            />
+          </Box>
+        )}
         {task.priority && (
           <Tooltip label={task.priority}>
             <Box
@@ -940,6 +980,9 @@ function BoardColumn({
   isFiltered,
   isDropTarget,
   canExecute,
+  selectedIds,
+  onToggleSelect,
+  selectionMode,
 }: {
   column: Column;
   /** The pages of this column the client has loaded — not necessarily all of it. */
@@ -964,6 +1007,9 @@ function BoardColumn({
   isFiltered: boolean;
   isDropTarget: boolean;
   canExecute: boolean;
+  selectedIds?: Set<number>;
+  onToggleSelect?: (id: number, checked: boolean) => void;
+  selectionMode?: boolean;
 }) {
   const {
     setNodeRef,
@@ -1384,6 +1430,9 @@ function BoardColumn({
                 onRetry={onRetryTask}
                 onTagClick={onTagClick}
                 activeTags={activeTags}
+                isSelected={selectedIds?.has(task.id)}
+                onToggleSelect={onToggleSelect}
+                selectionMode={selectionMode}
               />
             ))
           )}
@@ -4248,6 +4297,21 @@ const BoardPage = () => {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+
+  const toggleSelect = useCallback((id: number, checked: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  }, []);
+
+  const clearSelection = useCallback(() => setSelectedIds(new Set()), []);
+
+  const { execute: executeBulkAction } = useBulkActions({ projectId: project.id, onSuccess: clearSelection });
+
   // Opening by id, for a task the board may not hold a card for — an epic's child or parent that
   // lives on a page no column has loaded.
   const openTaskById = useCallback(
@@ -4385,6 +4449,7 @@ const BoardPage = () => {
     },
     [project.id, closeTask],
   );
+
 
   // Drag-and-drop (task moves + column reorder) lives in useBoardDnd so its behaviour is
   // testable without element geometry, which jsdom cannot provide for dnd-kit's sensors.
@@ -4788,6 +4853,9 @@ const BoardPage = () => {
                   isFiltered={hasActiveFilters}
                   isDropTarget={hoverColumnId === col.id}
                   canExecute={canExecute}
+                  selectedIds={selectedIds}
+                  onToggleSelect={canExecute ? toggleSelect : undefined}
+                  selectionMode={canExecute && selectedIds.size > 0}
                 />
               ))}
             </SortableContext>
@@ -4864,6 +4932,14 @@ const BoardPage = () => {
           onClose={() => setActivityOpen(false)}
         />
       </Box>
+
+      <SelectionBar
+        selectedCount={selectedIds.size}
+        columns={localColumns}
+        canExecute={canExecute}
+        onAction={(action, columnId) => executeBulkAction(action, [...selectedIds], columnId)}
+        onClear={clearSelection}
+      />
 
       <TaskDetailSidebar
         task={selectedTask}

--- a/app/frontend/pages/Projects/Board/BoardPage.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.tsx
@@ -672,11 +672,12 @@ function TaskCardUI({
 
   const isLink = !isDragOverlay && !!href;
   const handleClick = (e: React.MouseEvent<HTMLElement>) => {
+    if (e.defaultPrevented) return;
     if (!isLink) {
       onClick?.(task);
       return;
     }
-    if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     e.preventDefault();
     onClick?.(task);
   };
@@ -735,6 +736,7 @@ function TaskCardUI({
           aria-checked={!!isSelected}
           onPointerDown={(e: React.PointerEvent) => e.stopPropagation()}
           onClick={(e: React.MouseEvent) => {
+            e.preventDefault();
             e.stopPropagation();
             onToggleSelect(task.id, !isSelected);
           }}
@@ -1456,7 +1458,7 @@ function BoardColumn({
 
       {/* Task list — one page at a time, extended as it is scrolled */}
       <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
-        <Box onScroll={handleScroll} style={{ flex: 1, overflowY: 'auto', padding: '0 12px 12px', minHeight: 60 }}>
+        <Box onScroll={handleScroll} style={{ flex: 1, overflowY: 'auto', padding: '8px 12px 12px', minHeight: 60 }}>
           {tasks.length === 0 && !loadingMore ? (
             <Text size="xs" c="dimmed" ta="center" py="xl">
               {isFiltered ? 'No matching tasks' : 'No tasks yet'}

--- a/app/frontend/pages/Projects/Board/BoardPage.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.tsx
@@ -627,6 +627,7 @@ function TaskCardUI({
   activeTags,
   isSelected,
   onToggleSelect,
+  selectionMode,
 }: {
   task: Task;
   href?: string;

--- a/app/frontend/pages/Projects/Board/BoardPage.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.tsx
@@ -716,7 +716,7 @@ function TaskCardUI({
       }}
     >
       {/* Title row with selection checkbox, priority dot */}
-      <Group gap={4} align="flex-start" wrap="nowrap">
+      <Group gap={8} align="flex-start" wrap="nowrap">
         {onToggleSelect && (
           <Box
             className={[
@@ -725,7 +725,6 @@ function TaskCardUI({
             ].join(' ')}
             onPointerDown={(e: React.PointerEvent) => e.stopPropagation()}
             onClick={(e: React.MouseEvent) => {
-              e.preventDefault();
               e.stopPropagation();
             }}
           >

--- a/app/frontend/pages/Projects/Board/BoardPage.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.tsx
@@ -84,6 +84,7 @@ import {
   IconListDetails,
   IconLink,
   IconMessage,
+  IconMinus,
   IconPencil,
   IconPlus,
   IconRefresh,
@@ -640,8 +641,6 @@ function TaskCardUI({
   onToggleSelect?: (id: number, checked: boolean) => void;
   selectionMode?: boolean;
 }) {
-  const [cardHovered, setCardHovered] = useState(false);
-
   // A card shows at most three tags. Whichever ones the board is filtered by come first, so the
   // filter that put this card on screen is always the one you can click to take it back off.
   const cardTags = (activeTags ?? []).length
@@ -682,6 +681,14 @@ function TaskCardUI({
     onClick?.(task);
   };
 
+  const cardClasses = [
+    styles.taskCard,
+    selectionMode || isSelected ? styles.taskCardSelectionMode : '',
+    isSelected ? styles.taskCardSelected : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
     <Paper
       component={isLink ? 'a' : 'div'}
@@ -693,6 +700,7 @@ function TaskCardUI({
       withBorder
       bg="var(--app-bg-elevated)"
       onClick={handleClick}
+      className={cardClasses}
       style={{
         cursor: 'pointer',
         transition: 'border-color 0.15s, background-color 0.15s',
@@ -705,37 +713,38 @@ function TaskCardUI({
         padding: '12px 13px',
       }}
       onMouseEnter={(e: React.MouseEvent<HTMLElement>) => {
-        (e.currentTarget as HTMLElement).style.borderColor = 'var(--mantine-color-brand-4)';
-        (e.currentTarget as HTMLElement).style.backgroundColor = 'var(--app-bg-paper)';
-        setCardHovered(true);
+        if (!isSelected) {
+          (e.currentTarget as HTMLElement).style.borderColor = 'var(--mantine-color-brand-4)';
+          (e.currentTarget as HTMLElement).style.backgroundColor = 'var(--app-bg-paper)';
+        }
       }}
       onMouseLeave={(e: React.MouseEvent<HTMLElement>) => {
-        (e.currentTarget as HTMLElement).style.borderColor = 'var(--app-border-strong)';
-        (e.currentTarget as HTMLElement).style.backgroundColor = 'var(--app-bg-elevated)';
-        setCardHovered(false);
+        if (!isSelected) {
+          (e.currentTarget as HTMLElement).style.borderColor = 'var(--app-border-strong)';
+          (e.currentTarget as HTMLElement).style.backgroundColor = 'var(--app-bg-elevated)';
+        }
       }}
     >
-      {/* Title row with selection checkbox, priority dot */}
-      <Group gap={8} align="flex-start" wrap="nowrap">
-        {onToggleSelect && (
-          <Box
-            className={[
-              styles.selectionCheckboxWrapper,
-              isSelected || selectionMode || cardHovered ? styles.selectionCheckboxVisible : '',
-            ].join(' ')}
-            onPointerDown={(e: React.PointerEvent) => e.stopPropagation()}
-            onClick={(e: React.MouseEvent) => {
-              e.stopPropagation();
-            }}
-          >
-            <Checkbox
-              size="xs"
-              checked={!!isSelected}
-              onChange={(e) => onToggleSelect(task.id, e.currentTarget.checked)}
-              aria-label={`Select ${task.title}`}
-            />
-          </Box>
-        )}
+      {/* Absolutely-positioned selection checkbox — slides in on hover or selection mode */}
+      {onToggleSelect && (
+        <Box
+          component="button"
+          role="checkbox"
+          className={[styles.taskCardCheck, isSelected ? styles.taskCardCheckSelected : ''].filter(Boolean).join(' ')}
+          aria-label={`Select ${task.title}`}
+          aria-checked={!!isSelected}
+          onPointerDown={(e: React.PointerEvent) => e.stopPropagation()}
+          onClick={(e: React.MouseEvent) => {
+            e.stopPropagation();
+            onToggleSelect(task.id, !isSelected);
+          }}
+        >
+          {isSelected && <IconCheck size={10} />}
+        </Box>
+      )}
+
+      {/* Title row — padding-left animates in when checkbox is shown */}
+      <Group gap={8} align="flex-start" wrap="nowrap" className={styles.taskCardTop}>
         {task.priority && (
           <Tooltip label={task.priority}>
             <Box
@@ -982,6 +991,7 @@ function BoardColumn({
   canExecute,
   selectedIds,
   onToggleSelect,
+  onToggleColumn,
   selectionMode,
 }: {
   column: Column;
@@ -1009,6 +1019,7 @@ function BoardColumn({
   canExecute: boolean;
   selectedIds?: Set<number>;
   onToggleSelect?: (id: number, checked: boolean) => void;
+  onToggleColumn?: (columnId: number, taskIds: number[], select: boolean) => void;
   selectionMode?: boolean;
 }) {
   const {
@@ -1237,8 +1248,38 @@ function BoardColumn({
         >
           <IconChevronDown size={15} />
         </ActionIcon>
-        {/* Left: name (drag handle) + count + bolt chip */}
+        {/* Left: column tri-state checkbox (selection mode) + name (drag handle) + count + bolt chip */}
         <Group gap={6} style={{ overflow: 'hidden', flex: 1, minWidth: 0 }}>
+          {selectionMode &&
+            onToggleColumn &&
+            (() => {
+              const colTaskIds = tasks.map((t) => t.id);
+              const selectedInCol = colTaskIds.filter((id) => selectedIds?.has(id)).length;
+              const allSelected = colTaskIds.length > 0 && selectedInCol === colTaskIds.length;
+              const someSelected = selectedInCol > 0 && !allSelected;
+              return (
+                <Box
+                  component="button"
+                  className={[
+                    styles.colHeaderCheck,
+                    styles.colHeaderCheckVisible,
+                    allSelected ? styles.colHeaderCheckOn : someSelected ? styles.colHeaderCheckSome : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
+                  aria-label={`Toggle all tasks in ${column.name}`}
+                  aria-pressed={allSelected}
+                  onClick={(e: React.MouseEvent) => {
+                    e.stopPropagation();
+                    onToggleColumn(column.id, colTaskIds, !allSelected);
+                  }}
+                  onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+                >
+                  {allSelected && <IconCheck size={10} />}
+                  {someSelected && <IconMinus size={10} />}
+                </Box>
+              );
+            })()}
           {renaming ? (
             <TextInput
               ref={renameInputRef}
@@ -4310,7 +4351,26 @@ const BoardPage = () => {
 
   const clearSelection = useCallback(() => setSelectedIds(new Set()), []);
 
-  const { execute: executeBulkAction } = useBulkActions({ projectId: project.id, onSuccess: clearSelection });
+  const {
+    execute: executeBulkAction,
+    bulkSetPriority,
+    bulkAssign,
+    bulkAddTag,
+  } = useBulkActions({
+    projectId: project.id,
+    onSuccess: clearSelection,
+  });
+
+  const toggleColumn = useCallback((_columnId: number, taskIds: number[], select: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      for (const id of taskIds) {
+        if (select) next.add(id);
+        else next.delete(id);
+      }
+      return next;
+    });
+  }, []);
 
   // Opening by id, for a task the board may not hold a card for — an epic's child or parent that
   // lives on a page no column has loaded.
@@ -4788,6 +4848,20 @@ const BoardPage = () => {
           )}
         </Group>
 
+        {/* Selection toolbar — second row, visible only when tasks are selected */}
+        <SelectionBar
+          selectedCount={selectedIds.size}
+          selectedIds={selectedIds}
+          columns={localColumns}
+          members={members}
+          canExecute={canExecute}
+          onAction={(action, columnId) => executeBulkAction(action, [...selectedIds], columnId)}
+          onBulkPriority={(priority) => bulkSetPriority([...selectedIds], priority)}
+          onBulkAssign={(assigneeId) => bulkAssign([...selectedIds], assigneeId)}
+          onBulkTag={(tag) => bulkAddTag([...selectedIds], tag)}
+          onClear={clearSelection}
+        />
+
         {/* Board area */}
         <DndContext
           sensors={sensors}
@@ -4854,6 +4928,7 @@ const BoardPage = () => {
                   canExecute={canExecute}
                   selectedIds={selectedIds}
                   onToggleSelect={canExecute ? toggleSelect : undefined}
+                  onToggleColumn={canExecute ? toggleColumn : undefined}
                   selectionMode={canExecute && selectedIds.size > 0}
                 />
               ))}
@@ -4931,14 +5006,6 @@ const BoardPage = () => {
           onClose={() => setActivityOpen(false)}
         />
       </Box>
-
-      <SelectionBar
-        selectedCount={selectedIds.size}
-        columns={localColumns}
-        canExecute={canExecute}
-        onAction={(action, columnId) => executeBulkAction(action, [...selectedIds], columnId)}
-        onClear={clearSelection}
-      />
 
       <TaskDetailSidebar
         task={selectedTask}

--- a/app/frontend/pages/Projects/Board/SelectionBar.tsx
+++ b/app/frontend/pages/Projects/Board/SelectionBar.tsx
@@ -3,11 +3,16 @@ import { modals } from '@mantine/modals';
 import {
   IconAlertTriangle,
   IconArchive,
+  IconArrowRight,
+  IconBolt,
+  IconCheckbox,
   IconChevronDown,
+  IconColumns,
   IconFlag,
   IconTag,
   IconTrash,
   IconUser,
+  IconUserOff,
   IconX,
 } from '@tabler/icons-react';
 
@@ -52,6 +57,59 @@ function avatarInitials(name: string) {
     .toUpperCase()
     .slice(0, 2);
 }
+
+// Matches .pop from the reference HTML
+const menuStyles = {
+  dropdown: {
+    background: 'var(--app-bg-elevated)',
+    border: '1px solid var(--app-border-strong)',
+    borderRadius: 8,
+    padding: 4,
+    minWidth: 220,
+    boxShadow: '0 8px 32px rgba(0,0,0,0.5)',
+  },
+  // Matches .pop-head
+  label: {
+    fontSize: 10,
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase' as const,
+    color: 'var(--mantine-color-dimmed)',
+    fontWeight: 600,
+    padding: '7px 10px 4px',
+  },
+  // Matches .pop-item
+  item: {
+    padding: '7px 10px',
+    borderRadius: 5,
+    fontSize: 13,
+    color: 'var(--app-text-secondary)',
+  },
+  // Matches .pop-div
+  divider: {
+    borderColor: 'var(--app-border-default)',
+    margin: '3px 0',
+  },
+};
+
+const btnStyle = {
+  root: {
+    height: 32,
+    padding: '0 10px',
+    fontSize: 12,
+    fontWeight: 500,
+    color: 'var(--app-text-secondary)',
+    border: '1px solid var(--app-border-default)',
+    borderRadius: 5,
+    backgroundColor: 'transparent',
+  },
+};
+
+const dangerBtnStyle = {
+  root: {
+    ...btnStyle.root,
+    color: 'var(--mantine-color-red-6)',
+  },
+};
 
 export function SelectionBar({
   selectedCount,
@@ -112,7 +170,7 @@ export function SelectionBar({
           <TextInput
             label="Tag name"
             placeholder="e.g. needs-review"
-            autoFocus
+            data-autofocus
             onChange={(e) => {
               tagValue = e.currentTarget.value;
             }}
@@ -148,29 +206,9 @@ export function SelectionBar({
     });
   };
 
-  const btnStyle = {
-    root: {
-      height: 32,
-      padding: '0 10px',
-      fontSize: 12,
-      fontWeight: 500,
-      color: 'var(--app-text-secondary)',
-      border: '1px solid var(--app-border-default)',
-      borderRadius: 5,
-      backgroundColor: 'transparent',
-    },
-  };
-
-  const dangerBtnStyle = {
-    root: {
-      ...btnStyle.root,
-      color: 'var(--mantine-color-red-6)',
-    },
-  };
-
   return (
     <Group gap={8} mb="sm" wrap="nowrap" align="center" style={{ flexShrink: 0 }}>
-      {/* Count badge */}
+      {/* Count badge — matches .sb-count */}
       <Group
         gap={6}
         align="center"
@@ -183,37 +221,56 @@ export function SelectionBar({
           flexShrink: 0,
         }}
       >
+        <IconCheckbox size={14} color="var(--mantine-color-brand-6)" />
         <Text size="xs" fw={600} c="brand">
           {selectedCount} selected
         </Text>
       </Group>
 
-      {/* Separator */}
+      {/* Separator — matches .sb-sep */}
       <div style={{ width: 1, height: 20, backgroundColor: 'var(--app-border-default)', flexShrink: 0 }} />
 
-      {/* Move to → */}
-      <Menu shadow="md" position="bottom-start" withinPortal>
+      {/* Move to — items match .pop-item with ti-columns icon + auto-flag on right */}
+      <Menu shadow="md" position="bottom-start" withinPortal styles={menuStyles}>
         <Menu.Target>
-          <Button size="xs" variant="default" rightSection={<IconChevronDown size={11} />} styles={btnStyle}>
+          <Button
+            size="xs"
+            variant="default"
+            leftSection={<IconArrowRight size={12} />}
+            rightSection={<IconChevronDown size={11} />}
+            styles={btnStyle}
+          >
             Move to
           </Button>
         </Menu.Target>
         <Menu.Dropdown>
+          <Menu.Label>
+            Move {selectedCount} task{selectedCount === 1 ? '' : 's'} to
+          </Menu.Label>
           {columns.map((col) => (
-            <Menu.Item key={col.id} onClick={() => confirmMoveToColumn(col)}>
+            <Menu.Item
+              key={col.id}
+              leftSection={<IconColumns size={13} color="var(--mantine-color-dimmed)" />}
+              rightSection={
+                col.workflowBinding?.triggerMode === 'auto' ? (
+                  <Group gap={3} align="center" wrap="nowrap">
+                    <IconBolt size={11} color="var(--mantine-color-brand-6)" />
+                    <Text size="xs" fw={600} c="brand" style={{ letterSpacing: '0.03em' }}>
+                      Runs
+                    </Text>
+                  </Group>
+                ) : undefined
+              }
+              onClick={() => confirmMoveToColumn(col)}
+            >
               {col.name}
-              {col.workflowBinding?.triggerMode === 'auto' && (
-                <Text span size="xs" c="brand" fw={600} ml={8}>
-                  Runs
-                </Text>
-              )}
             </Menu.Item>
           ))}
         </Menu.Dropdown>
       </Menu>
 
       {/* Priority */}
-      <Menu shadow="md" position="bottom-start" withinPortal>
+      <Menu shadow="md" position="bottom-start" withinPortal styles={menuStyles}>
         <Menu.Target>
           <Button
             size="xs"
@@ -228,7 +285,11 @@ export function SelectionBar({
         <Menu.Dropdown>
           <Menu.Label>Set priority</Menu.Label>
           {PRIORITY_OPTIONS.map(({ value, label }) => (
-            <Menu.Item key={label} leftSection={<IconFlag size={13} />} onClick={() => onBulkPriority(value)}>
+            <Menu.Item
+              key={label}
+              leftSection={<IconFlag size={13} color="var(--mantine-color-dimmed)" />}
+              onClick={() => onBulkPriority(value)}
+            >
               {label}
             </Menu.Item>
           ))}
@@ -237,7 +298,7 @@ export function SelectionBar({
 
       {/* Assign */}
       {members.length > 0 && (
-        <Menu shadow="md" position="bottom-start" withinPortal>
+        <Menu shadow="md" position="bottom-start" withinPortal styles={menuStyles}>
           <Menu.Target>
             <Button
               size="xs"
@@ -252,19 +313,20 @@ export function SelectionBar({
           <Menu.Dropdown>
             <Menu.Label>Assign to</Menu.Label>
             {members.map((m) => (
-              <Menu.Item key={m.id} onClick={() => onBulkAssign(m.id)}>
-                <Group gap={8} align="center">
+              <Menu.Item
+                key={m.id}
+                leftSection={
                   <div
                     style={{
-                      width: 20,
-                      height: 20,
+                      width: 18,
+                      height: 18,
                       borderRadius: '50%',
                       backgroundColor: 'color-mix(in srgb, var(--mantine-color-brand-6) 12%, transparent)',
                       border: '1px solid color-mix(in srgb, var(--mantine-color-brand-6) 30%, transparent)',
                       display: 'flex',
                       alignItems: 'center',
                       justifyContent: 'center',
-                      fontSize: 9,
+                      fontSize: 8,
                       fontWeight: 700,
                       color: 'var(--mantine-color-brand-6)',
                       flexShrink: 0,
@@ -272,12 +334,17 @@ export function SelectionBar({
                   >
                     {avatarInitials(m.name)}
                   </div>
-                  {m.name}
-                </Group>
+                }
+                onClick={() => onBulkAssign(m.id)}
+              >
+                {m.name}
               </Menu.Item>
             ))}
             <Menu.Divider />
-            <Menu.Item leftSection={<IconUser size={13} />} onClick={() => onBulkAssign(null)}>
+            <Menu.Item
+              leftSection={<IconUserOff size={13} color="var(--mantine-color-dimmed)" />}
+              onClick={() => onBulkAssign(null)}
+            >
               Unassign
             </Menu.Item>
           </Menu.Dropdown>
@@ -300,7 +367,7 @@ export function SelectionBar({
         Archive
       </Button>
 
-      {/* Delete */}
+      {/* Delete — matches .btn.danger */}
       <Button
         size="xs"
         variant="default"
@@ -314,14 +381,14 @@ export function SelectionBar({
       {/* Spacer */}
       <div style={{ flex: 1 }} />
 
-      {/* Cancel */}
+      {/* Cancel — matches .sb-cancel */}
       <Button
         size="xs"
-        variant="subtle"
+        variant="default"
         leftSection={<IconX size={12} />}
-        color="gray"
-        onClick={onClear}
+        styles={btnStyle}
         aria-label="Clear selection"
+        onClick={onClear}
       >
         Cancel
       </Button>

--- a/app/frontend/pages/Projects/Board/SelectionBar.tsx
+++ b/app/frontend/pages/Projects/Board/SelectionBar.tsx
@@ -73,7 +73,8 @@ export function SelectionBar({ selectedCount, columns, canExecute, onAction, onC
     });
   };
 
-  const lastColumn = [...columns].sort((a, b) => 0)[columns.length - 1];
+  // "Move to Done" targets the last column by position (the rightmost column on the board).
+  const lastColumn = columns.length > 0 ? columns[columns.length - 1] : undefined;
 
   return (
     <Paper

--- a/app/frontend/pages/Projects/Board/SelectionBar.tsx
+++ b/app/frontend/pages/Projects/Board/SelectionBar.tsx
@@ -1,8 +1,8 @@
 import { ActionIcon, Alert, Badge, Button, Group, Menu, Paper, Stack, Text } from '@mantine/core';
 import { modals } from '@mantine/modals';
-import { IconAlertTriangle, IconArchive, IconCircleCheck, IconTrash, IconX } from '@tabler/icons-react';
+import { IconAlertTriangle, IconArchive, IconTrash, IconX } from '@tabler/icons-react';
 
-export type BulkAction = 'delete' | 'archive' | 'move_to_done' | 'move_to_column';
+export type BulkAction = 'delete' | 'archive' | 'move_to_column';
 
 interface BulkColumn {
   id: number;
@@ -24,8 +24,6 @@ function actionTitle(action: BulkAction): string {
       return 'Delete tasks';
     case 'archive':
       return 'Archive tasks';
-    case 'move_to_done':
-      return 'Move to Done';
     case 'move_to_column':
       return 'Move to column';
   }
@@ -37,8 +35,6 @@ function actionMessage(action: BulkAction, count: number): string {
       return `Delete ${count} task${count === 1 ? '' : 's'}? This cannot be undone.`;
     case 'archive':
       return `Archive ${count} task${count === 1 ? '' : 's'}?`;
-    case 'move_to_done':
-      return `Move ${count} task${count === 1 ? '' : 's'} to the Done column?`;
     case 'move_to_column':
       return `Move ${count} task${count === 1 ? '' : 's'} to this column?`;
   }
@@ -50,8 +46,6 @@ function actionLabel(action: BulkAction): string {
       return 'Delete';
     case 'archive':
       return 'Archive';
-    case 'move_to_done':
-      return 'Move to Done';
     case 'move_to_column':
       return 'Move';
   }
@@ -84,9 +78,6 @@ export function SelectionBar({ selectedCount, columns, canExecute, onAction, onC
       onConfirm: () => onAction(action, targetColumn?.id),
     });
   };
-
-  // "Move to Done" targets the last column by position (the rightmost column on the board).
-  const lastColumn = columns.length > 0 ? columns[columns.length - 1] : undefined;
 
   return (
     <Paper
@@ -136,16 +127,6 @@ export function SelectionBar({ selectedCount, columns, canExecute, onAction, onC
           onClick={() => confirmBulkAction('archive')}
         >
           Archive
-        </Button>
-
-        <Button
-          size="compact-sm"
-          variant="light"
-          color="green"
-          leftSection={<IconCircleCheck size={13} />}
-          onClick={() => confirmBulkAction('move_to_done', lastColumn)}
-        >
-          Move to Done
         </Button>
 
         <Menu shadow="md" position="top-end" withinPortal>

--- a/app/frontend/pages/Projects/Board/SelectionBar.tsx
+++ b/app/frontend/pages/Projects/Board/SelectionBar.tsx
@@ -20,28 +20,40 @@ interface SelectionBarProps {
 
 function actionTitle(action: BulkAction): string {
   switch (action) {
-    case 'delete': return 'Delete tasks';
-    case 'archive': return 'Archive tasks';
-    case 'move_to_done': return 'Move to Done';
-    case 'move_to_column': return 'Move to column';
+    case 'delete':
+      return 'Delete tasks';
+    case 'archive':
+      return 'Archive tasks';
+    case 'move_to_done':
+      return 'Move to Done';
+    case 'move_to_column':
+      return 'Move to column';
   }
 }
 
 function actionMessage(action: BulkAction, count: number): string {
   switch (action) {
-    case 'delete': return `Delete ${count} task${count === 1 ? '' : 's'}? This cannot be undone.`;
-    case 'archive': return `Archive ${count} task${count === 1 ? '' : 's'}?`;
-    case 'move_to_done': return `Move ${count} task${count === 1 ? '' : 's'} to the Done column?`;
-    case 'move_to_column': return `Move ${count} task${count === 1 ? '' : 's'} to this column?`;
+    case 'delete':
+      return `Delete ${count} task${count === 1 ? '' : 's'}? This cannot be undone.`;
+    case 'archive':
+      return `Archive ${count} task${count === 1 ? '' : 's'}?`;
+    case 'move_to_done':
+      return `Move ${count} task${count === 1 ? '' : 's'} to the Done column?`;
+    case 'move_to_column':
+      return `Move ${count} task${count === 1 ? '' : 's'} to this column?`;
   }
 }
 
 function actionLabel(action: BulkAction): string {
   switch (action) {
-    case 'delete': return 'Delete';
-    case 'archive': return 'Archive';
-    case 'move_to_done': return 'Move to Done';
-    case 'move_to_column': return 'Move';
+    case 'delete':
+      return 'Delete';
+    case 'archive':
+      return 'Archive';
+    case 'move_to_done':
+      return 'Move to Done';
+    case 'move_to_column':
+      return 'Move';
   }
 }
 
@@ -100,13 +112,7 @@ export function SelectionBar({ selectedCount, columns, canExecute, onAction, onC
         <Badge size="sm" variant="filled" color="blue">
           {selectedCount} selected
         </Badge>
-        <ActionIcon
-          size="xs"
-          variant="subtle"
-          color="gray"
-          aria-label="Clear selection"
-          onClick={onClear}
-        >
+        <ActionIcon size="xs" variant="subtle" color="gray" aria-label="Clear selection" onClick={onClear}>
           <IconX size={12} />
         </ActionIcon>
       </Group>

--- a/app/frontend/pages/Projects/Board/SelectionBar.tsx
+++ b/app/frontend/pages/Projects/Board/SelectionBar.tsx
@@ -1,0 +1,161 @@
+import { ActionIcon, Alert, Badge, Button, Group, Menu, Paper, Stack, Text } from '@mantine/core';
+import { modals } from '@mantine/modals';
+import { IconAlertTriangle, IconArchive, IconCircleCheck, IconTrash, IconX } from '@tabler/icons-react';
+
+export type BulkAction = 'delete' | 'archive' | 'move_to_done' | 'move_to_column';
+
+interface BulkColumn {
+  id: number;
+  name: string;
+  workflowBinding: { triggerMode: string } | null;
+}
+
+interface SelectionBarProps {
+  selectedCount: number;
+  columns: BulkColumn[];
+  canExecute: boolean;
+  onAction: (action: BulkAction, columnId?: number) => void;
+  onClear: () => void;
+}
+
+function actionTitle(action: BulkAction): string {
+  switch (action) {
+    case 'delete': return 'Delete tasks';
+    case 'archive': return 'Archive tasks';
+    case 'move_to_done': return 'Move to Done';
+    case 'move_to_column': return 'Move to column';
+  }
+}
+
+function actionMessage(action: BulkAction, count: number): string {
+  switch (action) {
+    case 'delete': return `Delete ${count} task${count === 1 ? '' : 's'}? This cannot be undone.`;
+    case 'archive': return `Archive ${count} task${count === 1 ? '' : 's'}?`;
+    case 'move_to_done': return `Move ${count} task${count === 1 ? '' : 's'} to the Done column?`;
+    case 'move_to_column': return `Move ${count} task${count === 1 ? '' : 's'} to this column?`;
+  }
+}
+
+function actionLabel(action: BulkAction): string {
+  switch (action) {
+    case 'delete': return 'Delete';
+    case 'archive': return 'Archive';
+    case 'move_to_done': return 'Move to Done';
+    case 'move_to_column': return 'Move';
+  }
+}
+
+function isDestructive(action: BulkAction): boolean {
+  return action === 'delete';
+}
+
+export function SelectionBar({ selectedCount, columns, canExecute, onAction, onClear }: SelectionBarProps) {
+  if (!canExecute || selectedCount === 0) return null;
+
+  const confirmBulkAction = (action: BulkAction, targetColumn?: BulkColumn) => {
+    const triggersWorkflow = targetColumn?.workflowBinding?.triggerMode === 'auto';
+
+    modals.openConfirmModal({
+      title: actionTitle(action),
+      children: (
+        <Stack gap="xs">
+          <Text size="sm">{actionMessage(action, selectedCount)}</Text>
+          {triggersWorkflow && (
+            <Alert color="yellow" icon={<IconAlertTriangle size={16} />}>
+              This will start {selectedCount} agent run{selectedCount > 1 ? 's' : ''}.
+            </Alert>
+          )}
+        </Stack>
+      ),
+      labels: { confirm: actionLabel(action), cancel: 'Cancel' },
+      confirmProps: { color: isDestructive(action) ? 'red' : 'blue' },
+      onConfirm: () => onAction(action, targetColumn?.id),
+    });
+  };
+
+  const lastColumn = [...columns].sort((a, b) => 0)[columns.length - 1];
+
+  return (
+    <Paper
+      withBorder
+      shadow="md"
+      style={{
+        position: 'fixed',
+        bottom: 24,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 200,
+        padding: '10px 16px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        backgroundColor: 'var(--app-bg-elevated)',
+        borderColor: 'var(--app-border-strong)',
+        borderRadius: 10,
+        minWidth: 420,
+      }}
+    >
+      <Group gap={6} style={{ flex: 1 }}>
+        <Badge size="sm" variant="filled" color="blue">
+          {selectedCount} selected
+        </Badge>
+        <ActionIcon
+          size="xs"
+          variant="subtle"
+          color="gray"
+          aria-label="Clear selection"
+          onClick={onClear}
+        >
+          <IconX size={12} />
+        </ActionIcon>
+      </Group>
+
+      <Group gap={8}>
+        <Button
+          size="compact-sm"
+          variant="light"
+          color="red"
+          leftSection={<IconTrash size={13} />}
+          onClick={() => confirmBulkAction('delete')}
+        >
+          Delete
+        </Button>
+
+        <Button
+          size="compact-sm"
+          variant="light"
+          color="gray"
+          leftSection={<IconArchive size={13} />}
+          onClick={() => confirmBulkAction('archive')}
+        >
+          Archive
+        </Button>
+
+        <Button
+          size="compact-sm"
+          variant="light"
+          color="green"
+          leftSection={<IconCircleCheck size={13} />}
+          onClick={() => confirmBulkAction('move_to_done', lastColumn)}
+        >
+          Move to Done
+        </Button>
+
+        <Menu shadow="md" position="top-end" withinPortal>
+          <Menu.Target>
+            <Button size="compact-sm" variant="light" color="blue">
+              Move to column
+            </Button>
+          </Menu.Target>
+          <Menu.Dropdown>
+            {columns.map((col) => (
+              <Menu.Item key={col.id} onClick={() => confirmBulkAction('move_to_column', col)}>
+                {col.name}
+              </Menu.Item>
+            ))}
+          </Menu.Dropdown>
+        </Menu>
+      </Group>
+    </Paper>
+  );
+}

--- a/app/frontend/pages/Projects/Board/SelectionBar.tsx
+++ b/app/frontend/pages/Projects/Board/SelectionBar.tsx
@@ -1,8 +1,17 @@
-import { ActionIcon, Alert, Badge, Button, Group, Menu, Paper, Stack, Text } from '@mantine/core';
+import { Alert, Button, Group, Menu, Stack, Text, TextInput } from '@mantine/core';
 import { modals } from '@mantine/modals';
-import { IconAlertTriangle, IconArchive, IconTrash, IconX } from '@tabler/icons-react';
+import {
+  IconAlertTriangle,
+  IconArchive,
+  IconChevronDown,
+  IconFlag,
+  IconTag,
+  IconTrash,
+  IconUser,
+  IconX,
+} from '@tabler/icons-react';
 
-export type BulkAction = 'delete' | 'archive' | 'move_to_column';
+export type BulkAction = 'delete' | 'archive' | 'move_to_column' | 'set_priority' | 'set_assignee' | 'add_tag';
 
 interface BulkColumn {
   id: number;
@@ -10,62 +19,77 @@ interface BulkColumn {
   workflowBinding: { triggerMode: string } | null;
 }
 
-interface SelectionBarProps {
+interface Member {
+  id: number;
+  name: string;
+}
+
+export interface SelectionBarProps {
   selectedCount: number;
+  selectedIds: Set<number>;
   columns: BulkColumn[];
+  members: Member[];
   canExecute: boolean;
   onAction: (action: BulkAction, columnId?: number) => void;
+  onBulkPriority: (priority: string | null) => void;
+  onBulkAssign: (assigneeId: number | null) => void;
+  onBulkTag: (tag: string) => void;
   onClear: () => void;
 }
 
-function actionTitle(action: BulkAction): string {
-  switch (action) {
-    case 'delete':
-      return 'Delete tasks';
-    case 'archive':
-      return 'Archive tasks';
-    case 'move_to_column':
-      return 'Move to column';
-  }
+const PRIORITY_OPTIONS: { value: string | null; label: string }[] = [
+  { value: 'high', label: 'High' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'low', label: 'Low' },
+  { value: null, label: 'None' },
+];
+
+function avatarInitials(name: string) {
+  return name
+    .split(' ')
+    .map((p) => p[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
 }
 
-function actionMessage(action: BulkAction, count: number): string {
-  switch (action) {
-    case 'delete':
-      return `Delete ${count} task${count === 1 ? '' : 's'}? This cannot be undone.`;
-    case 'archive':
-      return `Archive ${count} task${count === 1 ? '' : 's'}?`;
-    case 'move_to_column':
-      return `Move ${count} task${count === 1 ? '' : 's'} to this column?`;
-  }
-}
-
-function actionLabel(action: BulkAction): string {
-  switch (action) {
-    case 'delete':
-      return 'Delete';
-    case 'archive':
-      return 'Archive';
-    case 'move_to_column':
-      return 'Move';
-  }
-}
-
-function isDestructive(action: BulkAction): boolean {
-  return action === 'delete';
-}
-
-export function SelectionBar({ selectedCount, columns, canExecute, onAction, onClear }: SelectionBarProps) {
+export function SelectionBar({
+  selectedCount,
+  columns,
+  members,
+  canExecute,
+  onAction,
+  onBulkPriority,
+  onBulkAssign,
+  onBulkTag,
+  onClear,
+}: SelectionBarProps) {
   if (!canExecute || selectedCount === 0) return null;
 
-  const confirmBulkAction = (action: BulkAction, targetColumn?: BulkColumn) => {
-    const triggersWorkflow = targetColumn?.workflowBinding?.triggerMode === 'auto';
-
+  const confirmDestructive = (action: 'delete' | 'archive') => {
+    const isDelete = action === 'delete';
     modals.openConfirmModal({
-      title: actionTitle(action),
+      title: isDelete ? 'Delete tasks' : 'Archive tasks',
+      children: (
+        <Text size="sm">
+          {isDelete
+            ? `Delete ${selectedCount} task${selectedCount === 1 ? '' : 's'}? This cannot be undone.`
+            : `Archive ${selectedCount} task${selectedCount === 1 ? '' : 's'}?`}
+        </Text>
+      ),
+      labels: { confirm: isDelete ? 'Delete' : 'Archive', cancel: 'Cancel' },
+      confirmProps: { color: isDelete ? 'red' : 'blue' },
+      onConfirm: () => onAction(action),
+    });
+  };
+
+  const confirmMoveToColumn = (col: BulkColumn) => {
+    const triggersWorkflow = col.workflowBinding?.triggerMode === 'auto';
+    modals.openConfirmModal({
+      title: 'Move to column',
       children: (
         <Stack gap="xs">
-          <Text size="sm">{actionMessage(action, selectedCount)}</Text>
+          <Text size="sm">{`Move ${selectedCount} task${selectedCount === 1 ? '' : 's'} to "${col.name}"?`}</Text>
           {triggersWorkflow && (
             <Alert color="yellow" icon={<IconAlertTriangle size={16} />}>
               This will start {selectedCount} agent run{selectedCount > 1 ? 's' : ''}.
@@ -73,77 +97,234 @@ export function SelectionBar({ selectedCount, columns, canExecute, onAction, onC
           )}
         </Stack>
       ),
-      labels: { confirm: actionLabel(action), cancel: 'Cancel' },
-      confirmProps: { color: isDestructive(action) ? 'red' : 'blue' },
-      onConfirm: () => onAction(action, targetColumn?.id),
+      labels: { confirm: 'Move', cancel: 'Cancel' },
+      confirmProps: { color: 'blue' },
+      onConfirm: () => onAction('move_to_column', col.id),
     });
   };
 
+  const openTagPrompt = () => {
+    let tagValue = '';
+    modals.open({
+      title: 'Add tag',
+      children: (
+        <Stack gap="sm">
+          <TextInput
+            label="Tag name"
+            placeholder="e.g. needs-review"
+            autoFocus
+            onChange={(e) => {
+              tagValue = e.currentTarget.value;
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                const trimmed = tagValue.trim();
+                if (trimmed) {
+                  onBulkTag(trimmed);
+                  modals.closeAll();
+                }
+              }
+            }}
+          />
+          <Group justify="flex-end">
+            <Button variant="default" size="xs" onClick={() => modals.closeAll()}>
+              Cancel
+            </Button>
+            <Button
+              size="xs"
+              onClick={() => {
+                const trimmed = tagValue.trim();
+                if (trimmed) {
+                  onBulkTag(trimmed);
+                  modals.closeAll();
+                }
+              }}
+            >
+              Add tag
+            </Button>
+          </Group>
+        </Stack>
+      ),
+    });
+  };
+
+  const btnStyle = {
+    root: {
+      height: 32,
+      padding: '0 10px',
+      fontSize: 12,
+      fontWeight: 500,
+      color: 'var(--app-text-secondary)',
+      border: '1px solid var(--app-border-default)',
+      borderRadius: 5,
+      backgroundColor: 'transparent',
+    },
+  };
+
+  const dangerBtnStyle = {
+    root: {
+      ...btnStyle.root,
+      color: 'var(--mantine-color-red-6)',
+    },
+  };
+
   return (
-    <Paper
-      withBorder
-      shadow="md"
-      style={{
-        position: 'fixed',
-        bottom: 24,
-        left: '50%',
-        transform: 'translateX(-50%)',
-        zIndex: 200,
-        padding: '10px 16px',
-        display: 'flex',
-        alignItems: 'center',
-        gap: 12,
-        backgroundColor: 'var(--app-bg-elevated)',
-        borderColor: 'var(--app-border-strong)',
-        borderRadius: 10,
-        minWidth: 420,
-      }}
-    >
-      <Group gap={6} style={{ flex: 1 }}>
-        <Badge size="sm" variant="filled" color="blue">
+    <Group gap={8} mb="sm" wrap="nowrap" align="center" style={{ flexShrink: 0 }}>
+      {/* Count badge */}
+      <Group
+        gap={6}
+        align="center"
+        style={{
+          height: 32,
+          padding: '0 12px',
+          borderRadius: 6,
+          backgroundColor: 'color-mix(in srgb, var(--mantine-color-brand-6) 12%, transparent)',
+          border: '1px solid color-mix(in srgb, var(--mantine-color-brand-6) 30%, transparent)',
+          flexShrink: 0,
+        }}
+      >
+        <Text size="xs" fw={600} c="brand">
           {selectedCount} selected
-        </Badge>
-        <ActionIcon size="xs" variant="subtle" color="gray" aria-label="Clear selection" onClick={onClear}>
-          <IconX size={12} />
-        </ActionIcon>
+        </Text>
       </Group>
 
-      <Group gap={8}>
-        <Button
-          size="compact-sm"
-          variant="light"
-          color="red"
-          leftSection={<IconTrash size={13} />}
-          onClick={() => confirmBulkAction('delete')}
-        >
-          Delete
-        </Button>
+      {/* Separator */}
+      <div style={{ width: 1, height: 20, backgroundColor: 'var(--app-border-default)', flexShrink: 0 }} />
 
-        <Button
-          size="compact-sm"
-          variant="light"
-          color="gray"
-          leftSection={<IconArchive size={13} />}
-          onClick={() => confirmBulkAction('archive')}
-        >
-          Archive
-        </Button>
+      {/* Move to → */}
+      <Menu shadow="md" position="bottom-start" withinPortal>
+        <Menu.Target>
+          <Button size="xs" variant="default" rightSection={<IconChevronDown size={11} />} styles={btnStyle}>
+            Move to
+          </Button>
+        </Menu.Target>
+        <Menu.Dropdown>
+          {columns.map((col) => (
+            <Menu.Item key={col.id} onClick={() => confirmMoveToColumn(col)}>
+              {col.name}
+              {col.workflowBinding?.triggerMode === 'auto' && (
+                <Text span size="xs" c="brand" fw={600} ml={8}>
+                  Runs
+                </Text>
+              )}
+            </Menu.Item>
+          ))}
+        </Menu.Dropdown>
+      </Menu>
 
-        <Menu shadow="md" position="top-end" withinPortal>
+      {/* Priority */}
+      <Menu shadow="md" position="bottom-start" withinPortal>
+        <Menu.Target>
+          <Button
+            size="xs"
+            variant="default"
+            leftSection={<IconFlag size={12} />}
+            rightSection={<IconChevronDown size={11} />}
+            styles={btnStyle}
+          >
+            Priority
+          </Button>
+        </Menu.Target>
+        <Menu.Dropdown>
+          <Menu.Label>Set priority</Menu.Label>
+          {PRIORITY_OPTIONS.map(({ value, label }) => (
+            <Menu.Item key={label} leftSection={<IconFlag size={13} />} onClick={() => onBulkPriority(value)}>
+              {label}
+            </Menu.Item>
+          ))}
+        </Menu.Dropdown>
+      </Menu>
+
+      {/* Assign */}
+      {members.length > 0 && (
+        <Menu shadow="md" position="bottom-start" withinPortal>
           <Menu.Target>
-            <Button size="compact-sm" variant="light" color="blue">
-              Move to column
+            <Button
+              size="xs"
+              variant="default"
+              leftSection={<IconUser size={12} />}
+              rightSection={<IconChevronDown size={11} />}
+              styles={btnStyle}
+            >
+              Assign
             </Button>
           </Menu.Target>
           <Menu.Dropdown>
-            {columns.map((col) => (
-              <Menu.Item key={col.id} onClick={() => confirmBulkAction('move_to_column', col)}>
-                {col.name}
+            <Menu.Label>Assign to</Menu.Label>
+            {members.map((m) => (
+              <Menu.Item key={m.id} onClick={() => onBulkAssign(m.id)}>
+                <Group gap={8} align="center">
+                  <div
+                    style={{
+                      width: 20,
+                      height: 20,
+                      borderRadius: '50%',
+                      backgroundColor: 'color-mix(in srgb, var(--mantine-color-brand-6) 12%, transparent)',
+                      border: '1px solid color-mix(in srgb, var(--mantine-color-brand-6) 30%, transparent)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      fontSize: 9,
+                      fontWeight: 700,
+                      color: 'var(--mantine-color-brand-6)',
+                      flexShrink: 0,
+                    }}
+                  >
+                    {avatarInitials(m.name)}
+                  </div>
+                  {m.name}
+                </Group>
               </Menu.Item>
             ))}
+            <Menu.Divider />
+            <Menu.Item leftSection={<IconUser size={13} />} onClick={() => onBulkAssign(null)}>
+              Unassign
+            </Menu.Item>
           </Menu.Dropdown>
         </Menu>
-      </Group>
-    </Paper>
+      )}
+
+      {/* Add tag */}
+      <Button size="xs" variant="default" leftSection={<IconTag size={12} />} styles={btnStyle} onClick={openTagPrompt}>
+        Add tag
+      </Button>
+
+      {/* Archive */}
+      <Button
+        size="xs"
+        variant="default"
+        leftSection={<IconArchive size={12} />}
+        styles={btnStyle}
+        onClick={() => confirmDestructive('archive')}
+      >
+        Archive
+      </Button>
+
+      {/* Delete */}
+      <Button
+        size="xs"
+        variant="default"
+        leftSection={<IconTrash size={12} />}
+        styles={dangerBtnStyle}
+        onClick={() => confirmDestructive('delete')}
+      >
+        Delete
+      </Button>
+
+      {/* Spacer */}
+      <div style={{ flex: 1 }} />
+
+      {/* Cancel */}
+      <Button
+        size="xs"
+        variant="subtle"
+        leftSection={<IconX size={12} />}
+        color="gray"
+        onClick={onClear}
+        aria-label="Clear selection"
+      >
+        Cancel
+      </Button>
+    </Group>
   );
 }

--- a/app/frontend/pages/Projects/Board/useBulkActions.ts
+++ b/app/frontend/pages/Projects/Board/useBulkActions.ts
@@ -18,8 +18,6 @@ function actionLabel(action: BulkAction): string {
       return 'Deleted';
     case 'archive':
       return 'Archived';
-    case 'move_to_done':
-      return 'Moved';
     case 'move_to_column':
       return 'Moved';
   }

--- a/app/frontend/pages/Projects/Board/useBulkActions.ts
+++ b/app/frontend/pages/Projects/Board/useBulkActions.ts
@@ -1,0 +1,82 @@
+import { router } from '@inertiajs/react';
+import { notifications } from '@mantine/notifications';
+import { useCallback } from 'react';
+
+import { apiFetch } from 'shared/lib/apiFetch';
+import { bulkActionsApiV1ProjectTasksPath } from 'shared/routes';
+
+import type { BulkAction } from './SelectionBar';
+
+interface BulkActionResult {
+  succeeded: number[];
+  skipped: Array<{ task_id: number; reason: string }>;
+}
+
+function actionLabel(action: BulkAction): string {
+  switch (action) {
+    case 'delete': return 'Deleted';
+    case 'archive': return 'Archived';
+    case 'move_to_done': return 'Moved';
+    case 'move_to_column': return 'Moved';
+  }
+}
+
+interface UseBulkActionsOptions {
+  projectId: number;
+  onSuccess: () => void;
+}
+
+export function useBulkActions({ projectId, onSuccess }: UseBulkActionsOptions) {
+  const execute = useCallback(
+    async (action: BulkAction, taskIds: number[], columnId?: number) => {
+      try {
+        const res = await apiFetch(bulkActionsApiV1ProjectTasksPath(projectId), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action_type: action,
+            task_ids: taskIds,
+            column_id: columnId,
+          }),
+        });
+
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          notifications.show({
+            color: 'red',
+            title: 'Bulk action failed',
+            message: (err as { errors?: string[] }).errors?.[0] ?? 'An error occurred.',
+          });
+          return;
+        }
+
+        const data: BulkActionResult = await res.json();
+        const total = data.succeeded.length + data.skipped.length;
+
+        if (data.skipped.length > 0) {
+          notifications.show({
+            color: 'yellow',
+            title: 'Partial success',
+            message: `${actionLabel(action)} ${data.succeeded.length} of ${total} task${total === 1 ? '' : 's'}. ${data.skipped.length} skipped (active agent run).`,
+          });
+        } else {
+          notifications.show({
+            color: 'green',
+            message: `${actionLabel(action)} ${data.succeeded.length} task${data.succeeded.length === 1 ? '' : 's'}.`,
+          });
+        }
+
+        onSuccess();
+        router.reload({ only: ['tasks'] });
+      } catch {
+        notifications.show({
+          color: 'red',
+          message: 'Bulk action failed. Please try again.',
+        });
+      }
+    },
+    [projectId, onSuccess],
+  );
+
+  return { execute };
+}

--- a/app/frontend/pages/Projects/Board/useBulkActions.ts
+++ b/app/frontend/pages/Projects/Board/useBulkActions.ts
@@ -14,10 +14,14 @@ interface BulkActionResult {
 
 function actionLabel(action: BulkAction): string {
   switch (action) {
-    case 'delete': return 'Deleted';
-    case 'archive': return 'Archived';
-    case 'move_to_done': return 'Moved';
-    case 'move_to_column': return 'Moved';
+    case 'delete':
+      return 'Deleted';
+    case 'archive':
+      return 'Archived';
+    case 'move_to_done':
+      return 'Moved';
+    case 'move_to_column':
+      return 'Moved';
   }
 }
 

--- a/app/frontend/pages/Projects/Board/useBulkActions.ts
+++ b/app/frontend/pages/Projects/Board/useBulkActions.ts
@@ -3,7 +3,7 @@ import { notifications } from '@mantine/notifications';
 import { useCallback } from 'react';
 
 import { apiFetch } from 'shared/lib/apiFetch';
-import { bulkActionsApiV1ProjectTasksPath } from 'shared/routes';
+import { apiV1ProjectTaskPath, bulkActionsApiV1ProjectTasksPath } from 'shared/routes';
 
 import type { BulkAction } from './SelectionBar';
 
@@ -20,6 +20,12 @@ function actionLabel(action: BulkAction): string {
       return 'Archived';
     case 'move_to_column':
       return 'Moved';
+    case 'set_priority':
+      return 'Updated priority for';
+    case 'set_assignee':
+      return 'Updated assignee for';
+    case 'add_tag':
+      return 'Tagged';
   }
 }
 
@@ -80,5 +86,107 @@ export function useBulkActions({ projectId, onSuccess }: UseBulkActionsOptions) 
     [projectId, onSuccess],
   );
 
-  return { execute };
+  // Bulk set priority: calls single-task PATCH for each selected task
+  const bulkSetPriority = useCallback(
+    async (taskIds: number[], priority: string | null) => {
+      try {
+        await Promise.all(
+          taskIds.map((id) =>
+            apiFetch(apiV1ProjectTaskPath(projectId, id), {
+              method: 'PATCH',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ board_task: { priority } }),
+            }),
+          ),
+        );
+
+        notifications.show({
+          color: 'green',
+          message: `Updated priority for ${taskIds.length} task${taskIds.length === 1 ? '' : 's'}.`,
+        });
+
+        router.reload({ only: ['tasks'] });
+      } catch {
+        notifications.show({
+          color: 'red',
+          message: 'Failed to update priority. Please try again.',
+        });
+      }
+    },
+    [projectId],
+  );
+
+  // Bulk assign: calls single-task PATCH for each selected task
+  const bulkAssign = useCallback(
+    async (taskIds: number[], assigneeId: number | null) => {
+      try {
+        await Promise.all(
+          taskIds.map((id) =>
+            apiFetch(apiV1ProjectTaskPath(projectId, id), {
+              method: 'PATCH',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ board_task: { assignee_id: assigneeId } }),
+            }),
+          ),
+        );
+
+        notifications.show({
+          color: 'green',
+          message: `Updated assignee for ${taskIds.length} task${taskIds.length === 1 ? '' : 's'}.`,
+        });
+
+        router.reload({ only: ['tasks'] });
+      } catch {
+        notifications.show({
+          color: 'red',
+          message: 'Failed to update assignee. Please try again.',
+        });
+      }
+    },
+    [projectId],
+  );
+
+  // Bulk add tag: calls bulk_actions endpoint with add_tag action
+  const bulkAddTag = useCallback(
+    async (taskIds: number[], tag: string) => {
+      try {
+        const res = await apiFetch(bulkActionsApiV1ProjectTasksPath(projectId), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action_type: 'add_tag',
+            task_ids: taskIds,
+            tag,
+          }),
+        });
+
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          notifications.show({
+            color: 'red',
+            title: 'Bulk action failed',
+            message: (err as { errors?: string[] }).errors?.[0] ?? 'An error occurred.',
+          });
+          return;
+        }
+
+        const data: BulkActionResult = await res.json();
+
+        notifications.show({
+          color: 'green',
+          message: `Tagged ${data.succeeded.length} task${data.succeeded.length === 1 ? '' : 's'}.`,
+        });
+
+        router.reload({ only: ['tasks'] });
+      } catch {
+        notifications.show({
+          color: 'red',
+          message: 'Failed to add tag. Please try again.',
+        });
+      }
+    },
+    [projectId],
+  );
+
+  return { execute, bulkSetPriority, bulkAssign, bulkAddTag };
 }

--- a/app/frontend/shared/routes.ts
+++ b/app/frontend/shared/routes.ts
@@ -377,6 +377,11 @@ export function apiV1ProjectTasksPath(project_id: ScalarType, options?: object):
   return "/" + "api" + "/" + "v1" + "/" + "projects" + "/" + project_id + "/" + "tasks" + ($hasPresentOwnProperty(options, "format") ? "." + (options as any).format : "") + $buildOptions(options, ["project_id","format"]);
 }
 
+/** /api/v1/projects/:project_id/tasks/bulk_actions(.:format) */
+export function bulkActionsApiV1ProjectTasksPath(project_id: ScalarType, options?: object): string {
+  return "/" + "api" + "/" + "v1" + "/" + "projects" + "/" + project_id + "/" + "tasks" + "/" + "bulk_actions" + ($hasPresentOwnProperty(options, "format") ? "." + (options as any).format : "") + $buildOptions(options, ["project_id","format"]);
+}
+
 /** /api/v1/projects/:project_id/tasks/new(.:format) */
 export function newApiV1ProjectTaskPath(project_id: ScalarType, options?: object): string {
   return "/" + "api" + "/" + "v1" + "/" + "projects" + "/" + project_id + "/" + "tasks" + "/" + "new" + ($hasPresentOwnProperty(options, "format") ? "." + (options as any).format : "") + $buildOptions(options, ["project_id","format"]);

--- a/app/policies/api/v1/projects/board/tasks_policy.rb
+++ b/app/policies/api/v1/projects/board/tasks_policy.rb
@@ -15,6 +15,7 @@ module Api
           def archive? = project_writable?
           def unarchive? = project_writable?
           def trigger_workflow? = project_writable?
+          def bulk_actions? = project_writable?
         end
       end
     end

--- a/app/services/task_service.rb
+++ b/app/services/task_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TaskService
-  BULK_ACTIONS = %i[delete archive move_to_done move_to_column].freeze
+  BULK_ACTIONS = %i[delete archive move_to_column].freeze
 
   class << self
     def create(board:, params:, actor:)
@@ -128,8 +128,7 @@ class TaskService
         case action
         when :delete        then destroy(task: task, actor: actor)
         when :archive       then archive(task: task, actor: actor)
-        when :move_to_done,
-             :move_to_column then move(task: task, to_column: to_column, actor: actor)
+        when :move_to_column then move(task: task, to_column: to_column, actor: actor)
         end
 
         succeeded << task.id

--- a/app/services/task_service.rb
+++ b/app/services/task_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TaskService
-  BULK_ACTIONS = %i[delete archive move_to_column].freeze
+  BULK_ACTIONS = %i[delete archive move_to_column set_priority set_assignee add_tag].freeze
 
   class << self
     def create(board:, params:, actor:)
@@ -115,7 +115,7 @@ class TaskService
       task.reload
     end
 
-    def bulk_action(action:, tasks:, actor:, to_column: nil)
+    def bulk_action(action:, tasks:, actor:, to_column: nil, extra_params: {})
       succeeded = []
       skipped   = []
 
@@ -129,6 +129,9 @@ class TaskService
         when :delete        then destroy(task: task, actor: actor)
         when :archive       then archive(task: task, actor: actor)
         when :move_to_column then move(task: task, to_column: to_column, actor: actor)
+        when :set_priority  then task.update!(priority: extra_params[:priority])
+        when :set_assignee  then task.update!(assignee_id: extra_params[:assignee_id])
+        when :add_tag       then task.update!(tags: (task.tags + [ extra_params[:tag] ]).uniq)
         end
 
         succeeded << task.id

--- a/app/services/task_service.rb
+++ b/app/services/task_service.rb
@@ -113,6 +113,34 @@ class TaskService
       task.reload
     end
 
+    BULK_ACTIONS = %i[delete archive move_to_done move_to_column].freeze
+
+    def bulk_action(action:, tasks:, actor:, to_column: nil)
+      succeeded = []
+      skipped   = []
+
+      tasks.each do |task|
+        if task.workflow_runs.where(state: %w[pending running paused]).exists?
+          skipped << { task_id: task.id, reason: "active_run" }
+          next
+        end
+
+        case action
+        when :delete        then destroy(task: task, actor: actor)
+        when :archive       then archive(task: task, actor: actor)
+        when :move_to_done,
+             :move_to_column then move(task: task, to_column: to_column, actor: actor)
+        end
+
+        succeeded << task.id
+      rescue => e
+        Rails.logger.warn("[TaskService] bulk_action #{action} failed for task #{task.id}: #{e.message}")
+        skipped << { task_id: task.id, reason: "error" }
+      end
+
+      { succeeded: succeeded, skipped: skipped }
+    end
+
     def add_comment(task:, params:, actor:)
       comment = task.task_comments.build(params)
       comment.author = actor

--- a/app/services/task_service.rb
+++ b/app/services/task_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TaskService
+  BULK_ACTIONS = %i[delete archive move_to_done move_to_column].freeze
+
   class << self
     def create(board:, params:, actor:)
       task = board.board_tasks.build(params)
@@ -112,8 +114,6 @@ class TaskService
 
       task.reload
     end
-
-    BULK_ACTIONS = %i[delete archive move_to_done move_to_column].freeze
 
     def bulk_action(action:, tasks:, actor:, to_column: nil)
       succeeded = []

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,9 @@ Rails.application.routes.draw do
             end
             resources :activities, only: %i[index]
             resources :tasks do
+              collection do
+                post :bulk_actions
+              end
               member do
                 patch :move
                 patch :archive

--- a/test/controllers/api/v1/projects/board/tasks_controller_test.rb
+++ b/test/controllers/api/v1/projects/board/tasks_controller_test.rb
@@ -303,6 +303,87 @@ module Api
           assert_equal @col2.id, @task.reload.board_column_id
         end
 
+        # === bulk_actions ===
+
+        test "bulk_actions deletes all tasks when none have active runs" do
+          t2 = create(:board_task, board: @board, board_column: @col1)
+
+          post :bulk_actions, params: {
+            project_id: @project.id,
+            action_type: "delete",
+            task_ids: [ @task.id, t2.id ]
+          }, as: :json
+
+          assert_response :success
+          body = JSON.parse(response.body)
+          assert_equal [ @task.id, t2.id ].sort, body["succeeded"].sort
+          assert_empty body["skipped"]
+          assert_not BoardTask.exists?(@task.id)
+          assert_not BoardTask.exists?(t2.id)
+        end
+
+        test "bulk_actions skips tasks with an active workflow run" do
+          create(:workflow_run, workflow: @workflow, project: @project, user: @user, board_task: @task, state: "running")
+          t2 = create(:board_task, board: @board, board_column: @col1)
+
+          post :bulk_actions, params: {
+            project_id: @project.id,
+            action_type: "delete",
+            task_ids: [ @task.id, t2.id ]
+          }, as: :json
+
+          assert_response :success
+          body = JSON.parse(response.body)
+          assert_equal [ t2.id ], body["succeeded"]
+          assert_equal 1, body["skipped"].length
+          assert_equal @task.id, body["skipped"].first["task_id"]
+          assert_equal "active_run", body["skipped"].first["reason"]
+          assert BoardTask.exists?(@task.id)
+        end
+
+        test "bulk_actions returns 400 when action_type is missing" do
+          post :bulk_actions, params: {
+            project_id: @project.id,
+            task_ids: [ @task.id ]
+          }, as: :json
+
+          assert_response :bad_request
+          assert_includes JSON.parse(response.body)["errors"], "action_type is required"
+        end
+
+        test "bulk_actions returns 400 for unknown action_type" do
+          post :bulk_actions, params: {
+            project_id: @project.id,
+            action_type: "nuke",
+            task_ids: [ @task.id ]
+          }, as: :json
+
+          assert_response :bad_request
+          assert_includes JSON.parse(response.body)["errors"], "Unknown action"
+        end
+
+        test "bulk_actions returns 400 when task_ids is empty" do
+          post :bulk_actions, params: {
+            project_id: @project.id,
+            action_type: "delete",
+            task_ids: []
+          }, as: :json
+
+          assert_response :bad_request
+          assert_includes JSON.parse(response.body)["errors"], "task_ids is required"
+        end
+
+        test "bulk_actions returns 400 when move_to_column is missing column_id" do
+          post :bulk_actions, params: {
+            project_id: @project.id,
+            action_type: "move_to_column",
+            task_ids: [ @task.id ]
+          }, as: :json
+
+          assert_response :bad_request
+          assert_includes JSON.parse(response.body)["errors"], "column_id is required"
+        end
+
         # === viewer (read-only) enforcement ===
 
         class ViewerTest < ActionController::TestCase
@@ -362,6 +443,15 @@ module Api
 
           test "viewer trigger_workflow is forbidden" do
             post :trigger_workflow, params: { project_id: @project.id, id: @task.id }
+            assert_response :forbidden
+          end
+
+          test "viewer bulk_actions is forbidden" do
+            post :bulk_actions, params: {
+              project_id: @project.id,
+              action_type: "delete",
+              task_ids: [ @task.id ]
+            }, as: :json
             assert_response :forbidden
           end
         end

--- a/test/integration/api/v1/projects/board/tasks_authorization_test.rb
+++ b/test/integration/api/v1/projects/board/tasks_authorization_test.rb
@@ -69,4 +69,11 @@ class Api::V1::Projects::Board::TasksAuthorizationTest < ActionDispatch::Integra
       post trigger_workflow_api_v1_project_task_path(@project, @task), as: :json
     end
   end
+
+  test "bulk_actions is a project write" do
+    assert_project_write(transport: :api) do
+      post bulk_actions_api_v1_project_tasks_path(@project),
+           params: { action_type: "delete", task_ids: [ @task.id ] }, as: :json
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/projects/:project_id/tasks/bulk_actions` endpoint (delete, archive, move_to_column) with partial-success response — tasks with an active agent run are skipped, not failed
- Adds selection checkboxes to task cards (visible for non-view-only members); view-only users see no checkboxes and no bar
- Adds a fixed `SelectionBar` at the bottom of the board viewport that appears when ≥1 card is selected, with Delete, Archive, and Move to column actions
- Confirmation dialogs warn when a bulk move targets a column with an auto-trigger workflow binding
- Notifications report full or partial success; selection is cleared after each action

## What changed

**Backend**
- `config/routes.rb` — `collection { post :bulk_actions }` inside `resources :tasks`
- `app/policies/api/v1/projects/board/tasks_policy.rb` — `def bulk_actions? = project_writable?`
- `app/services/task_service.rb` — new `TaskService.bulk_action` class method; iterates tasks, skips any with an active run, delegates to existing `destroy`/`archive`/`move`
- `app/controllers/api/v1/projects/board/tasks_controller.rb` — new `bulk_actions` action; validates `action_type`, `task_ids`, and `column_id`; delegates to `TaskService.bulk_action`

**Frontend**
- `app/frontend/shared/routes.ts` — added `bulkActionsApiV1ProjectTasksPath`
- `app/frontend/pages/Projects/Board/SelectionBar.tsx` — new component (fixed bottom bar with action buttons + confirm modals)
- `app/frontend/pages/Projects/Board/useBulkActions.ts` — new hook wrapping the POST request and showing Mantine notifications
- `app/frontend/pages/Projects/Board/BoardPage.tsx` — selection state (`useState<Set<number>>`), `toggleSelect` / `clearSelection` callbacks, `selectedIds` + `onToggleSelect` props threaded through `BoardColumn` → `SortableTaskCard` → `TaskCardUI`, checkbox rendered in card title row, `SelectionBar` mounted after board area
- `app/frontend/pages/Projects/Board/BoardPage.module.css` — `.selectionCheckboxWrapper` and `.selectionCheckboxVisible` CSS classes for opacity transition

## Test plan

- [x] Select one or more task cards; SelectionBar appears at bottom with correct count
- [x] Delete: confirm dialog shown, tasks removed from board, notification shown
- [x] Archive: tasks archived, board refreshes, notification shown
- [x] Move to column: column picker in menu, tasks moved, notification shown
- [x] Cards with an active run are skipped; partial-success notification appears
- [x] View-only members see no checkboxes and no SelectionBar
- [x] Clearing selection (× button) hides SelectionBar
- [x] Moving to auto-trigger column shows workflow warning in confirm dialog

Closes #715

<img width="1920" height="1080" alt="SCR-20260825-qgyz" src="https://github.com/user-attachments/assets/e7acf647-505a-4f18-b4a4-565c4d9d338d" />
<img width="1920" height="1080" alt="SCR-20260825-qhcm" src="https://github.com/user-attachments/assets/d7e65ad2-f99d-478c-a507-1459c8334a8f" />
<img width="1920" height="1080" alt="SCR-20260825-qhfr" src="https://github.com/user-attachments/assets/446c30e0-4c8e-43d9-82e8-9e0a581bd72c" />
<img width="1920" height="1080" alt="SCR-20260825-qhhc" src="https://github.com/user-attachments/assets/9580f14a-ac7f-4100-afa6-e77579dc5c05" />
<img width="1920" height="1080" alt="SCR-20260825-qhja" src="https://github.com/user-attachments/assets/6e9c4811-b842-4ce0-a314-60748f2145ec" />
<img width="1920" height="1080" alt="SCR-20260825-qhms" src="https://github.com/user-attachments/assets/17078fc6-76b1-4240-bf28-9f8e7e1bb91b" />
<img width="1920" height="1080" alt="SCR-20260825-qhps" src="https://github.com/user-attachments/assets/af2e449e-0275-4779-aa0c-aeabc2a5c9ec" />
