### PR TITLE
chore(devcontainer): persist root home volume

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,9 +17,10 @@
 	// Mount persisted developer tool state
 	"mounts": [
 		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
-		"source=aixle-app-codex,target=/root/.codex,type=volume",
-		"source=aixle-app-vscode-extensions,target=/root/.vscode-server/extensions,type=volume",
-		"source=aixle-app-claude,target=/root/.claude,type=volume"
+		"source=aixle-app-home,target=/root,type=volume"
+		// "source=aixle-app-codex,target=/root/.codex,type=volume",
+		// "source=aixle-app-vscode-extensions,target=/root/.vscode-server/extensions,type=volume",
+		// "source=aixle-app-claude,target=/root/.claude,type=volume"
 	],
 
 	"containerEnv": {

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -19,28 +19,6 @@ OS=linux
 # devcontainer. Production containers never run this setup script.
 bundle config set --local frozen false
 
-ensure_persistent_home_state() {
-  local claude_state_dir=/root/.claude-state
-  local claude_json="${claude_state_dir}/.claude.json"
-
-  mkdir -p /root/.claude "${claude_state_dir}"
-
-  if [[ -f /root/.claude.json && ! -L /root/.claude.json && ! -f "${claude_json}" ]]; then
-    mv /root/.claude.json "${claude_json}"
-  fi
-
-  touch "${claude_json}"
-  ln -sfn "${claude_json}" /root/.claude.json
-
-  chmod 700 /root/.claude 2>/dev/null || true
-  chmod 700 "${claude_state_dir}" 2>/dev/null || true
-  chmod 600 "${claude_json}" 2>/dev/null || true
-
-  echo "Claude auth state is persisted through /root/.claude and /root/.claude-state/.claude.json"
-}
-
-ensure_persistent_home_state
-
 # docker cli
 apk add --no-cache docker docker-cli-compose unzip
 


### PR DESCRIPTION
<!--
Thanks for contributing to Aixle Flow! Please fill in the sections below.
Keep PRs focused on a single concern. See CONTRIBUTING.md.
-->

## Summary

<!-- What does this PR do and why? -->

## Related issues

<!-- e.g. Closes #123, Refs #456 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / chore
- [ ] Breaking change

## How was this tested?

<!-- Describe the tests you ran / added. -->

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] All my commits are signed off for the [DCO](../DCO) (`git commit -s`).
- [x] I have signed (or will sign) the [CLA](../CLA.md) when the bot prompts me — or my
      organization has executed the [Corporate CLA](../CLA-CORPORATE.md).
- [x] `make check_all` passes locally (tests, rubocop, brakeman, eslint, typescript).
- [x] I added/updated tests where it makes sense.
- [x] I updated documentation where it makes sense.
- [x] My commits use clear, descriptive messages.
