### PR TITLE
refactor(frontend): extract duplicated helpers into shared modules

### DIFF
--- a/app/frontend/pages/Company/Analytics/AnalyticsPage.tsx
+++ b/app/frontend/pages/Company/Analytics/AnalyticsPage.tsx
@@ -1,7 +1,7 @@
 import { Deferred, Head, router, usePage } from '@inertiajs/react';
 import { Box, Grid, Group, Paper, SegmentedControl, Select, SimpleGrid, Skeleton, Text } from '@mantine/core';
 import { IconChartBar, IconClock, IconCoin, IconPlayerPlay, IconRoute } from '@tabler/icons-react';
-import { type CSSProperties, type ReactNode, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Area,
   AreaChart,
@@ -19,15 +19,29 @@ import {
 
 import { AuthLayout } from 'layouts/AuthLayout';
 
-import { LOGO_TILE_BG } from 'shared/theme/vendorColors';
-import claudeLogo from 'shared/ui/agent-logos/claude.png';
-import codexLogo from 'shared/ui/agent-logos/codex.png';
-import cursorLogo from 'shared/ui/agent-logos/cursor.png';
-import geminiLogo from 'shared/ui/agent-logos/gemini.png';
+import {
+  AgentLogo,
+  buildActivityChartData,
+  centerLabelFontSize,
+  CHART_ACCENT,
+  CHART_NEUTRAL,
+  CHART_TAUPE,
+  ChartSkeleton,
+  chartTooltipStyle,
+  formatAxisDate,
+  getAgentColor,
+  type AgentActivityData,
+  type Period,
+  PERIOD_OPTIONS,
+  ScopeBadge,
+  sharePct,
+  SummarySkeletons,
+  tickIntervalForPeriod,
+} from 'shared/analytics/chartHelpers';
+import { formatCostCents, formatTokens } from 'shared/lib/formatUsage';
 import { PageHeader } from 'shared/ui/PageHeader';
 
 type Scope = 'company' | 'user';
-type Period = '7d' | '30d' | '90d' | '1y';
 type UsageScope = 'all' | 'workflows';
 
 interface ProjectBreakdown {
@@ -45,23 +59,6 @@ interface SummaryData {
   avgCostCentsPerSession: number;
   workflowsRun: number;
   projectBreakdowns: ProjectBreakdown[];
-}
-
-interface AgentSessionCount {
-  agentType: string;
-  sessions: number;
-  costCents: number;
-  tokens: number;
-}
-interface AgentActivityPoint {
-  date: string;
-  agentType: string;
-  sessions: number;
-}
-interface AgentActivityData {
-  agentTypes: string[];
-  sessionsByAgent: AgentSessionCount[];
-  activityOverTime: AgentActivityPoint[];
 }
 
 interface SourceRow {
@@ -99,200 +96,8 @@ interface Props {
   workflowCosts?: WorkflowCostData;
 }
 
-// Warm chart-series palette. Primary = accent; everything else is a warm neutral ramp.
-// Identity on agent charts is carried by logo + label; color is a secondary cue.
-// Falls back to the always-defined semantic token when `--accent` hasn't been set by
-// the current page (it's only ever defined by the Workflow Builder's stylesheet).
-const CHART_ACCENT = 'var(--accent, var(--app-primary))';
-const CHART_TAUPE = 'var(--app-chart-warm-1)';
-const CHART_NEUTRAL = 'var(--app-text-tertiary)';
-
-const AGENT_COLOR: Record<string, string> = {
-  claude_code: CHART_ACCENT,
-  cursor: 'var(--app-chart-warm-2)',
-  cursor_cli: 'var(--app-chart-warm-2)',
-  codex: 'var(--app-chart-warm-1)',
-  gemini: 'var(--app-chart-warm-3)',
-  gemini_cli: 'var(--app-chart-warm-3)',
-  // No xAI artwork ships in this repo, so a Grok row renders the neutral chip
-  // AgentLogo falls back to; naming it here keeps the runtime known, not unmapped.
-  grok: CHART_NEUTRAL,
-};
-
-const getAgentColor = (agentType: string): string => AGENT_COLOR[agentType] ?? CHART_NEUTRAL;
-
-const AGENT_LOGO_SRC: Record<string, string> = {
-  claude_code: claudeLogo,
-  cursor: cursorLogo,
-  cursor_cli: cursorLogo,
-  codex: codexLogo,
-  gemini: geminiLogo,
-  gemini_cli: geminiLogo,
-};
-
-function agentLogoChipStyle(agentType: string, size: number): CSSProperties {
-  const base: CSSProperties = {
-    width: size,
-    height: size,
-    borderRadius: 5,
-    flexShrink: 0,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  };
-
-  if (agentType === 'codex') {
-    return { ...base, backgroundColor: LOGO_TILE_BG.light };
-  }
-  if (agentType === 'gemini' || agentType === 'gemini_cli') {
-    return { ...base, backgroundColor: LOGO_TILE_BG.dark, border: '1px solid var(--app-border-default)' };
-  }
-  return base;
-}
-
-function agentLogoImageSize(agentType: string, chipSize: number): number {
-  if (agentType === 'codex') return Math.round(chipSize * (13 / 18));
-  if (agentType === 'gemini' || agentType === 'gemini_cli') return Math.round(chipSize * (12 / 18));
-  return chipSize;
-}
-
-// Agent brand mark; falls back to a rounded color chip for unrecognized agent types.
-function AgentLogo({ agentType, size = 18 }: { agentType: string; size?: number }) {
-  const src = AGENT_LOGO_SRC[agentType];
-  if (src) {
-    const imageSize = agentLogoImageSize(agentType, size);
-    return (
-      <Box data-testid="agent-logo" style={agentLogoChipStyle(agentType, size)}>
-        <Box component="img" src={src} alt={agentType} w={imageSize} h={imageSize} style={{ objectFit: 'contain' }} />
-      </Box>
-    );
-  }
-  return (
-    <Box
-      data-testid="agent-logo"
-      w={size}
-      h={size}
-      style={{ borderRadius: 5, backgroundColor: getAgentColor(agentType), flexShrink: 0 }}
-    />
-  );
-}
-
-// Scales down as the digit count grows so a future 6-7 digit total still fits the donut hole.
-function centerLabelFontSize(value: number): number {
-  const digits = String(Math.trunc(value)).length;
-  if (digits >= 7) return 12;
-  if (digits >= 6) return 13;
-  if (digits >= 5) return 15;
-  return 18;
-}
-
-function sharePct(count: number, total: number): number {
-  return total > 0 ? Math.round((count / total) * 100) : 0;
-}
-
-// Small uppercase pill used to show the active data scope in a chart card's corner.
-function ScopeBadge({ children }: { children: string }) {
-  return (
-    <Text
-      c="dimmed"
-      fw={600}
-      tt="uppercase"
-      style={{
-        fontSize: 10,
-        letterSpacing: '0.05em',
-        padding: '2px 8px',
-        borderRadius: 4,
-        border: '1px solid var(--app-border-default)',
-        backgroundColor: 'var(--app-bg-elevated)',
-      }}
-    >
-      {children}
-    </Text>
-  );
-}
-
-const PERIOD_OPTIONS = [
-  { value: '7d', label: 'Last 7 days' },
-  { value: '30d', label: 'Last 30 days' },
-  { value: '90d', label: 'Last 90 days' },
-  { value: '1y', label: 'Last year' },
-];
-
-const chartTooltipStyle = {
-  backgroundColor: 'var(--app-bg-default)',
-  border: '1px solid var(--app-border-default)',
-  borderRadius: 8,
-  fontSize: 12,
-  color: 'var(--app-text-primary)',
-};
-
-function formatCostCents(cents: number): string {
-  const d = (cents ?? 0) / 100;
-  if (d >= 1000) return `$${(d / 1000).toFixed(1)}k`;
-  return `$${d.toFixed(2)}`;
-}
-
-function formatTokens(n: number): string {
-  if (!n) return '0';
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return String(n);
-}
-
-function buildActivityChartData(data: AgentActivityData): Record<string, string | number>[] {
-  // Group by the raw ISO date (unambiguously sortable) rather than the display label,
-  // so the chart stays chronological regardless of the input array's row order.
-  const dateMap = new Map<string, Record<string, string | number>>();
-  for (const point of data.activityOverTime) {
-    if (!dateMap.has(point.date)) dateMap.set(point.date, { date: point.date });
-    dateMap.get(point.date)![point.agentType] = point.sessions;
-  }
-  // The backend only emits a (date, agentType) row when that agent had ≥1 session that
-  // day, so most rows are missing most agent keys. Recharts treats a missing key as a
-  // gap (not 0) and doesn't connect across it, which fragments each agent's line into
-  // disconnected flat segments instead of a continuous trend. Zero-fill every known
-  // agent type on every date that has data for *some* agent, so each line spans the
-  // full visible range and actually dips to 0 on its quiet days.
-  return Array.from(dateMap.keys())
-    .sort()
-    .map((iso) => {
-      const row = dateMap.get(iso)!;
-      const filled: Record<string, string | number> = { date: iso };
-      for (const agentType of data.agentTypes) filled[agentType] = row[agentType] ?? 0;
-      return { ...filled, date: new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) };
-    });
-}
-
-function formatAxisDate(iso: string | number | ReactNode): string {
-  return new Date(String(iso)).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-}
-
-function tickIntervalForPeriod(period: Period): number {
-  const days = period === '7d' ? 7 : period === '30d' ? 30 : period === '90d' ? 90 : 365;
-  return days <= 7 ? 0 : days <= 30 ? 4 : days <= 90 ? 9 : 29;
-}
-
 function navigateWithFilters(scope: string, period: string) {
   router.get(window.location.pathname, { scope, period }, { preserveState: true, preserveScroll: true });
-}
-
-// --- Skeleton blocks ---
-
-function SummarySkeletons() {
-  return (
-    <>
-      {Array.from({ length: 5 }).map((_, i) => (
-        <Paper key={i} withBorder px={20} py={18} radius="md" bg="var(--app-bg-card)">
-          <Skeleton height={12} width={100} mb={12} />
-          <Skeleton height={24} width={70} />
-        </Paper>
-      ))}
-    </>
-  );
-}
-
-function ChartSkeleton({ height = 240 }: { height?: number }) {
-  return <Skeleton height={height} radius="sm" />;
 }
 
 // --- Data panels ---

--- a/app/frontend/pages/Profile/Show.tsx
+++ b/app/frontend/pages/Profile/Show.tsx
@@ -32,6 +32,8 @@ import { AuthLayout } from 'layouts/AuthLayout';
 
 import { getConsumer } from 'shared/lib/actionCableConsumer';
 import { apiFetch } from 'shared/lib/apiFetch';
+import { formatDateMedium } from 'shared/lib/formatDate';
+import { getInitials } from 'shared/lib/getInitials';
 import { useInertiaCableStream } from 'shared/lib/hooks/useInertiaCableStream';
 import { AwsConnectionModal } from 'shared/resources/cloud-connections/AwsConnectionModal';
 import {
@@ -123,11 +125,6 @@ const AGENT_STATUS_BADGE: Record<AgentCredential['connectionStatus'], { tone: St
   active: { tone: 'success', label: 'Connected' },
   expiring: { tone: 'warning', label: 'Expiring soon' },
   expired: { tone: 'danger', label: 'Expired' },
-};
-
-const formatDate = (d: string | null) => {
-  if (!d) return '';
-  return new Date(d).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
 };
 
 const getAgentInfo = (type: AgentType) => AVAILABLE_AGENTS.find((a) => a.type === type)!;
@@ -323,18 +320,6 @@ function AgentDefaultsSection({ profile, agentModels }: { profile: SharedUser; a
       </Stack>
     </Card>
   );
-}
-
-// "Acme Robotics" -> "AR". Duplicated locally rather than shared: the same
-// small helper is copy-pasted across AppSidebar/MembersContent/etc rather
-// than centralized, so this follows the existing pattern.
-function getInitials(name: string): string {
-  const parts = name.trim().split(/\s+/);
-  return parts
-    .slice(0, 2)
-    .map((w) => w[0])
-    .join('')
-    .toUpperCase();
 }
 
 function CompaniesSection({
@@ -935,9 +920,9 @@ function AgentRuntimesSection({ profile }: { profile: SharedUser }) {
                   </Text>
                   {isConfigured && credential && (
                     <Text size="xs" c="dimmed" mt={4}>
-                      Configured {formatDate(credential.createdAt)}
-                      {credential.lastUsedAt && ` · Last used ${formatDate(credential.lastUsedAt)}`}
-                      {credential.expiresAt && ` · Expires ${formatDate(credential.expiresAt)}`}
+                      Configured {formatDateMedium(credential.createdAt)}
+                      {credential.lastUsedAt && ` · Last used ${formatDateMedium(credential.lastUsedAt)}`}
+                      {credential.expiresAt && ` · Expires ${formatDateMedium(credential.expiresAt)}`}
                     </Text>
                   )}
                   {/* Billing target lives in the card body, not among the action buttons: it is

--- a/app/frontend/pages/Profile/Usage.tsx
+++ b/app/frontend/pages/Profile/Usage.tsx
@@ -33,6 +33,7 @@ import {
 
 import { AuthLayout } from 'layouts/AuthLayout';
 
+import { formatCostCents, formatTokens } from 'shared/lib/formatUsage';
 import { CHART_SERIES } from 'shared/theme/chartPalette';
 import { type SharedProps } from 'shared/ui';
 import { ContributionHeatmap } from 'shared/ui/ContributionHeatmap';
@@ -150,19 +151,6 @@ const chartTooltipStyle = {
   fontSize: 12,
   color: 'var(--app-text-primary)',
 };
-
-function formatCostCents(cents: number): string {
-  const d = (cents ?? 0) / 100;
-  if (d >= 1000) return `$${(d / 1000).toFixed(1)}k`;
-  return `$${d.toFixed(2)}`;
-}
-
-function formatTokens(n: number): string {
-  if (!n) return '0';
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return String(n);
-}
 
 function tickIntervalForPeriod(period: Period): number {
   const days = period === '7d' ? 7 : period === '30d' ? 30 : period === '90d' ? 90 : 365;

--- a/app/frontend/pages/Projects/Analytics/AnalyticsPage.tsx
+++ b/app/frontend/pages/Projects/Analytics/AnalyticsPage.tsx
@@ -12,7 +12,7 @@ import {
   IconRobot,
   IconRoute,
 } from '@tabler/icons-react';
-import { type ComponentType, type CSSProperties, type ReactNode, useEffect, useMemo, useState } from 'react';
+import { type ComponentType, type ReactNode, useEffect, useMemo, useState } from 'react';
 import {
   Area,
   AreaChart,
@@ -30,11 +30,26 @@ import {
   YAxis,
 } from 'recharts';
 
-import { LOGO_TILE_BG } from 'shared/theme/vendorColors';
-import claudeLogo from 'shared/ui/agent-logos/claude.png';
-import codexLogo from 'shared/ui/agent-logos/codex.png';
-import cursorLogo from 'shared/ui/agent-logos/cursor.png';
-import geminiLogo from 'shared/ui/agent-logos/gemini.png';
+import {
+  AgentLogo,
+  buildActivityChartData,
+  centerLabelFontSize,
+  CHART_ACCENT,
+  CHART_NEUTRAL,
+  CHART_TAUPE,
+  ChartSkeleton,
+  chartTooltipStyle,
+  formatAxisDate,
+  getAgentColor,
+  type AgentActivityData,
+  type Period,
+  PERIOD_OPTIONS,
+  ScopeBadge,
+  sharePct,
+  SummarySkeletons,
+  tickIntervalForPeriod,
+} from 'shared/analytics/chartHelpers';
+import { formatCostCents, formatTokens } from 'shared/lib/formatUsage';
 import { ContributionHeatmap } from 'shared/ui/ContributionHeatmap';
 import { PageHeader } from 'shared/ui/PageHeader';
 
@@ -56,7 +71,6 @@ interface HeatmapData {
 }
 
 type Scope = 'project' | 'user';
-type Period = '7d' | '30d' | '90d' | '1y';
 type UsageScope = 'all' | 'workflows';
 
 interface SummaryData {
@@ -65,23 +79,6 @@ interface SummaryData {
   totalTokens: number;
   avgCostCentsPerSession: number;
   workflowsRun: number;
-}
-
-interface AgentSessionCount {
-  agentType: string;
-  sessions: number;
-  costCents: number;
-  tokens: number;
-}
-interface AgentActivityPoint {
-  date: string;
-  agentType: string;
-  sessions: number;
-}
-interface AgentActivityData {
-  agentTypes: string[];
-  sessionsByAgent: AgentSessionCount[];
-  activityOverTime: AgentActivityPoint[];
 }
 
 interface SourceRow {
@@ -151,88 +148,10 @@ interface Props {
   activityHeatmap?: HeatmapData;
 }
 
-// Warm chart-series palette. Primary = accent; everything else is a warm neutral ramp.
-// Identity on agent charts is carried by logo + label; color is a secondary cue.
-// Falls back to the always-defined semantic token when `--accent` hasn't been set by
-// the current page (it's only ever defined by the Workflow Builder's stylesheet).
-const CHART_ACCENT = 'var(--accent, var(--app-primary))';
-const CHART_TAUPE = 'var(--app-chart-warm-1)';
-const CHART_NEUTRAL = 'var(--app-text-tertiary)';
-
-const AGENT_COLOR: Record<string, string> = {
-  claude_code: CHART_ACCENT,
-  cursor: 'var(--app-chart-warm-2)',
-  cursor_cli: 'var(--app-chart-warm-2)',
-  codex: 'var(--app-chart-warm-1)',
-  gemini: 'var(--app-chart-warm-3)',
-  gemini_cli: 'var(--app-chart-warm-3)',
-  // No xAI artwork ships in this repo, so a Grok row renders the neutral chip
-  // AgentLogo falls back to; naming it here keeps the runtime known, not unmapped.
-  grok: CHART_NEUTRAL,
-};
-
-const getAgentColor = (agentType: string): string => AGENT_COLOR[agentType] ?? CHART_NEUTRAL;
-
 // Same warm rota as AGENT_COLOR, applied by rank (highest-cost workflow first) so the
 // per-workflow dot/bar/progress-bar color stays consistent across the table and both charts.
 const WORKFLOW_PALETTE = [CHART_ACCENT, CHART_TAUPE, 'var(--app-chart-warm-2)', 'var(--app-chart-warm-3)'];
 const getWorkflowColor = (index: number): string => WORKFLOW_PALETTE[index % WORKFLOW_PALETTE.length];
-
-const AGENT_LOGO_SRC: Record<string, string> = {
-  claude_code: claudeLogo,
-  cursor: cursorLogo,
-  cursor_cli: cursorLogo,
-  codex: codexLogo,
-  gemini: geminiLogo,
-  gemini_cli: geminiLogo,
-};
-
-function agentLogoChipStyle(agentType: string, size: number): CSSProperties {
-  const base: CSSProperties = {
-    width: size,
-    height: size,
-    borderRadius: 5,
-    flexShrink: 0,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  };
-
-  if (agentType === 'codex') {
-    return { ...base, backgroundColor: LOGO_TILE_BG.light };
-  }
-  if (agentType === 'gemini' || agentType === 'gemini_cli') {
-    return { ...base, backgroundColor: LOGO_TILE_BG.dark, border: '1px solid var(--app-border-default)' };
-  }
-  return base;
-}
-
-function agentLogoImageSize(agentType: string, chipSize: number): number {
-  if (agentType === 'codex') return Math.round(chipSize * (13 / 18));
-  if (agentType === 'gemini' || agentType === 'gemini_cli') return Math.round(chipSize * (12 / 18));
-  return chipSize;
-}
-
-// Agent brand mark; falls back to a rounded color chip for unrecognized agent types.
-function AgentLogo({ agentType, size = 18 }: { agentType: string; size?: number }) {
-  const src = AGENT_LOGO_SRC[agentType];
-  if (src) {
-    const imageSize = agentLogoImageSize(agentType, size);
-    return (
-      <Box data-testid="agent-logo" style={agentLogoChipStyle(agentType, size)}>
-        <Box component="img" src={src} alt={agentType} w={imageSize} h={imageSize} style={{ objectFit: 'contain' }} />
-      </Box>
-    );
-  }
-  return (
-    <Box
-      data-testid="agent-logo"
-      w={size}
-      h={size}
-      style={{ borderRadius: 5, backgroundColor: getAgentColor(agentType), flexShrink: 0 }}
-    />
-  );
-}
 
 // Section heading with a leading muted icon, matching the design's `sec-head` pattern.
 // `right` renders an optional control (e.g. a scope switcher) flush to the right edge.
@@ -259,67 +178,6 @@ function SectionHeading({
 }
 
 // Small uppercase pill used to show the active data scope in a chart card's corner.
-function ScopeBadge({ children }: { children: ReactNode }) {
-  return (
-    <Text
-      c="dimmed"
-      fw={600}
-      tt="uppercase"
-      style={{
-        fontSize: 10,
-        letterSpacing: '0.05em',
-        padding: '2px 8px',
-        borderRadius: 4,
-        border: '1px solid var(--app-border-default)',
-        backgroundColor: 'var(--app-bg-elevated)',
-      }}
-    >
-      {children}
-    </Text>
-  );
-}
-
-const PERIOD_OPTIONS = [
-  { value: '7d', label: 'Last 7 days' },
-  { value: '30d', label: 'Last 30 days' },
-  { value: '90d', label: 'Last 90 days' },
-  { value: '1y', label: 'Last year' },
-];
-
-const chartTooltipStyle = {
-  backgroundColor: 'var(--app-bg-default)',
-  border: '1px solid var(--app-border-default)',
-  borderRadius: 8,
-  fontSize: 12,
-  color: 'var(--app-text-primary)',
-};
-
-function formatCostCents(cents: number): string {
-  const d = (cents ?? 0) / 100;
-  if (d >= 1000) return `$${(d / 1000).toFixed(1)}k`;
-  return `$${d.toFixed(2)}`;
-}
-
-function formatTokens(n: number): string {
-  if (!n) return '0';
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return String(n);
-}
-
-// Scales down as the digit count grows so a future 6-7 digit total still fits the donut hole.
-function centerLabelFontSize(value: number): number {
-  const digits = String(Math.trunc(value)).length;
-  if (digits >= 7) return 12;
-  if (digits >= 6) return 13;
-  if (digits >= 5) return 15;
-  return 18;
-}
-
-function sharePct(count: number, total: number): number {
-  return total > 0 ? Math.round((count / total) * 100) : 0;
-}
-
 function formatDuration(seconds: number): string {
   if (!seconds || seconds <= 0) return '0s';
   const h = Math.floor(seconds / 3600);
@@ -328,39 +186,6 @@ function formatDuration(seconds: number): string {
   if (h > 0) return `${h}h ${m}m`;
   if (m > 0) return `${m}m ${s}s`;
   return `${s}s`;
-}
-
-function buildActivityChartData(data: AgentActivityData): Record<string, string | number>[] {
-  // Group by the raw ISO date (unambiguously sortable) rather than the display label,
-  // so the chart stays chronological regardless of the input array's row order.
-  const dateMap = new Map<string, Record<string, string | number>>();
-  for (const point of data.activityOverTime) {
-    if (!dateMap.has(point.date)) dateMap.set(point.date, { date: point.date });
-    dateMap.get(point.date)![point.agentType] = point.sessions;
-  }
-  // The backend only emits a (date, agentType) row when that agent had ≥1 session that
-  // day, so most rows are missing most agent keys. Recharts treats a missing key as a
-  // gap (not 0) and doesn't connect across it, which fragments each agent's line into
-  // disconnected flat segments instead of a continuous trend. Zero-fill every known
-  // agent type on every date that has data for *some* agent, so each line spans the
-  // full visible range and actually dips to 0 on its quiet days.
-  return Array.from(dateMap.keys())
-    .sort()
-    .map((iso) => {
-      const row = dateMap.get(iso)!;
-      const filled: Record<string, string | number> = { date: iso };
-      for (const agentType of data.agentTypes) filled[agentType] = row[agentType] ?? 0;
-      return { ...filled, date: new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) };
-    });
-}
-
-function formatAxisDate(iso: string | number | ReactNode): string {
-  return new Date(String(iso)).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-}
-
-function tickIntervalForPeriod(period: Period): number {
-  const days = period === '7d' ? 7 : period === '30d' ? 30 : period === '90d' ? 90 : 365;
-  return days <= 7 ? 0 : days <= 30 ? 4 : days <= 90 ? 9 : 29;
 }
 
 function navigateWithFilters(scope: string, period: string, participantId?: string | null) {
@@ -372,23 +197,6 @@ function navigateWithFilters(scope: string, period: string, participantId?: stri
 }
 
 // --- Skeleton blocks for deferred fallbacks ---
-
-function SummarySkeletons() {
-  return (
-    <>
-      {Array.from({ length: 5 }).map((_, i) => (
-        <Paper key={i} withBorder px={20} py={18} radius="md" bg="var(--app-bg-card)">
-          <Skeleton height={12} width={100} mb={12} />
-          <Skeleton height={24} width={70} />
-        </Paper>
-      ))}
-    </>
-  );
-}
-
-function ChartSkeleton({ height = 240 }: { height?: number }) {
-  return <Skeleton height={height} radius="sm" />;
-}
 
 function WorkflowCostSkeletons() {
   return (

--- a/app/frontend/pages/Projects/Members/MembersPage.tsx
+++ b/app/frontend/pages/Projects/Members/MembersPage.tsx
@@ -4,6 +4,7 @@ import { modals } from '@mantine/modals';
 import { IconCrown, IconPlus, IconSearch, IconTrash, IconUsers } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
 
+import { getInitials } from 'shared/lib/getInitials';
 import { EmptyState } from 'shared/ui/EmptyState';
 import { PageHeader } from 'shared/ui/PageHeader';
 import { ResourceDrawer } from 'shared/ui/ResourceDrawer';
@@ -30,14 +31,6 @@ interface Props {
   companyUsers: User[];
   ownerId: number;
 }
-
-const getInitials = (name: string) =>
-  name
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 2);
 
 const MembersPage = () => {
   const { project, members, companyUsers, ownerId } = usePage<{ props: Props }>().props as unknown as Props;

--- a/app/frontend/pages/Projects/Workflows/TriggerFormPanel.tsx
+++ b/app/frontend/pages/Projects/Workflows/TriggerFormPanel.tsx
@@ -4,6 +4,7 @@ import cronstrue from 'cronstrue';
 import { useCallback, useState } from 'react';
 
 import { apiFetch } from 'shared/lib/apiFetch';
+import { TIMEZONE_OPTIONS } from 'shared/lib/timezones';
 import { apiV1ProjectWorkflowTriggerPath, apiV1ProjectWorkflowTriggersPath } from 'shared/routes';
 
 import type { Trigger } from './TriggersTab';
@@ -31,30 +32,6 @@ interface TriggerFormPanelProps {
 }
 
 type Kind = 'column' | 'slack' | 'webhook' | 'schedule';
-
-const IANA_TIMEZONES: string[] = (() => {
-  try {
-    const intl = Intl as typeof Intl & { supportedValuesOf?: (key: string) => string[] };
-    return intl.supportedValuesOf?.('timeZone') ?? ['UTC'];
-  } catch {
-    return ['UTC'];
-  }
-})();
-
-function tzLabel(tz: string): string {
-  try {
-    const raw =
-      new Intl.DateTimeFormat('en-US', { timeZone: tz, timeZoneName: 'longOffset' })
-        .formatToParts(new Date())
-        .find((p) => p.type === 'timeZoneName')?.value ?? 'GMT';
-    const offset = raw === 'GMT' ? 'UTC+00:00' : raw.replace('GMT', 'UTC');
-    return `${tz} (${offset})`;
-  } catch {
-    return tz;
-  }
-}
-
-const TIMEZONE_OPTIONS = IANA_TIMEZONES.map((tz) => ({ value: tz, label: tzLabel(tz) }));
 
 function describeCron(expr: string): { ok: boolean; text: string } {
   const value = expr.trim();

--- a/app/frontend/pages/Projects/Workflows/WorkflowTriggersDrawer.tsx
+++ b/app/frontend/pages/Projects/Workflows/WorkflowTriggersDrawer.tsx
@@ -34,6 +34,7 @@ import cronstrue from 'cronstrue';
 import { useCallback, useEffect, useState } from 'react';
 
 import { apiFetch } from 'shared/lib/apiFetch';
+import { TIMEZONE_OPTIONS } from 'shared/lib/timezones';
 import { apiV1ProjectWorkflowTriggerPath, apiV1ProjectWorkflowTriggersPath } from 'shared/routes';
 
 interface ColumnOption {
@@ -76,32 +77,6 @@ const KIND_META: Record<string, { label: string; color: string; icon: typeof Ico
   schedule: { label: 'Schedule', color: 'green', icon: IconBolt },
   event: { label: 'Event', color: 'blue', icon: IconBolt },
 };
-
-// IANA timezone list from the runtime (falls back to UTC if unsupported).
-const TIMEZONES: string[] = (() => {
-  try {
-    const intl = Intl as typeof Intl & { supportedValuesOf?: (key: string) => string[] };
-    return intl.supportedValuesOf?.('timeZone') ?? ['UTC'];
-  } catch {
-    return ['UTC'];
-  }
-})();
-
-// Append the current UTC offset to a timezone, e.g. "Europe/Belgrade (UTC+02:00)".
-function tzLabel(tz: string): string {
-  try {
-    const raw =
-      new Intl.DateTimeFormat('en-US', { timeZone: tz, timeZoneName: 'longOffset' })
-        .formatToParts(new Date())
-        .find((p) => p.type === 'timeZoneName')?.value ?? 'GMT';
-    const offset = raw === 'GMT' ? 'UTC+00:00' : raw.replace('GMT', 'UTC');
-    return `${tz} (${offset})`;
-  } catch {
-    return tz;
-  }
-}
-
-const TIMEZONE_OPTIONS = TIMEZONES.map((tz) => ({ value: tz, label: tzLabel(tz) }));
 
 // Human-readable description of a cron expression (e.g. "At 09:00, Monday through Friday").
 function describeCron(expr: string): { ok: boolean; text: string } {

--- a/app/frontend/shared/analytics/chartHelpers.tsx
+++ b/app/frontend/shared/analytics/chartHelpers.tsx
@@ -1,0 +1,204 @@
+import { Box, Paper, Skeleton, Text } from '@mantine/core';
+import { type CSSProperties, type ReactNode } from 'react';
+
+import { LOGO_TILE_BG } from 'shared/theme/vendorColors';
+import claudeLogo from 'shared/ui/agent-logos/claude.png';
+import codexLogo from 'shared/ui/agent-logos/codex.png';
+import cursorLogo from 'shared/ui/agent-logos/cursor.png';
+import geminiLogo from 'shared/ui/agent-logos/gemini.png';
+
+export type Period = '7d' | '30d' | '90d' | '1y';
+
+export interface AgentSessionCount {
+  agentType: string;
+  sessions: number;
+  costCents: number;
+  tokens: number;
+}
+export interface AgentActivityPoint {
+  date: string;
+  agentType: string;
+  sessions: number;
+}
+export interface AgentActivityData {
+  agentTypes: string[];
+  sessionsByAgent: AgentSessionCount[];
+  activityOverTime: AgentActivityPoint[];
+}
+
+// Warm chart-series palette. Primary = accent; everything else is a warm neutral ramp.
+// Identity on agent charts is carried by logo + label; color is a secondary cue.
+// Falls back to the always-defined semantic token when `--accent` hasn't been set by
+// the current page (it's only ever defined by the Workflow Builder's stylesheet).
+export const CHART_ACCENT = 'var(--accent, var(--app-primary))';
+export const CHART_TAUPE = 'var(--app-chart-warm-1)';
+export const CHART_NEUTRAL = 'var(--app-text-tertiary)';
+
+const AGENT_COLOR: Record<string, string> = {
+  claude_code: CHART_ACCENT,
+  cursor: 'var(--app-chart-warm-2)',
+  cursor_cli: 'var(--app-chart-warm-2)',
+  codex: 'var(--app-chart-warm-1)',
+  gemini: 'var(--app-chart-warm-3)',
+  gemini_cli: 'var(--app-chart-warm-3)',
+  // No xAI artwork ships in this repo, so a Grok row renders the neutral chip
+  // AgentLogo falls back to; naming it here keeps the runtime known, not unmapped.
+  grok: CHART_NEUTRAL,
+};
+
+export const getAgentColor = (agentType: string): string => AGENT_COLOR[agentType] ?? CHART_NEUTRAL;
+
+const AGENT_LOGO_SRC: Record<string, string> = {
+  claude_code: claudeLogo,
+  cursor: cursorLogo,
+  cursor_cli: cursorLogo,
+  codex: codexLogo,
+  gemini: geminiLogo,
+  gemini_cli: geminiLogo,
+};
+
+function agentLogoChipStyle(agentType: string, size: number): CSSProperties {
+  const base: CSSProperties = {
+    width: size,
+    height: size,
+    borderRadius: 5,
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  };
+
+  if (agentType === 'codex') {
+    return { ...base, backgroundColor: LOGO_TILE_BG.light };
+  }
+  if (agentType === 'gemini' || agentType === 'gemini_cli') {
+    return { ...base, backgroundColor: LOGO_TILE_BG.dark, border: '1px solid var(--app-border-default)' };
+  }
+  return base;
+}
+
+function agentLogoImageSize(agentType: string, chipSize: number): number {
+  if (agentType === 'codex') return Math.round(chipSize * (13 / 18));
+  if (agentType === 'gemini' || agentType === 'gemini_cli') return Math.round(chipSize * (12 / 18));
+  return chipSize;
+}
+
+// Agent brand mark; falls back to a rounded color chip for unrecognized agent types.
+export function AgentLogo({ agentType, size = 18 }: { agentType: string; size?: number }) {
+  const src = AGENT_LOGO_SRC[agentType];
+  if (src) {
+    const imageSize = agentLogoImageSize(agentType, size);
+    return (
+      <Box data-testid="agent-logo" style={agentLogoChipStyle(agentType, size)}>
+        <Box component="img" src={src} alt={agentType} w={imageSize} h={imageSize} style={{ objectFit: 'contain' }} />
+      </Box>
+    );
+  }
+  return (
+    <Box
+      data-testid="agent-logo"
+      w={size}
+      h={size}
+      style={{ borderRadius: 5, backgroundColor: getAgentColor(agentType), flexShrink: 0 }}
+    />
+  );
+}
+
+// Small uppercase pill used to show the active data scope in a chart card's corner.
+export function ScopeBadge({ children }: { children: ReactNode }) {
+  return (
+    <Text
+      c="dimmed"
+      fw={600}
+      tt="uppercase"
+      style={{
+        fontSize: 10,
+        letterSpacing: '0.05em',
+        padding: '2px 8px',
+        borderRadius: 4,
+        border: '1px solid var(--app-border-default)',
+        backgroundColor: 'var(--app-bg-elevated)',
+      }}
+    >
+      {children}
+    </Text>
+  );
+}
+
+export const PERIOD_OPTIONS = [
+  { value: '7d', label: 'Last 7 days' },
+  { value: '30d', label: 'Last 30 days' },
+  { value: '90d', label: 'Last 90 days' },
+  { value: '1y', label: 'Last year' },
+];
+
+export const chartTooltipStyle = {
+  backgroundColor: 'var(--app-bg-default)',
+  border: '1px solid var(--app-border-default)',
+  borderRadius: 8,
+  fontSize: 12,
+  color: 'var(--app-text-primary)',
+};
+
+// Scales down as the digit count grows so a future 6-7 digit total still fits the donut hole.
+export function centerLabelFontSize(value: number): number {
+  const digits = String(Math.trunc(value)).length;
+  if (digits >= 7) return 12;
+  if (digits >= 6) return 13;
+  if (digits >= 5) return 15;
+  return 18;
+}
+
+export function sharePct(count: number, total: number): number {
+  return total > 0 ? Math.round((count / total) * 100) : 0;
+}
+
+export function tickIntervalForPeriod(period: Period): number {
+  const days = period === '7d' ? 7 : period === '30d' ? 30 : period === '90d' ? 90 : 365;
+  return days <= 7 ? 0 : days <= 30 ? 4 : days <= 90 ? 9 : 29;
+}
+
+export function formatAxisDate(iso: string | number | ReactNode): string {
+  return new Date(String(iso)).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+export function SummarySkeletons() {
+  return (
+    <>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <Paper key={i} withBorder px={20} py={18} radius="md" bg="var(--app-bg-card)">
+          <Skeleton height={12} width={100} mb={12} />
+          <Skeleton height={24} width={70} />
+        </Paper>
+      ))}
+    </>
+  );
+}
+
+export function ChartSkeleton({ height = 240 }: { height?: number }) {
+  return <Skeleton height={height} radius="sm" />;
+}
+
+export function buildActivityChartData(data: AgentActivityData): Record<string, string | number>[] {
+  // Group by the raw ISO date (unambiguously sortable) rather than the display label,
+  // so the chart stays chronological regardless of the input array's row order.
+  const dateMap = new Map<string, Record<string, string | number>>();
+  for (const point of data.activityOverTime) {
+    if (!dateMap.has(point.date)) dateMap.set(point.date, { date: point.date });
+    dateMap.get(point.date)![point.agentType] = point.sessions;
+  }
+  // The backend only emits a (date, agentType) row when that agent had ≥1 session that
+  // day, so most rows are missing most agent keys. Recharts treats a missing key as a
+  // gap (not 0) and doesn't connect across it, which fragments each agent's line into
+  // disconnected flat segments instead of a continuous trend. Zero-fill every known
+  // agent type on every date that has data for *some* agent, so each line spans the
+  // full visible range and actually dips to 0 on its quiet days.
+  return Array.from(dateMap.keys())
+    .sort()
+    .map((iso) => {
+      const row = dateMap.get(iso)!;
+      const filled: Record<string, string | number> = { date: iso };
+      for (const agentType of data.agentTypes) filled[agentType] = row[agentType] ?? 0;
+      return { ...filled, date: new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) };
+    });
+}

--- a/app/frontend/shared/lib/formatDate.ts
+++ b/app/frontend/shared/lib/formatDate.ts
@@ -28,3 +28,9 @@ export function formatTime(value: string | null | undefined): string {
   const d = parseDate(value);
   return d ? d.toLocaleTimeString() : '—';
 }
+
+/** e.g. "Feb 28, 2026" */
+export function formatDateMedium(value: string | null | undefined): string {
+  const d = parseDate(value);
+  return d ? d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }) : '—';
+}

--- a/app/frontend/shared/lib/formatFileSize.ts
+++ b/app/frontend/shared/lib/formatFileSize.ts
@@ -1,0 +1,7 @@
+export function formatFileSize(bytes: number | null): string {
+  if (!bytes) return '—';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}

--- a/app/frontend/shared/lib/formatUsage.ts
+++ b/app/frontend/shared/lib/formatUsage.ts
@@ -1,0 +1,12 @@
+export function formatCostCents(cents: number): string {
+  const d = (cents ?? 0) / 100;
+  if (d >= 1000) return `$${(d / 1000).toFixed(1)}k`;
+  return `$${d.toFixed(2)}`;
+}
+
+export function formatTokens(n: number): string {
+  if (!n) return '0';
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}

--- a/app/frontend/shared/lib/getInitials.ts
+++ b/app/frontend/shared/lib/getInitials.ts
@@ -1,0 +1,7 @@
+// "Acme Robotics" -> "AR"; single word -> first letter; empty -> "U".
+export const getInitials = (name: string): string => {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return 'U';
+  if (parts.length === 1) return (parts[0][0] ?? 'U').toUpperCase();
+  return ((parts[0][0] ?? 'U') + (parts[parts.length - 1][0] ?? 'U')).toUpperCase();
+};

--- a/app/frontend/shared/lib/timezones.ts
+++ b/app/frontend/shared/lib/timezones.ts
@@ -1,0 +1,25 @@
+// IANA timezone list from the runtime (falls back to UTC if unsupported).
+export const IANA_TIMEZONES: string[] = (() => {
+  try {
+    const intl = Intl as typeof Intl & { supportedValuesOf?: (key: string) => string[] };
+    return intl.supportedValuesOf?.('timeZone') ?? ['UTC'];
+  } catch {
+    return ['UTC'];
+  }
+})();
+
+// Append the current UTC offset to a timezone, e.g. "Europe/Belgrade (UTC+02:00)".
+export function tzLabel(tz: string): string {
+  try {
+    const raw =
+      new Intl.DateTimeFormat('en-US', { timeZone: tz, timeZoneName: 'longOffset' })
+        .formatToParts(new Date())
+        .find((p) => p.type === 'timeZoneName')?.value ?? 'GMT';
+    const offset = raw === 'GMT' ? 'UTC+00:00' : raw.replace('GMT', 'UTC');
+    return `${tz} (${offset})`;
+  } catch {
+    return tz;
+  }
+}
+
+export const TIMEZONE_OPTIONS = IANA_TIMEZONES.map((tz) => ({ value: tz, label: tzLabel(tz) }));

--- a/app/frontend/shared/resources/agents/DeleteAgentModal.tsx
+++ b/app/frontend/shared/resources/agents/DeleteAgentModal.tsx
@@ -1,6 +1,7 @@
-import { router } from '@inertiajs/react';
-import { Box, Button, Group, Modal, Text } from '@mantine/core';
-import { useState, type FC } from 'react';
+import { Box, Text } from '@mantine/core';
+import { type FC } from 'react';
+
+import { ConfirmDeleteModal } from 'shared/ui/ConfirmDeleteModal';
 
 interface Agent {
   id: number;
@@ -17,66 +18,30 @@ interface DeleteAgentModalProps {
 }
 
 export const DeleteAgentModal: FC<DeleteAgentModalProps> = ({ opened, onClose, agent, basePath }) => {
-  const [deleting, setDeleting] = useState(false);
-
-  const handleDelete = () => {
-    if (!agent) return;
-
-    setDeleting(true);
-    router.delete(`${basePath}/${agent.id}`, {
-      preserveScroll: true,
-      onSuccess: () => {
-        setDeleting(false);
-        onClose();
-      },
-      onError: () => {
-        setDeleting(false);
-      },
-    });
-  };
-
   if (!agent) return null;
 
   return (
-    <Modal opened={opened} onClose={onClose} title="Delete Agent" size="sm" centered>
-      <Text c="dimmed" mb="md">
-        Are you sure you want to delete this agent?
-      </Text>
-
-      <Box
-        p="sm"
-        mb="md"
-        style={{
-          backgroundColor: 'var(--app-bg-deep)',
-          borderRadius: 'var(--mantine-radius-sm)',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 12,
-        }}
-      >
-        <Text fz={24}>{agent.icon || '🤖'}</Text>
-        <Box>
-          <Text fw={500} c="var(--app-text-primary)">
-            {agent.title}
-          </Text>
-          <Text fz={12} ff="JetBrains Mono, monospace" c="dimmed">
-            {agent.name}
-          </Text>
-        </Box>
-      </Box>
-
-      <Text fz={13} c="var(--app-warning-fg)" mb="md">
-        This action cannot be undone. Any sessions or workflows using this agent may be affected.
-      </Text>
-
-      <Group justify="flex-end">
-        <Button variant="default" onClick={onClose} disabled={deleting}>
-          Cancel
-        </Button>
-        <Button color="red" onClick={handleDelete} loading={deleting}>
-          Delete
-        </Button>
-      </Group>
-    </Modal>
+    <ConfirmDeleteModal
+      opened={opened}
+      onClose={onClose}
+      title="Delete Agent"
+      itemId={agent.id}
+      basePath={basePath}
+      description="Are you sure you want to delete this agent?"
+      preview={
+        <>
+          <Text fz={24}>{agent.icon || '🤖'}</Text>
+          <Box>
+            <Text fw={500} c="var(--app-text-primary)">
+              {agent.title}
+            </Text>
+            <Text fz={12} ff="JetBrains Mono, monospace" c="dimmed">
+              {agent.name}
+            </Text>
+          </Box>
+        </>
+      }
+      warning="This action cannot be undone. Any sessions or workflows using this agent may be affected."
+    />
   );
 };

--- a/app/frontend/shared/resources/assets/AssetPreviewModal.tsx
+++ b/app/frontend/shared/resources/assets/AssetPreviewModal.tsx
@@ -2,28 +2,15 @@ import { Badge, Box, Button, Center, Code, Group, Loader, Modal, Stack, Text } f
 import { IconDownload, IconFile } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 
+import { formatDateMedium } from 'shared/lib/formatDate';
+import { formatFileSize } from 'shared/lib/formatFileSize';
+
 import type { Asset } from './AssetsContent';
 
 interface AssetPreviewModalProps {
   asset: Asset | null;
   onClose: () => void;
   downloadUrl: string;
-}
-
-function formatFileSize(bytes: number | null): string {
-  if (!bytes) return '—';
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-}
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
 }
 
 type PreviewType = 'image' | 'video' | 'audio' | 'pdf' | 'text' | 'markdown' | 'svg' | 'unsupported';
@@ -312,7 +299,7 @@ export function AssetPreviewModal({ asset, onClose, downloadUrl }: AssetPreviewM
               &middot;
             </Text>
             <Text fz={12} c="dimmed">
-              {formatDate(asset.updatedAt)}
+              {formatDateMedium(asset.updatedAt)}
             </Text>
             <Text fz={12} c="dimmed">
               &middot;

--- a/app/frontend/shared/resources/assets/AssetsContent.tsx
+++ b/app/frontend/shared/resources/assets/AssetsContent.tsx
@@ -24,6 +24,8 @@ import type { Body, Meta } from '@uppy/core';
 import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { apiFetch } from 'shared/lib/apiFetch';
+import { formatDateMedium } from 'shared/lib/formatDate';
+import { formatFileSize } from 'shared/lib/formatFileSize';
 import { useProjectPermissions } from 'shared/lib/hooks/useProjectPermissions';
 import { downloadApiV1CompanyAssetPath, downloadApiV1ProjectAssetPath } from 'shared/routes';
 import { EmptyState } from 'shared/ui/EmptyState';
@@ -90,22 +92,6 @@ interface AssetsContentProps {
   apiBasePath: string;
   createEndpoint?: string;
   projectId?: number;
-}
-
-function formatFileSize(bytes: number | null): string {
-  if (!bytes) return '—';
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-}
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
 }
 
 const SCOPE_COLORS: Record<string, string> = {
@@ -485,7 +471,7 @@ export function AssetsContent({
                   )}
                   <Table.Td>
                     <Text fz={13} c="dimmed">
-                      {formatDate(asset.updatedAt)}
+                      {formatDateMedium(asset.updatedAt)}
                     </Text>
                   </Table.Td>
                   <Table.Td>
@@ -697,7 +683,7 @@ export function AssetsContent({
                       </Text>
                     </Table.Td>
                     <Table.Td>
-                      <Text fz={13}>{v.createdAt ? formatDate(v.createdAt) : '—'}</Text>
+                      <Text fz={13}>{v.createdAt ? formatDateMedium(v.createdAt) : '—'}</Text>
                     </Table.Td>
                     <Table.Td>
                       <Text fz={13} ff="JetBrains Mono, monospace" c="dimmed">

--- a/app/frontend/shared/resources/integrations/IntegrationsContent.tsx
+++ b/app/frontend/shared/resources/integrations/IntegrationsContent.tsx
@@ -36,6 +36,7 @@ import {
 } from '@tabler/icons-react';
 import { useCallback, useMemo, useState } from 'react';
 
+import { formatDateMedium } from 'shared/lib/formatDate';
 import { useProjectPermissions } from 'shared/lib/hooks/useProjectPermissions';
 import { isValidHttpUrl } from 'shared/lib/urlValidation';
 import { EmptyState } from 'shared/ui/EmptyState';
@@ -93,9 +94,6 @@ const SCOPE_COLORS: Record<string, string> = {
 
 // Mirrors the server-side fallback in Coder::LockService#ttl_minutes.
 const DEFAULT_CODER_LOCK_TTL = 120;
-
-const formatDate = (d: string) =>
-  new Date(d).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
 
 export const IntegrationsContent = ({ integrations, basePath, title }: IntegrationsContentProps) => {
   const { canExecute } = useProjectPermissions();
@@ -533,7 +531,7 @@ export const IntegrationsContent = ({ integrations, basePath, title }: Integrati
                     </Table.Td>
                     <Table.Td>
                       <Text fz={13} c="dimmed">
-                        {integration.connectedBy.name} · {formatDate(integration.createdAt)}
+                        {integration.connectedBy.name} · {formatDateMedium(integration.createdAt)}
                       </Text>
                     </Table.Td>
                     <Table.Td>

--- a/app/frontend/shared/resources/mcp-servers/DeleteMcpServerModal.tsx
+++ b/app/frontend/shared/resources/mcp-servers/DeleteMcpServerModal.tsx
@@ -1,6 +1,7 @@
-import { router } from '@inertiajs/react';
-import { Box, Button, Group, Modal, Text } from '@mantine/core';
-import { useState, type FC } from 'react';
+import { Text } from '@mantine/core';
+import { type FC } from 'react';
+
+import { ConfirmDeleteModal } from 'shared/ui/ConfirmDeleteModal';
 
 interface McpServer {
   id: number;
@@ -15,39 +16,24 @@ interface DeleteMcpServerModalProps {
 }
 
 export const DeleteMcpServerModal: FC<DeleteMcpServerModalProps> = ({ opened, onClose, server, basePath }) => {
-  const [loading, setLoading] = useState(false);
-
   if (!server) return null;
 
-  const handleDelete = () => {
-    setLoading(true);
-    router.delete(`${basePath}/${server.id}`, {
-      preserveScroll: true,
-      onFinish: () => setLoading(false),
-      onSuccess: () => onClose(),
-    });
-  };
-
   return (
-    <Modal opened={opened} onClose={onClose} title="Delete MCP Server" size="sm">
-      <Box>
-        <Text fz={14} c="dimmed" mb="md">
+    <ConfirmDeleteModal
+      opened={opened}
+      onClose={onClose}
+      title="Delete MCP Server"
+      itemId={server.id}
+      basePath={basePath}
+      description={
+        <>
           Are you sure you want to delete{' '}
           <Text span fw={600} c="var(--app-text-primary)">
             {server.name}
           </Text>
           ? This action cannot be undone.
-        </Text>
-
-        <Group justify="flex-end">
-          <Button variant="default" onClick={onClose} disabled={loading}>
-            Cancel
-          </Button>
-          <Button color="red" onClick={handleDelete} loading={loading}>
-            Delete
-          </Button>
-        </Group>
-      </Box>
-    </Modal>
+        </>
+      }
+    />
   );
 };

--- a/app/frontend/shared/resources/members/MembersContent.tsx
+++ b/app/frontend/shared/resources/members/MembersContent.tsx
@@ -28,6 +28,8 @@ import {
 } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
 
+import { formatDateMedium } from 'shared/lib/formatDate';
+import { getInitials } from 'shared/lib/getInitials';
 import type { SharedProps, UserRole } from 'shared/ui';
 import { EmptyState } from 'shared/ui/EmptyState';
 import { PageHeader } from 'shared/ui/PageHeader';
@@ -108,11 +110,6 @@ function RoleTag({ role }: { role: UserRole }) {
   );
 }
 
-const formatDate = (d: string | null) => {
-  if (!d) return '—';
-  return new Date(d).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
-};
-
 const ROLE_FILTER_OPTIONS = [
   { value: 'all', label: 'All Roles' },
   { value: 'admin', label: 'Admins' },
@@ -126,12 +123,6 @@ const STATUS_FILTER_OPTIONS = [
   { value: 'suspended', label: 'Suspended' },
   { value: 'all', label: 'All Statuses' },
 ];
-
-const getInitials = (name: string): string => {
-  const parts = name.trim().split(/\s+/);
-  if (parts.length === 1) return parts[0].substring(0, 2).toUpperCase();
-  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-};
 
 export const MembersContent = ({ users, basePath, title, subtitle, showRoleActions = true }: MembersContentProps) => {
   const { currentUser, permissions } = usePage<SharedProps>().props;
@@ -335,7 +326,7 @@ export const MembersContent = ({ users, basePath, title, subtitle, showRoleActio
                     </Table.Td>
                     <Table.Td>
                       <Text size="sm" c="var(--app-text-primary)">
-                        {formatDate(user.invitedAt ?? user.createdAt)}
+                        {formatDateMedium(user.invitedAt ?? user.createdAt)}
                       </Text>
                       <Text size="xs" c="dimmed">
                         {user.invitedBy ? `by ${user.invitedBy.name}` : 'Self-registered'}

--- a/app/frontend/shared/resources/skills/DeleteSkillModal.tsx
+++ b/app/frontend/shared/resources/skills/DeleteSkillModal.tsx
@@ -1,7 +1,8 @@
-import { router } from '@inertiajs/react';
-import { Box, Button, Group, Modal, Text } from '@mantine/core';
+import { Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import { useState, type FC } from 'react';
+import { type FC } from 'react';
+
+import { ConfirmDeleteModal } from 'shared/ui/ConfirmDeleteModal';
 
 interface Skill {
   id: number;
@@ -17,42 +18,25 @@ interface DeleteSkillModalProps {
 }
 
 export const DeleteSkillModal: FC<DeleteSkillModalProps> = ({ opened, onClose, skill, basePath }) => {
-  const [loading, setLoading] = useState(false);
-
   if (!skill) return null;
 
-  const handleDelete = () => {
-    setLoading(true);
-    router.delete(`${basePath}/${skill.id}`, {
-      preserveScroll: true,
-      onSuccess: () => onClose(),
-      onError: () => {
-        notifications.show({ message: 'Failed to delete skill', color: 'red' });
-      },
-      onFinish: () => setLoading(false),
-    });
-  };
-
   return (
-    <Modal opened={opened} onClose={onClose} title="Delete Skill" size="sm">
-      <Box>
-        <Text fz={14} c="dimmed" mb="md">
+    <ConfirmDeleteModal
+      opened={opened}
+      onClose={onClose}
+      title="Delete Skill"
+      itemId={skill.id}
+      basePath={basePath}
+      description={
+        <>
           Are you sure you want to delete skill{' '}
           <Text span fw={600} c="var(--app-text-primary)">
             {skill.title || skill.name}
           </Text>
           ? This action cannot be undone.
-        </Text>
-
-        <Group justify="flex-end">
-          <Button variant="default" onClick={onClose} disabled={loading}>
-            Cancel
-          </Button>
-          <Button color="red" onClick={handleDelete} loading={loading}>
-            Delete
-          </Button>
-        </Group>
-      </Box>
-    </Modal>
+        </>
+      }
+      onDeleteError={() => notifications.show({ message: 'Failed to delete skill', color: 'red' })}
+    />
   );
 };

--- a/app/frontend/shared/resources/tools/DeleteToolModal.tsx
+++ b/app/frontend/shared/resources/tools/DeleteToolModal.tsx
@@ -1,6 +1,7 @@
-import { router } from '@inertiajs/react';
-import { Box, Button, Group, Modal, Text } from '@mantine/core';
-import { useState, type FC } from 'react';
+import { Box, Text } from '@mantine/core';
+import { type FC } from 'react';
+
+import { ConfirmDeleteModal } from 'shared/ui/ConfirmDeleteModal';
 
 interface Tool {
   id: number;
@@ -16,60 +17,27 @@ interface DeleteToolModalProps {
 }
 
 export const DeleteToolModal: FC<DeleteToolModalProps> = ({ opened, onClose, tool, basePath }) => {
-  const [deleting, setDeleting] = useState(false);
-
-  const handleDelete = () => {
-    if (!tool) return;
-
-    setDeleting(true);
-    router.delete(`${basePath}/${tool.id}`, {
-      preserveScroll: true,
-      onSuccess: () => {
-        setDeleting(false);
-        onClose();
-      },
-      onError: () => {
-        setDeleting(false);
-      },
-    });
-  };
-
   if (!tool) return null;
 
   return (
-    <Modal opened={opened} onClose={onClose} title="Delete Tool" size="sm" centered>
-      <Text c="dimmed" mb="md">
-        Are you sure you want to delete this tool?
-      </Text>
-
-      <Box
-        p="sm"
-        mb="md"
-        style={{
-          backgroundColor: 'var(--app-bg-deep)',
-          borderRadius: 'var(--mantine-radius-sm)',
-        }}
-      >
-        <Text fw={500} c="var(--app-text-primary)">
-          {tool.displayName}
-        </Text>
-        <Text fz={12} ff="JetBrains Mono, monospace" c="dimmed">
-          {tool.name}
-        </Text>
-      </Box>
-
-      <Text fz={13} c="var(--app-warning-fg)" mb="md">
-        This action cannot be undone. Any workflows using this tool may be affected.
-      </Text>
-
-      <Group justify="flex-end">
-        <Button variant="default" onClick={onClose} disabled={deleting}>
-          Cancel
-        </Button>
-        <Button color="red" onClick={handleDelete} loading={deleting}>
-          Delete
-        </Button>
-      </Group>
-    </Modal>
+    <ConfirmDeleteModal
+      opened={opened}
+      onClose={onClose}
+      title="Delete Tool"
+      itemId={tool.id}
+      basePath={basePath}
+      description="Are you sure you want to delete this tool?"
+      preview={
+        <Box>
+          <Text fw={500} c="var(--app-text-primary)">
+            {tool.displayName}
+          </Text>
+          <Text fz={12} ff="JetBrains Mono, monospace" c="dimmed">
+            {tool.name}
+          </Text>
+        </Box>
+      }
+      warning="This action cannot be undone. Any workflows using this tool may be affected."
+    />
   );
 };

--- a/app/frontend/shared/ui/AppSidebar.tsx
+++ b/app/frontend/shared/ui/AppSidebar.tsx
@@ -30,6 +30,7 @@ import {
 import { Fragment, useCallback, useMemo, useState } from 'react';
 
 import { CreateProjectModal } from 'pages/Projects/CreateProjectModal';
+import { getInitials } from 'shared/lib/getInitials';
 import {
   companyAssetsPath,
   companyMembersPath,
@@ -81,13 +82,6 @@ const writeCollapsedGroups = (groups: Set<string>) => {
   } catch {
     // localStorage unavailable (private browsing, quota exceeded)
   }
-};
-
-const getInitials = (name: string): string => {
-  const parts = name.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return 'U';
-  if (parts.length === 1) return (parts[0][0] ?? 'U').toUpperCase();
-  return ((parts[0][0] ?? 'U') + (parts[parts.length - 1][0] ?? 'U')).toUpperCase();
 };
 
 // True for the clicks the browser handles itself on a link — Cmd/Ctrl+click (new tab),

--- a/app/frontend/shared/ui/ConfirmDeleteModal.tsx
+++ b/app/frontend/shared/ui/ConfirmDeleteModal.tsx
@@ -1,0 +1,82 @@
+import { router } from '@inertiajs/react';
+import { Box, Button, Group, Modal, Text } from '@mantine/core';
+import { useState, type FC, type ReactNode } from 'react';
+
+interface ConfirmDeleteModalProps {
+  opened: boolean;
+  onClose: () => void;
+  title: string;
+  /** id of the item being deleted; the modal renders nothing while this is null */
+  itemId: number | null;
+  basePath: string;
+  description: ReactNode;
+  /** rendered inside the highlighted preview box, e.g. the item's name/icon */
+  preview?: ReactNode;
+  warning?: ReactNode;
+  onDeleteError?: () => void;
+}
+
+export const ConfirmDeleteModal: FC<ConfirmDeleteModalProps> = ({
+  opened,
+  onClose,
+  title,
+  itemId,
+  basePath,
+  description,
+  preview,
+  warning,
+  onDeleteError,
+}) => {
+  const [loading, setLoading] = useState(false);
+
+  if (itemId === null) return null;
+
+  const handleDelete = () => {
+    setLoading(true);
+    router.delete(`${basePath}/${itemId}`, {
+      preserveScroll: true,
+      onSuccess: () => onClose(),
+      onError: () => onDeleteError?.(),
+      onFinish: () => setLoading(false),
+    });
+  };
+
+  return (
+    <Modal opened={opened} onClose={onClose} title={title} size="sm" centered>
+      <Text fz={14} c="dimmed" mb="md">
+        {description}
+      </Text>
+
+      {preview && (
+        <Box
+          p="sm"
+          mb="md"
+          style={{
+            backgroundColor: 'var(--app-bg-deep)',
+            borderRadius: 'var(--mantine-radius-sm)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+          }}
+        >
+          {preview}
+        </Box>
+      )}
+
+      {warning && (
+        <Text fz={13} c="var(--app-warning-fg)" mb="md">
+          {warning}
+        </Text>
+      )}
+
+      <Group justify="flex-end">
+        <Button variant="default" onClick={onClose} disabled={loading}>
+          Cancel
+        </Button>
+        <Button color="red" onClick={handleDelete} loading={loading}>
+          Delete
+        </Button>
+      </Group>
+    </Modal>
+  );
+};


### PR DESCRIPTION
## Problem

Several pieces of frontend logic were copy-pasted across multiple files instead of being shared, in some cases drifting into slightly different implementations of the same thing (e.g. four different `getInitials` variants with different edge-case handling). This violates DRY and made bug fixes/behavior changes require updating N places.

## Fix

Extracted each duplicated block into a single shared implementation under `shared/lib`, `shared/ui`, or a new `shared/analytics` module, and updated every call site to import it instead of redefining it locally.

## Items extracted

- **`shared/lib/getInitials.ts`** — replaces 4 near-duplicate copies in `AppSidebar`, `MembersContent`, `MembersPage`, and `Profile/Show` (one of which even had a comment acknowledging the duplication).
- **`shared/lib/formatUsage.ts`** (`formatCostCents`, `formatTokens`) — replaces 3 identical copies in the Company/Projects Analytics pages and `Profile/Usage`.
- **`shared/ui/ConfirmDeleteModal.tsx`** — a generic confirm-delete modal replacing the near-identical bodies of `DeleteAgentModal`, `DeleteToolModal`, `DeleteMcpServerModal`, and `DeleteSkillModal` (same loading state, same `router.delete` pattern, same Cancel/Delete layout).
- **`shared/lib/formatDate.ts`** — added a `formatDateMedium` helper, replacing inline `new Date(...).toLocaleDateString(...)` calls scattered across `IntegrationsContent`, `MembersContent`, `Profile/Show`, `AssetPreviewModal`, and `AssetsContent`.
- **`shared/lib/formatFileSize.ts`** — replaces a duplicate byte-formatting function in `AssetPreviewModal` and `AssetsContent`.
- **`shared/lib/timezones.ts`** — replaces a duplicated IANA timezone list + UTC-offset label builder (`tzLabel`/`TIMEZONE_OPTIONS`) in `WorkflowTriggersDrawer` and `TriggerFormPanel`.
- **`shared/analytics/chartHelpers.tsx`** — the largest duplication (~150 lines) shared between the Company and Projects Analytics pages: `AgentLogo` component, agent color/logo maps, `ScopeBadge`, `PERIOD_OPTIONS`, `chartTooltipStyle`, `centerLabelFontSize`, `sharePct`, `tickIntervalForPeriod`, `formatAxisDate`, `buildActivityChartData`, `SummarySkeletons`, `ChartSkeleton`, plus the shared `AgentActivityData`/`Period` types.

No behavior changes — this is a pure refactor.

## Test plan
- [x] `docker compose exec -T web make check_all` — all green (rails-test, rubocop, brakeman, system-test, eslint, typescript, fe-test, vite-build)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all touched/new files
- [x] Relevant vitest suites (analytics pages, delete modals, members, assets, integrations, workflows, profile) — 569 tests passing