### PR TITLE
fix(repositories): make repository writes a plain project write

### DIFF
--- a/app/policies/web/company/projects/repositories_policy.rb
+++ b/app/policies/web/company/projects/repositories_policy.rb
@@ -3,11 +3,16 @@
 module Web
   module Company
     module Projects
+      # Attaching a repository is the same authority as adding an agent, a tool
+      # or an MCP server: it configures what a session runs with, inside a
+      # project the actor can already write to. It used to require a company
+      # admin, which left a project owner able to connect the GitHub
+      # integration (IntegrationsPolicy) but not add a repository from it.
       class RepositoriesPolicy < Web::Company::ApplicationPolicy
         def index? = project_accessible?
-        def create? = project_writable? && admin?
-        def update? = project_writable? && admin?
-        def destroy? = project_writable? && admin?
+        def create? = project_writable?
+        def update? = project_writable?
+        def destroy? = project_writable?
       end
     end
   end

--- a/app/services/personal_tools/create_repository.rb
+++ b/app/services/personal_tools/create_repository.rb
@@ -4,7 +4,7 @@ module PersonalTools
   class CreateRepository < Base
     tool do
       display_name "Create Repository"
-      description "Attach a git repository to a project (requires company admin)."
+      description "Attach a git repository to a project."
       audience :user
       tags :resources
       param :project_id, type: :integer, description: "Project id.", required: true

--- a/app/services/personal_tools/delete_repository.rb
+++ b/app/services/personal_tools/delete_repository.rb
@@ -4,7 +4,7 @@ module PersonalTools
   class DeleteRepository < Base
     tool do
       display_name "Delete Repository"
-      description "Detach a repository from a project (requires company admin)."
+      description "Detach a repository from a project."
       audience :user
       tags :resources
       param :project_id, type: :integer, description: "Project id.", required: true

--- a/app/services/personal_tools/update_repository.rb
+++ b/app/services/personal_tools/update_repository.rb
@@ -4,7 +4,7 @@ module PersonalTools
   class UpdateRepository < Base
     tool do
       display_name "Update Repository"
-      description "Update a project repository's branch, purpose or description (requires company admin)."
+      description "Update a project repository's branch, purpose or description."
       audience :user
       tags :resources
       param :project_id, type: :integer, description: "Project id.", required: true

--- a/test/integration/personal_mcp_project_config_test.rb
+++ b/test/integration/personal_mcp_project_config_test.rb
@@ -40,7 +40,7 @@ class PersonalMCPProjectConfigTest < ActionDispatch::IntegrationTest
     assert_not ConfigItem.exists?(id)
   end
 
