### PR TITLE
fix(sessions): show steps by default on completed workflow runs

### DIFF
--- a/app/frontend/pages/Projects/WorkflowRuns/ShowPage.tsx
+++ b/app/frontend/pages/Projects/WorkflowRuns/ShowPage.tsx
@@ -214,7 +214,7 @@ const WorkflowRunShowPage = () => {
       key={step.id}
       data={toCardData(step, i)}
       live={isActive && liveStepIds.has(step.id)}
-      defaultOpen={isActive ? liveStepIds.has(step.id) : step.state === 'failed'}
+      defaultOpen={isActive ? liveStepIds.has(step.id) : isTerminal || step.state === 'failed'}
       sessionHref={step.terminalSessionId ? `${basePath}/sessions/${step.terminalSessionId}` : null}
     />
   ));


### PR DESCRIPTION
## Summary
- The Sessions & Runs redesign (#93) turned each step into a collapsible `SessionCard`. `defaultOpen` only expanded steps that were currently live or had failed, so on a **completed** run every step mounted collapsed and its step checklist never showed — reported as "no steps visible" on the Completed Run page.
- `defaultOpen` now also expands on terminal runs (completed/failed/cancelled), restoring the pre-redesign behavior of always showing the step list.

## Test plan
- [x] `docker compose exec -T web make check_all` green (rails-test, rubocop, brakeman, system-test, eslint, typescript, fe-test, vite-build)
- [ ] Manually verify on a real completed run (e.g. `/company/projects/27/workflow_runs/4325`) that steps now render expanded by default

https://claude.ai/code/session_01JAYLETVBCYiuH2MAqtdmx8