### PR TITLE
fix(quota): detect Claude CLI workspace API usage limit message

### DIFF
--- a/app/services/quota_error_detector.rb
+++ b/app/services/quota_error_detector.rb
@@ -9,7 +9,9 @@ class QuotaErrorDetector
       /insufficient_quota/i,
       /billing_hard_limit/i,
       /Add funds:.*platform\.claude\.com/i,
-      /individual spend limit/i
+      /individual spend limit/i,
+      /workspace API usage limits/i,
+      /You will regain access on/i
     ],
     gemini: [
       /Usage limit reached/i,

--- a/test/services/quota_error_detector_test.rb
+++ b/test/services/quota_error_detector_test.rb
@@ -78,6 +78,14 @@ class QuotaErrorDetectorTest < ActiveSupport::TestCase
     assert_includes result.message, "individual spend limit"
   end
 
+  test "detects anthropic workspace API usage limits (claude CLI 400 error)" do
+    text = "API Error: 400 You have reached your specified workspace API usage limits. You will regain access on 2026-09-01 at 00:00 UTC."
+    result = QuotaErrorDetector.detect(text)
+    assert result.quota_error?
+    assert_equal :anthropic, result.provider
+    assert_equal text, result.message
+  end
+
   # --- OpenAI patterns ---
 
   test "detects openai quota exceeded" do


### PR DESCRIPTION

<img width="1201" height="475" alt="SCR-20260827-lhhf" src="https://github.com/user-attachments/assets/ecdcdcdd-661a-4ae4-86c9-3e9321bd346e" />


## Summary

- Adds two new Anthropic patterns to `QuotaErrorDetector` to handle the error Claude CLI emits when a **workspace spending limit** is reached:
  - `workspace API usage limits` — matches the 400 error body
  - `You will regain access on` — matches the reset-date phrase
- Adds a test covering the exact message format seen in production: `API Error: 400 You have reached your specified workspace API usage limits. You will regain access on 2026-09-01 at 00:00 UTC.`

## Test plan

- [x] `bin/rails test test/services/quota_error_detector_test.rb` — 39 tests, 0 failures
