### PR TITLE
fix(frontend): break circular imports in mcp-servers, assets, Workflows

### DIFF
--- a/app/frontend/pages/Projects/Workflows/TriggerFormPanel.test.tsx
+++ b/app/frontend/pages/Projects/Workflows/TriggerFormPanel.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { renderPage, screen, userEvent, waitFor } from 'test/renderPage';
 
 import { TriggerFormPanel } from './TriggerFormPanel';
-import type { Trigger } from './TriggersTab';
+import type { Trigger } from './types';
 
 // TriggerFormPanel takes plain props (no usePage/useForm read) and talks to the backend through
 // apiFetch() -> the global fetch() the test setup stubs. `defaultKind` seeds the create-mode kind and

--- a/app/frontend/pages/Projects/Workflows/TriggerFormPanel.tsx
+++ b/app/frontend/pages/Projects/Workflows/TriggerFormPanel.tsx
@@ -6,7 +6,7 @@ import { useCallback, useState } from 'react';
 import { apiFetch } from 'shared/lib/apiFetch';
 import { apiV1ProjectWorkflowTriggerPath, apiV1ProjectWorkflowTriggersPath } from 'shared/routes';
 
-import type { Trigger } from './TriggersTab';
+import type { Trigger } from './types';
 
 interface ColumnOption {
   id: number;

--- a/app/frontend/pages/Projects/Workflows/TriggersTab.tsx
+++ b/app/frontend/pages/Projects/Workflows/TriggersTab.tsx
@@ -16,6 +16,9 @@ import { apiFetch } from 'shared/lib/apiFetch';
 import { apiV1ProjectWorkflowTriggerPath, apiV1ProjectWorkflowTriggersPath } from 'shared/routes';
 
 import { TriggerFormPanel } from './TriggerFormPanel';
+import type { Trigger } from './types';
+
+export type { Trigger } from './types';
 
 interface ColumnOption {
   id: number;
@@ -26,23 +29,6 @@ interface ColumnOption {
 interface StepOption {
   id: number;
   name: string;
-}
-
-export interface Trigger {
-  id: number;
-  kind: string;
-  event_type: string;
-  name?: string | null;
-  trigger_mode?: string;
-  cooldown_seconds?: number;
-  enabled?: boolean;
-  column_name?: string;
-  board_column_id?: number;
-  subject_policy?: string;
-  subject_column_id?: number | null;
-  subject_title_template?: string | null;
-  filter_predicate?: Record<string, unknown>;
-  schedule_config?: { cron?: string; timezone?: string };
 }
 
 interface TriggersTabProps {

--- a/app/frontend/pages/Projects/Workflows/types.ts
+++ b/app/frontend/pages/Projects/Workflows/types.ts
@@ -1,0 +1,16 @@
+export interface Trigger {
+  id: number;
+  kind: string;
+  event_type: string;
+  name?: string | null;
+  trigger_mode?: string;
+  cooldown_seconds?: number;
+  enabled?: boolean;
+  column_name?: string;
+  board_column_id?: number;
+  subject_policy?: string;
+  subject_column_id?: number | null;
+  subject_title_template?: string | null;
+  filter_predicate?: Record<string, unknown>;
+  schedule_config?: { cron?: string; timezone?: string };
+}

--- a/app/frontend/shared/resources/assets/AssetPreviewModal.test.tsx
+++ b/app/frontend/shared/resources/assets/AssetPreviewModal.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { renderPage, screen, userEvent, waitFor } from 'test/renderPage';
 
 import { AssetPreviewModal } from './AssetPreviewModal';
-import type { Asset } from './AssetsContent';
+import type { Asset } from './types';
 
 function makeAsset(overrides: Partial<Asset> = {}): Asset {
   return {

--- a/app/frontend/shared/resources/assets/AssetPreviewModal.tsx
+++ b/app/frontend/shared/resources/assets/AssetPreviewModal.tsx
@@ -2,7 +2,7 @@ import { Badge, Box, Button, Center, Code, Group, Loader, Modal, Stack, Text } f
 import { IconDownload, IconFile } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 
-import type { Asset } from './AssetsContent';
+import type { Asset } from './types';
 
 interface AssetPreviewModalProps {
   asset: Asset | null;

--- a/app/frontend/shared/resources/assets/AssetsContent.tsx
+++ b/app/frontend/shared/resources/assets/AssetsContent.tsx
@@ -30,34 +30,9 @@ import { EmptyState } from 'shared/ui/EmptyState';
 import { PageHeader } from 'shared/ui/PageHeader';
 
 import { AssetPreviewModal } from './AssetPreviewModal';
+import type { Asset, AssetVersion } from './types';
 
-export interface AssetVersion {
-  id: number;
-  version: number;
-  contentType: string | null;
-  fileSize: number | null;
-  source: string | null;
-  fileUrl: string | null;
-  createdAt: string | null;
-}
-
-export interface Asset {
-  id: number;
-  name: string;
-  folder: string | null;
-  tags: string[];
-  public: boolean;
-  scopeType: string;
-  scopeId: number;
-  scopeIndicator: 'company' | 'project';
-  status: string;
-  createdById: number;
-  createdByName: string | null;
-  versionsCount: number;
-  latestVersion: AssetVersion | null;
-  createdAt: string;
-  updatedAt: string;
-}
+export type { Asset, AssetVersion } from './types';
 
 const PRESIGN_URL = '/api/v1/assets/presign';
 const MAX_FILE_SIZE = 1024 * 1024 * 1024;

--- a/app/frontend/shared/resources/assets/types.ts
+++ b/app/frontend/shared/resources/assets/types.ts
@@ -1,0 +1,27 @@
+export interface AssetVersion {
+  id: number;
+  version: number;
+  contentType: string | null;
+  fileSize: number | null;
+  source: string | null;
+  fileUrl: string | null;
+  createdAt: string | null;
+}
+
+export interface Asset {
+  id: number;
+  name: string;
+  folder: string | null;
+  tags: string[];
+  public: boolean;
+  scopeType: string;
+  scopeId: number;
+  scopeIndicator: 'company' | 'project';
+  status: string;
+  createdById: number;
+  createdByName: string | null;
+  versionsCount: number;
+  latestVersion: AssetVersion | null;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/app/frontend/shared/resources/mcp-servers/ConnectorUpdateModal.tsx
+++ b/app/frontend/shared/resources/mcp-servers/ConnectorUpdateModal.tsx
@@ -3,7 +3,7 @@ import { Alert, Button, Code, Group, Modal, Stack, Text } from '@mantine/core';
 import { IconArrowUpCircle } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 
-import type { McpServer } from './McpServersContent';
+import type { McpServer } from './types';
 
 interface ConnectorUpdateModalProps {
   server: McpServer | null;

--- a/app/frontend/shared/resources/mcp-servers/McpServersContent.tsx
+++ b/app/frontend/shared/resources/mcp-servers/McpServersContent.tsx
@@ -37,42 +37,9 @@ import { McpServerFormModal } from './McpServerFormModal';
 import { driftedServers } from './serverHealth';
 import { ServerHealthIcons } from './ServerHealthIcons';
 import { ToolDriftModal } from './ToolDriftModal';
+import type { McpServer } from './types';
 
-type McpServerKind = 'internal' | 'custom';
-type Transport = 'http' | 'sse' | 'stdio';
-
-export interface McpServer {
-  id: number;
-  name: string;
-  url: string | null;
-  transport: Transport;
-  headers: Record<string, string> | null;
-  description: string | null;
-  kind: McpServerKind;
-  scopeType: string | null;
-  scopeId: number | null;
-  scopeIndicator: string;
-  enabled: boolean;
-  internal: boolean;
-  command: string | null;
-  env: Record<string, string> | null;
-  // OAuth (oauth-unification §4.3/§4.6). oauthStatus is per-current-user and read-only.
-  authType?: 'none' | 'static' | 'oauth';
-  credentialScope?: 'shared' | 'per_user';
-  oauthStatus?: 'pending' | 'active' | 'expiring' | 'error' | null;
-  // Connector provenance and tool-baseline health. Null/false on hand-authored
-  // servers — nobody promised anything about a server someone typed in.
-  connectorName?: string | null;
-  connectorVersion?: string | null;
-  connectorStatus?: 'active' | 'deprecated' | 'deleted' | null;
-  connectorVersionPinned?: boolean;
-  toolBaseline?: boolean;
-  toolDrift?: { added?: string[]; removed?: string[]; changed?: string[]; detected_at?: string } | null;
-  /** Version the catalog now carries, when it differs from the installed one. */
-  connectorUpdateVersion?: string | null;
-  createdAt: string;
-  updatedAt: string;
-}
+export type { McpServer } from './types';
 
 // Maps a server's per-user oauth_status to a connection badge (functional labels,
 // not colour alone, so the state reads without relying on hue).

--- a/app/frontend/shared/resources/mcp-servers/ServerHealthIcons.tsx
+++ b/app/frontend/shared/resources/mcp-servers/ServerHealthIcons.tsx
@@ -8,8 +8,8 @@ import {
 } from '@tabler/icons-react';
 import type { FC } from 'react';
 
-import type { McpServer } from './McpServersContent';
 import { serverHealthSignals, type ServerHealthSignal } from './serverHealth';
+import type { McpServer } from './types';
 
 // Health reads as one glyph per fact, sitting with the server's name. In a
 // dense table the alternative — a badge per condition — would double the row's

--- a/app/frontend/shared/resources/mcp-servers/ToolDriftModal.test.tsx
+++ b/app/frontend/shared/resources/mcp-servers/ToolDriftModal.test.tsx
@@ -6,7 +6,7 @@ import { renderAuthedPage, screen, userEvent, within } from 'test/renderPage';
 
 import McpServersPage from 'pages/Projects/McpServers/McpServersPage';
 
-import type { McpServer } from './McpServersContent';
+import type { McpServer } from './types';
 
 // Drift surfacing is exercised through the real MCP servers page: the point of
 // the feature is that someone scanning their server list notices, so testing

--- a/app/frontend/shared/resources/mcp-servers/ToolDriftModal.tsx
+++ b/app/frontend/shared/resources/mcp-servers/ToolDriftModal.tsx
@@ -3,7 +3,7 @@ import { Alert, Button, Code, Group, List, Modal, Stack, Text } from '@mantine/c
 import { IconAlertTriangle } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 
-import type { McpServer } from './McpServersContent';
+import type { McpServer } from './types';
 
 interface ToolDriftModalProps {
   server: McpServer | null;

--- a/app/frontend/shared/resources/mcp-servers/serverHealth.test.ts
+++ b/app/frontend/shared/resources/mcp-servers/serverHealth.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import type { McpServer } from './McpServersContent';
 import { driftedServers, serverHealthSignals } from './serverHealth';
+import type { McpServer } from './types';
 
 const server = (overrides: Partial<McpServer> = {}): McpServer => ({
   id: 1,

--- a/app/frontend/shared/resources/mcp-servers/serverHealth.ts
+++ b/app/frontend/shared/resources/mcp-servers/serverHealth.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from './McpServersContent';
+import type { McpServer } from './types';
 
 // Health signals a catalog-installed MCP server can carry, ordered by how much
 // they should interrupt someone scanning a table.

--- a/app/frontend/shared/resources/mcp-servers/types.ts
+++ b/app/frontend/shared/resources/mcp-servers/types.ts
@@ -1,0 +1,35 @@
+export type McpServerKind = 'internal' | 'custom';
+export type Transport = 'http' | 'sse' | 'stdio';
+
+export interface McpServer {
+  id: number;
+  name: string;
+  url: string | null;
+  transport: Transport;
+  headers: Record<string, string> | null;
+  description: string | null;
+  kind: McpServerKind;
+  scopeType: string | null;
+  scopeId: number | null;
+  scopeIndicator: string;
+  enabled: boolean;
+  internal: boolean;
+  command: string | null;
+  env: Record<string, string> | null;
+  // OAuth (oauth-unification §4.3/§4.6). oauthStatus is per-current-user and read-only.
+  authType?: 'none' | 'static' | 'oauth';
+  credentialScope?: 'shared' | 'per_user';
+  oauthStatus?: 'pending' | 'active' | 'expiring' | 'error' | null;
+  // Connector provenance and tool-baseline health. Null/false on hand-authored
+  // servers — nobody promised anything about a server someone typed in.
+  connectorName?: string | null;
+  connectorVersion?: string | null;
+  connectorStatus?: 'active' | 'deprecated' | 'deleted' | null;
+  connectorVersionPinned?: boolean;
+  toolBaseline?: boolean;
+  toolDrift?: { added?: string[]; removed?: string[]; changed?: string[]; detected_at?: string } | null;
+  /** Version the catalog now carries, when it differs from the installed one. */
+  connectorUpdateVersion?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## Why circular imports are bad

A circular import means two (or more) modules depend on each other at load
time. JS/TS resolves this by handing back a partially-initialized module to
whichever side loads second — so a value can be `undefined` depending on
which file happens to be imported first, in dev vs. build vs. test. It also
makes each file harder to reason about and refactor in isolation, and it
tends to keep growing once a hub file becomes the place everything imports
from.

## What was found

Ran `madge --circular` over `app/frontend` and found 6 cycles, all with the
same root cause: a component file defined a shared TS type/interface, and
its own child components imported that type back from it.

1. `TriggersTab.tsx` ↔ `TriggerFormPanel.tsx` (via the `Trigger` type)
2. `AssetsContent.tsx` ↔ `AssetPreviewModal.tsx` (via the `Asset` type)
3. `McpServersContent.tsx` ↔ `ConnectorUpdateModal.tsx`
4. `McpServersContent.tsx` ↔ `ServerHealthIcons.tsx`
5. `McpServersContent.tsx` → `ServerHealthIcons.tsx` → `serverHealth.ts` (back to `McpServersContent.tsx`)
6. `McpServersContent.tsx` ↔ `ToolDriftModal.tsx`

(3–6 are all the same `McpServer` type import.)

## Fix

Extracted the shared type into a sibling `types.ts` in each directory
(`McpServer`, `Trigger`, `Asset`/`AssetVersion`), and re-exported it from
the original component file so existing external consumers didn't need to
change their import paths.

`madge --circular` now reports zero cycles. `tsc`, `eslint`, and the
affected vitest suites (13 files / 280 tests) all pass.

## Test plan

- [x] `npx madge --circular` → no circular dependency found
- [x] `npx tsc` → clean
- [x] `eslint` on touched dirs → clean
- [x] `vitest run` on touched dirs → 280/280 passing

https://claude.ai/code/session_01XZaA8zqV7YAHL4zVj7KKKM