### PR TITLE
fix(agents): pre-dismiss Claude Code auto-mode default nudge

### DIFF
--- a/app/services/agents/claude_code_adapter.rb
+++ b/app/services/agents/claude_code_adapter.rb
@@ -291,6 +291,12 @@ module Agents
         "lastOnboardingVersion" => CONFIG_VERSION,
         "numStartups" => 1,
         "effortCalloutV2Dismissed" => true,
+        # Suppresses the "Make auto mode your default permission mode?" nudge, which
+        # Claude Code offers whenever settings.json pins a defaultMode other than "auto"
+        # (ours is always bypassPermissions — see PERMISSION_DEFAULT_MODE). In an
+        # interactive container session the nudge steals the first keystrokes; the flag
+        # is what Claude Code itself writes once the nudge has been answered.
+        "hasSeenAutoDefaultNudge" => true,
 
         # Project config (generated based on workflow)
         "projects" => generate_projects_config(workflow_config)

--- a/test/services/agents/claude_code_adapter_test.rb
+++ b/test/services/agents/claude_code_adapter_test.rb
@@ -165,6 +165,7 @@ module Agents
       assert_equal "sk-xxx", config["primaryApiKey"]
       assert_equal "u1", config["userID"]
       assert config["hasCompletedOnboarding"]
+      assert config["hasSeenAutoDefaultNudge"], "auto-mode default nudge must be pre-dismissed"
       assert_equal "2.1.14", config["lastOnboardingVersion"]
       assert config["projects"].present?
     end


### PR DESCRIPTION
## Problem

Interactive container sessions on recent Claude Code (2.1.2xx) open with a dialog instead of a prompt:

```
Make auto mode your default permission mode?
  1. Yes, set auto mode as my default permission mode
  2. No, keep bypass permissions
```

The gate for that nudge, from the shipped CLI bundle:

```js
if (u && !t.hasCompletedOnboarding || t.hasSeenAutoDefaultNudge || !gate("tengu_maple_pier")) return null
let e = userSettings?.permissions?.defaultMode,
    n = ["projectSettings","localSettings","flagSettings","policySettings"].some(s => s?.permissions?.defaultMode)
if (e && e !== "auto" && !n && ...) return e   // <- show nudge
```

Every session we generate matches it exactly: `generate_settings` pins
`permissions.defaultMode = "bypassPermissions"` (a headless sandbox has nobody to
answer a permission prompt, see `PERMISSION_DEFAULT_MODE`), and we write no
project/local/policy settings that would override it.

## Fix

`generate_config` now writes `hasSeenAutoDefaultNudge: true` into `~/.claude.json`.
That is the flag Claude Code itself writes once the nudge has been answered, and it
is checked before the `defaultMode` comparison, so `bypassPermissions` stays and the
dialog never renders. Same shape as the existing `effortCalloutV2Dismissed` and
`hasCompletedOnboarding` entries.

## Testing

- `bin/rails test test/services/agents/claude_code_adapter_test.rb` — 118 runs, 345 assertions, 0 failures
- `make check_all` — brakeman / eslint / fe-test / rubocop / system-test / typescript / vite-build all OK.
  `rails-test` reported 9 errors, all `Temporalio::Internal::Bridge::Error: Failed starting server:
  error sending request for url (https://temporal.download/temporal-test-server/...)` in the
  `Workflows::*WorkflowTest` files — the local container could not reach temporal.download.
  Unrelated to this change; CI has network for that download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
