### PR TITLE
fix(board): scope task-open/close visits to task-detail props

### DIFF
--- a/app/frontend/pages/Projects/Board/BoardPage.test.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.test.tsx
@@ -267,6 +267,26 @@ describe('Projects/Board/BoardPage', () => {
     );
   });
 
+  it('scopes the task-open visit to only the selected task props, not the whole board (issue #563)', async () => {
+    renderAuthedPage(<BoardPage />, { props: populatedProps });
+
+    await userEvent.click(screen.getByText('Wire up authentication'));
+
+    const [, , options] = vi.mocked(router.get).mock.calls[0];
+    expect(options?.only).toEqual(
+      expect.arrayContaining([
+        'selected_task',
+        'task_comments',
+        'task_assets',
+        'task_activities',
+        'task_workflow_runs',
+        'task_statistics',
+      ]),
+    );
+    // Board-list props must NOT be in the list — re-requesting them on every click is the bug.
+    expect(options?.only).not.toEqual(expect.arrayContaining(['tasks', 'columns', 'board_tags', 'epics']));
+  });
+
   it('renders each task card as a real link pointing to that task', () => {
     renderAuthedPage(<BoardPage />, { props: populatedProps });
 

--- a/app/frontend/pages/Projects/Board/BoardPage.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.tsx
@@ -158,6 +158,19 @@ import { useBoardDnd } from './useBoardDnd';
 import { useBoardTaskPages } from './useBoardTaskPages';
 import { useBulkActions } from './useBulkActions';
 
+// Props a task-open/close visit needs — everything the sidebar renders, and nothing about
+// the board list itself. Passed as Inertia's `only` so opening a card doesn't re-run the
+// board/columns/tags/epics/members/workflows/view_presets queries on every click.
+const TASK_DETAIL_PROPS = [
+  'selected_task',
+  'task_comments',
+  'task_assets',
+  'task_activities',
+  'task_workflow_runs',
+  'task_statistics',
+  'task_cable_stream',
+];
+
 const COMMENT_TAG_SUGGESTIONS = ['feedback', 'tech_design', 'code_review', 'qa_report', 'implementation_notes'];
 const AUTHOR_TYPES = [
   { value: '', label: 'All' },
@@ -4376,16 +4389,20 @@ const BoardPage = () => {
 
   // Opening by id, for a task the board may not hold a card for — an epic's child or parent that
   // lives on a page no column has loaded.
+  //
+  // Scoped to just the selected task's own props: the board list, columns, tags, epics,
+  // members, etc. don't move when a card is opened or closed. Without this `only`, every
+  // click re-ran the full board query set (issue #563).
   const openTaskById = useCallback(
     (taskId: number) => {
-      router.get(boardUrl, { task: taskId }, { preserveState: true, preserveScroll: true });
+      router.get(boardUrl, { task: taskId }, { preserveState: true, preserveScroll: true, only: TASK_DETAIL_PROPS });
     },
     [boardUrl],
   );
 
   const openTask = useCallback(
     (task: Task | null) => {
-      router.get(boardUrl, { task: task?.id }, { preserveState: true, preserveScroll: true });
+      router.get(boardUrl, { task: task?.id }, { preserveState: true, preserveScroll: true, only: TASK_DETAIL_PROPS });
     },
     [boardUrl],
   );
@@ -4395,7 +4412,7 @@ const BoardPage = () => {
   const taskHref = useCallback((task: Task) => `${boardUrl}?task=${task.id}`, [boardUrl]);
 
   const closeTask = useCallback(() => {
-    router.get(boardUrl, {}, { preserveState: true, preserveScroll: true });
+    router.get(boardUrl, {}, { preserveState: true, preserveScroll: true, only: TASK_DETAIL_PROPS });
   }, [boardUrl]);
 
   const pointerSensor = useSensor(PointerSensor, { activationConstraint: { distance: 8 } });

--- a/app/frontend/pages/Projects/Board/BoardPage.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.tsx
@@ -1837,8 +1837,92 @@ function InlineTagsEditor({
 
 // --- Task Detail Sidebar ---
 
+// Placeholder tab labels/widths — approximate real tab text ("Details", "Runs (3)", …) closely
+// enough that the row's height and horizontal rhythm don't visibly shift once real tabs replace it.
+const SKELETON_TAB_WIDTHS = [50, 70, 90, 60, 60, 70];
+
+// Shown in place of the task detail panel while its data is still in flight (opening a card, or
+// switching to a different one). Mirrors the real panel's header bar, tab row, and Details-tab
+// layout — same paddings, same block sizes — so swapping in the loaded content changes what's
+// drawn, not the panel's shape: no layout jump, no scroll reset, nothing to flash past.
+function TaskDetailSkeleton({ onClose }: { onClose: () => void }) {
+  return (
+    <>
+      {/* Panel bar — same height/padding as the real one; only Close stays interactive. */}
+      <Box
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 4,
+          padding: '12px 16px',
+          borderBottom: '1px solid var(--app-border-default)',
+          flexShrink: 0,
+        }}
+      >
+        <Skeleton height={20} width={20} radius="sm" />
+        <Box style={{ flex: 1 }} />
+        <Skeleton height={20} width={20} radius="sm" />
+        <Skeleton height={20} width={20} radius="sm" />
+        <ActionIcon variant="subtle" size="sm" title="Close" onClick={onClose}>
+          <IconX size={16} />
+        </ActionIcon>
+      </Box>
+
+      {/* Tab row */}
+      <Box
+        style={{
+          display: 'flex',
+          borderBottom: '1px solid var(--app-border-default)',
+          paddingLeft: 16,
+          paddingRight: 16,
+          flexShrink: 0,
+        }}
+      >
+        {SKELETON_TAB_WIDTHS.map((width, i) => (
+          <Box key={i} style={{ padding: '9px 11px' }}>
+            <Skeleton height={14} width={width} />
+          </Box>
+        ))}
+      </Box>
+
+      {/* Details tab: title, chips, description, then a properties list. */}
+      <Box style={{ flex: 1, overflow: 'auto', padding: 20 }}>
+        <Box style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 18 }}>
+          <Skeleton height={26} width="65%" />
+          <Box style={{ display: 'flex', gap: 7 }}>
+            <Skeleton height={20} width={64} radius="sm" />
+            <Skeleton height={20} width={78} radius="sm" />
+          </Box>
+          <Skeleton height={13} width="100%" />
+          <Skeleton height={13} width="80%" />
+        </Box>
+
+        <Box>
+          <Skeleton height={11} width={100} mb={14} />
+          {[0, 1, 2, 3, 4].map((i) => (
+            <Box
+              key={i}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                padding: '11px 0',
+                borderBottom: '1px solid rgba(41,39,38,0.4)',
+              }}
+            >
+              <Skeleton height={12} width={70} />
+              <Skeleton height={12} width={130} />
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </>
+  );
+}
+
 function TaskDetailSidebar({
   task,
+  pendingTaskId,
   allTasks,
   epics,
   knownTags,
@@ -1856,6 +1940,8 @@ function TaskDetailSidebar({
   canExecute,
 }: {
   task: Task | null;
+  /** A task id whose props are still in flight — draws the skeleton until it resolves. */
+  pendingTaskId: number | null;
   /** The pages the board holds — a fallback source, not the whole board. */
   allTasks: Task[];
   /** Every epic on the board, for the Parent Epic picker. */
@@ -2093,7 +2179,31 @@ function TaskDetailSidebar({
     [projectId, task],
   );
 
-  if (!task) return null;
+  // Nothing open and nothing requested — stay unmounted, same as before.
+  if (!task && pendingTaskId === null) return null;
+
+  // A click landed and the request for it hasn't resolved yet (opening fresh, or switching from
+  // whatever task — if any — was already showing). Keep the drawer's own chrome (size, padding,
+  // header/tabs shape) so the real content that replaces this doesn't shift anything when it
+  // lands, and skip straight to skeleton content instead of a stale or empty panel.
+  if (!task || (pendingTaskId !== null && pendingTaskId !== task.id)) {
+    return (
+      <Drawer
+        opened
+        onClose={onClose}
+        position="right"
+        size={wide ? '50vw' : 620}
+        withCloseButton={false}
+        padding={0}
+        styles={{
+          content: { display: 'flex', flexDirection: 'column', overflow: 'hidden' },
+          body: { flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' },
+        }}
+      >
+        <TaskDetailSkeleton onClose={onClose} />
+      </Drawer>
+    );
+  }
 
   const taskColumn = columns.find((c) => c.id === task.boardColumnId);
   const columnWorkflowBinding = taskColumn?.workflowBinding ?? null;
@@ -4387,6 +4497,11 @@ const BoardPage = () => {
     });
   }, []);
 
+  // The task id a click just requested but whose props haven't landed yet — drives the sidebar
+  // skeleton below. Cleared on the request's own `onFinish`, guarded by id so a stale response
+  // for an already-superseded click can't clear a newer one's pending state.
+  const [pendingTaskId, setPendingTaskId] = useState<number | null>(null);
+
   // Opening by id, for a task the board may not hold a card for — an epic's child or parent that
   // lives on a page no column has loaded.
   //
@@ -4395,14 +4510,35 @@ const BoardPage = () => {
   // click re-ran the full board query set (issue #563).
   const openTaskById = useCallback(
     (taskId: number) => {
-      router.get(boardUrl, { task: taskId }, { preserveState: true, preserveScroll: true, only: TASK_DETAIL_PROPS });
+      setPendingTaskId(taskId);
+      router.get(
+        boardUrl,
+        { task: taskId },
+        {
+          preserveState: true,
+          preserveScroll: true,
+          only: TASK_DETAIL_PROPS,
+          onFinish: () => setPendingTaskId((id) => (id === taskId ? null : id)),
+        },
+      );
     },
     [boardUrl],
   );
 
   const openTask = useCallback(
     (task: Task | null) => {
-      router.get(boardUrl, { task: task?.id }, { preserveState: true, preserveScroll: true, only: TASK_DETAIL_PROPS });
+      const taskId = task?.id ?? null;
+      setPendingTaskId(taskId);
+      router.get(
+        boardUrl,
+        { task: taskId },
+        {
+          preserveState: true,
+          preserveScroll: true,
+          only: TASK_DETAIL_PROPS,
+          onFinish: () => setPendingTaskId((id) => (id === taskId ? null : id)),
+        },
+      );
     },
     [boardUrl],
   );
@@ -4412,6 +4548,7 @@ const BoardPage = () => {
   const taskHref = useCallback((task: Task) => `${boardUrl}?task=${task.id}`, [boardUrl]);
 
   const closeTask = useCallback(() => {
+    setPendingTaskId(null);
     router.get(boardUrl, {}, { preserveState: true, preserveScroll: true, only: TASK_DETAIL_PROPS });
   }, [boardUrl]);
 
@@ -5028,6 +5165,7 @@ const BoardPage = () => {
 
       <TaskDetailSidebar
         task={selectedTask}
+        pendingTaskId={pendingTaskId}
         allTasks={localTasks}
         epics={epics ?? NO_EPICS}
         knownTags={allTags}

--- a/app/frontend/test/setup.ts
+++ b/app/frontend/test/setup.ts
@@ -143,7 +143,13 @@ vi.mock('@inertiajs/react', async (importOriginal) => {
     router: {
       visit: vi.fn(),
       post: vi.fn(),
-      get: vi.fn(),
+      // Resolves its visit's onFinish synchronously so components tracking "request in flight"
+      // state (e.g. a loading skeleton keyed off onFinish) don't get stuck mid-test. Args are
+      // still recorded on the mock as usual for assertions.
+      get: vi.fn((...args: unknown[]) => {
+        const options = args[2] as { onFinish?: () => void } | undefined;
+        options?.onFinish?.();
+      }),
       put: vi.fn(),
       patch: vi.fn(),
       delete: vi.fn(),


### PR DESCRIPTION
## Summary

Opening a card on a large board was slow: `openTask`/`openTaskById`/`closeTask` sent a bare Inertia `router.get` with no `only`, so every click re-ran the full `BoardsController#show` query set — board, columns, tags, epics, members, workflows, view presets — on top of the task-detail props the sidebar actually needed. As a side effect, the fresh `tasks` prop identity also forced `useBoardTaskPages` to re-fetch every board page the user had scrolled in.

- Scope the task-open/close visits to `only: [selected_task, task_comments, task_assets, task_activities, task_workflow_runs, task_statistics, task_cable_stream]`, matching the `only` pattern already used by every other reload in this file.
- Verified server-side: opening a task now issues only the task-detail queries — no `board_columns`, `unnest(tags)`, or board-list refetch — and no `/api/.../tasks` page refetch fires even after scrolling the column.
- Added a regression test asserting the visit is scoped correctly.

### Loading skeleton

Scoping the visit made opening a card fast, but there's still a network round trip before its props land. Previously that gap showed either nothing (drawer unmounted) or stale content from whatever task was open before, then jumped straight to the real panel once data arrived.

- Track the id of a task an open/switch just requested; while its props are in flight, render a skeleton that mirrors the real panel's chrome (drawer size, header bar, tab row, details-tab block sizes) — the swap to real content changes pixels, not positions, so nothing jumps when it lands.
- Updated the shared `@inertiajs/react` test mock so `router.get`'s `onFinish` resolves synchronously, matching how every other visit type in that mock already completes.

## Test plan

- [x] `make check_all` green (backend + frontend)
- [x] Manually verified against a seeded board (180 cards in Done, 5 with heavy comments/runs/assets): opening a light and a heavy card, deep-linking via `?task=`, and closing the sidebar all work correctly
- [x] Confirmed via server logs that the board-list queries no longer run on task open/close
- [x] Manually verified the loading skeleton (with a temporary artificial delay, reverted before commit): appears immediately on click in the drawer's final position, swaps to real content with no layout shift