-  test "repository CRUD (company admin)" do
+  test "repository CRUD" do
     integration = create(:integration, company: @company, project: @project, provider: :github,
                          status: :active, connected_by: @user)
     created = payload(call_tool("create_repository",
@@ -69,12 +69,27 @@ class PersonalMCPProjectConfigTest < ActionDispatch::IntegrationTest
     assert_equal @company, project.company
   end
 
-  test "a non-admin cannot manage repositories" do
+  # Attaching a repository is a plain project write, so a collaborator without
+  # the company admin role manages them; only the read-only viewer is refused.
+  test "a collaborator without the admin role can manage repositories" do
+    integration = create(:integration, company: @company, project: @project, provider: :github,
+                         status: :active, connected_by: @user)
     member = create(:user, company: @company)
     @project.add_collaborator(member)
     mtoken = member.regenerate_mcp_token!
 
-    body = call_tool("create_repository", { project_id: @project.id, full_name: "o/r" }, token: mtoken)
+    body = call_tool("create_repository",
+                     { project_id: @project.id, full_name: "o/r", integration_id: integration.id },
+                     token: mtoken)
+    assert_not error?(body)
+  end
+
+  test "a read-only viewer cannot manage repositories" do
+    viewer = create(:user, :viewer, company: @company, email: "client@external.com")
+    @project.add_collaborator(viewer)
+    vtoken = viewer.regenerate_mcp_token!
+
+    body = call_tool("create_repository", { project_id: @project.id, full_name: "o/r" }, token: vtoken)
     assert error?(body)
     assert_match(/not allowed/i, body.dig("result", "content").map { |c| c["text"] }.join(" "))
   end

--- a/test/integration/web/company/projects/repositories_authorization_test.rb
+++ b/test/integration/web/company/projects/repositories_authorization_test.rb
@@ -6,17 +6,14 @@ require "test_helper"
 # via the shared AuthorizationMatrix harness (docs/testing.md §2).
 #
 # Policy (app/policies/web/company/projects/repositories_policy.rb):
-#   index?                       => project_accessible?                     (read)
-#   create? / update? / destroy? => project_writable? && current_user.admin? (write + admin role)
+#   index?                       => project_accessible?  (read)
+#   create? / update? / destroy? => project_writable?    (write)
 #
-# The read (index) follows the standard project-read matrix. The writes are NOT
-# the standard project-write preset: they additionally require the company ADMIN
-# *role* (current_user.admin?), so only @admin is allowed. The project owner and
-# the employee collaborator have project_writable? access but lack the admin
-# role, so they are DENIED; the read-only viewer is denied too. A same-company
-# stranger and a foreign-company admin are scoped out by the controller's
-# Project.for_user(current_user).find -> RecordNotFound -> 404 (before the policy
-# runs, when policy_context resolves current_project).
+# The standard project matrices apply: attaching a repository is the same
+# authority as adding an agent or an MCP server. The read-only viewer is denied
+# the writes; a same-company stranger and a foreign-company admin are scoped out
+# by the controller's Project.for_user(current_user).find -> RecordNotFound ->
+# 404 (before the policy runs, when policy_context resolves current_project).
 class Web::Company::Projects::RepositoriesAuthorizationTest < ActionDispatch::IntegrationTest
   include AuthorizationMatrix
 
@@ -32,11 +29,11 @@ class Web::Company::Projects::RepositoriesAuthorizationTest < ActionDispatch::In
     assert_project_read { get company_project_repositories_path(@project) }
   end
 
-  test "create requires the company admin role (project write + admin?)" do
-    assert_role_matrix(admin_write_expectations, transport: :web) do
+  test "create is a project write" do
+    assert_project_write do |role|
       post company_project_repositories_path(@project), params: {
         repository: {
-          full_name: "acme/authz-service",
+          full_name: "acme/authz-service-#{role}",
           clone_url: "https://github.com/acme/authz-service.git",
           source_branch: "main",
           integration_id: @integration.id
@@ -45,30 +42,17 @@ class Web::Company::Projects::RepositoriesAuthorizationTest < ActionDispatch::In
     end
   end
 
-  test "update requires the company admin role (project write + admin?)" do
-    assert_role_matrix(admin_write_expectations, transport: :web) do
+  test "update is a project write" do
+    assert_project_write do
       patch company_project_repository_path(@project, @repository),
             params: { repository: { description: "Updated by matrix" } }
     end
   end
 
   # destroy mutates, so build a throwaway project-scoped repository per iteration.
-  test "destroy requires the company admin role (project write + admin?)" do
-    assert_role_matrix(admin_write_expectations, transport: :web) do
+  test "destroy is a project write" do
+    assert_project_write do
       delete company_project_repository_path(@project, create(:repository, scope: @project, integration: @integration))
     end
-  end
-
-  private
-
-  # create/update/destroy gate on project_writable? AND current_user.admin?, so
-  # only the company admin passes; the owner and employee/viewer collaborators
-  # are denied, and non-members (stranger/foreign admin) are scoped out to 404.
-  def admin_write_expectations
-    {
-      admin: :allowed_write,
-      owner: :denied, collaborator: :denied, viewer: :denied,
-      stranger: :not_found, foreign_admin: :not_found
-    }
   end
 end

--- a/test/policies/web/company/projects/read_only_policies_test.rb
+++ b/test/policies/web/company/projects/read_only_policies_test.rb
@@ -113,6 +113,25 @@ module Web
           assert_not p.destroy?
         end
 
+        # Repositories used to require the company admin role, which left a
+        # project owner able to connect the GitHub integration but not attach a
+        # repository from it. They are a plain project write now.
+        test "RepositoriesPolicy: project owner without the admin role can write" do
+          p = RepositoriesPolicy.new(context_for(@owner), nil)
+          assert p.index?
+          assert p.create?
+          assert p.update?
+          assert p.destroy?
+        end
+
+        test "RepositoriesPolicy: viewer reads allowed, writes denied" do
+          p = RepositoriesPolicy.new(context_for(@viewer), nil)
+          assert p.index?
+          assert_not p.create?
+          assert_not p.update?
+          assert_not p.destroy?
+        end
+
         test "AgentsPolicy/ToolsPolicy: viewer writes denied" do
           assert_not AgentsPolicy.new(context_for(@viewer), nil).create?
           assert_not ToolsPolicy.new(context_for(@viewer), nil).create?


### PR DESCRIPTION
## Problem

A project owner who is not a company admin cannot add a repository. Reported from prod: the user connected a project-scoped GitHub integration successfully, then hit `You are not authorized to perform this action.` on **Add Repository**.

`RepositoriesPolicy` was the only project resource gating writes on the company **admin role**:

```ruby
def create? = project_writable? && admin?   # admin? == CompanyMembership#admin?
```

while `IntegrationsPolicy` accepts `admin? || project_owner?`. So the owner can connect GitHub but cannot use it. Worse, the page still shows the button: the frontend (`RepositoriesContent.tsx`) gates on `canExecute` (= not a viewer), which the policy no longer matched — every non-admin member gets a dead button.

## Change

Align with every other project resource (agents, tools, skills, MCP servers, workflows, config items):

```ruby
def create? = project_writable?
def update? = project_writable?
def destroy? = project_writable?
```

`index?` is unchanged. Read-only viewers stay denied, and the existing `canExecute` frontend gate now matches the policy exactly — no frontend change needed.

The personal MCP tools (`create_repository` / `update_repository` / `delete_repository`) authorize through the same policy, so their tool descriptions drop the now-false "(requires company admin)" note.

## Tests

- `repositories_authorization_test.rb` moves from the bespoke admin-only matrix to the shared `assert_project_write` preset.
- `read_only_policies_test.rb` gains the two cases that pin the fix: a project owner without the admin role can write; a viewer cannot.
- `personal_mcp_project_config_test.rb`: the old "a non-admin cannot manage repositories" case is replaced by a collaborator-can / viewer-cannot pair.

`make check_all` in Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)