### PR TITLE
fix(bmad): authenticate module installs against the GitHub API

### DIFF
--- a/app/models/terminal_session.rb
+++ b/app/models/terminal_session.rb
@@ -6,7 +6,15 @@ class TerminalSession < ApplicationRecord
   include TerminalSessionStateMachine
 
   WORKFLOW_TIMEOUT = 86_400 # 24 hours
-  BMAD_DEFAULT_MODULES = %w[bmm bmb cis wds].freeze
+
+  # `bmm` ships inside the npm package; every other module is cloned from GitHub
+  # at install time, and each one costs an api.github.com tag lookup against a
+  # per-IP hourly budget shared by the whole cluster (see BmadMethodInjector).
+  # `bmb` (builder) and `cis` (creative intelligence suite) are authoring
+  # toolkits that pipeline sessions never invoke, so they are no longer installed
+  # by default — a session that wants them still names them in
+  # `session_config.bmad_modules`.
+  BMAD_DEFAULT_MODULES = %w[bmm wds].freeze
 
   # Serialized keys (camelCase, as ApplicationResource emits them) stripped from
   # the session-list broadcast — see #broadcast_session_list_update.

--- a/app/services/bmad_method_injector.rb
+++ b/app/services/bmad_method_injector.rb
@@ -47,12 +47,19 @@ class BmadMethodInjector
   # Pinned to match _bmad/_config/manifest.yaml; bumping requires re-validating
   # skill target directories (cursor/codex/gemini moved to .agents/skills in 6.6.0).
   # Since 6.10.0 bmb/cis/wds are external modules fetched from GitHub during
-  # install, so the container needs outbound access to github.com.
+  # install, so the container needs outbound access to github.com — and enough
+  # api.github.com budget to resolve their tags, which is what #github_read_token
+  # buys.
   # 6.11.0 marks wds deprecated: it is hidden from the interactive picker but
   # still installs when named explicitly via --modules, which is how we drive it.
   BMAD_METHOD_VERSION = "6.11.0"
 
   INSTALL_TIMEOUT = 300
+
+  # How much of each captured stream survives into the recorded failure reason.
+  # `bmad_install_error` is itself truncated to 500 chars when stored, so this
+  # only has to keep the tail readable rather than bound the column.
+  OUTPUT_EXCERPT_LIMIT = 800
 
   class InstallError < StandardError; end
 
@@ -88,10 +95,29 @@ class BmadMethodInjector
     if exit_code.zero?
       Rails.logger.info("[BmadMethodInjector] BMAD installed in container #{container_id}")
     else
-      stderr = Array(result[1]).join
-      Rails.logger.error("[BmadMethodInjector] Install failed (exit #{exit_code}): #{stderr}")
-      raise InstallError, "npx bmad-method install failed with exit code #{exit_code}: #{stderr}"
+      details = install_failure_details(result)
+      Rails.logger.error("[BmadMethodInjector] Install failed (exit #{exit_code}): #{details}")
+      raise InstallError, "npx bmad-method install failed with exit code #{exit_code}: #{details}"
     end
+  end
+
+  # The installer explains why it gave up on STDOUT — its prompt/logger writes
+  # there — while STDERR carries npm's noise. Reporting stderr alone made every
+  # real failure read as an unrelated `npm warn deprecated glob@…` line, which is
+  # exactly how a GitHub rate-limit refusal stayed invisible in production: the
+  # recorded reason named a deprecation warning and the actual 403 was dropped.
+  # Both streams are kept, stdout first, with the token scrubbed out of each.
+  def install_failure_details(result)
+    streams = {
+      "stdout" => redact_token(Array(result[0]).join).strip,
+      "stderr" => redact_token(Array(result[1]).join).strip
+    }
+
+    excerpts = streams.filter_map do |name, text|
+      "#{name}: #{text.last(OUTPUT_EXCERPT_LIMIT)}" if text.present?
+    end
+
+    excerpts.presence&.join(" | ") || "no output captured"
   end
 
   def hide_bmad_in_vscode
@@ -114,7 +140,50 @@ class BmadMethodInjector
     parts << "--output-folder outputs"
     parts << "--yes"
 
-    parts.join(" ")
+    command = parts.join(" ")
+    token = github_read_token
+    return command if token.blank?
+
+    "GITHUB_TOKEN=#{shell_quote(token)} #{command}"
+  end
+
+  # Every external module (`bmb`, `cis`, `wds`) has its stable tag resolved
+  # through api.github.com — see the installer's
+  # tools/installer/modules/channel-resolver.js, which sends an Authorization
+  # header only when GITHUB_TOKEN is set. Unauthenticated that API allows 60
+  # requests/hour PER SOURCE IP, and every agent container in a cluster NATs
+  # through one address, so a busy project drains the hourly budget and each
+  # later install aborts with a 403. The installer's own error text says to set
+  # GITHUB_TOKEN; this reuses the scopeless public-read token the skills catalog
+  # already carries (Settings.github.read_token). Absent, the install still runs
+  # and simply keeps the anonymous budget it had before.
+  #
+  # Handed over as an argv-scoped env prefix rather than a file on disk: the
+  # install shell runs as uid 1001 while ContainerRuntime#write_file writes as
+  # root, so a token file in sticky /tmp is one that shell cannot unlink again,
+  # and a leftover secret at rest is worse than an argv the same single-tenant
+  # container already sees repo-scoped installation tokens through. It is
+  # scrubbed from everything this class logs or records.
+  def github_read_token
+    Settings.github.read_token.presence
+  end
+
+  def redact_token(text)
+    token = github_read_token
+    return text if token.blank?
+
+    text.gsub(token, "[REDACTED]")
+  end
+
+  # POSIX single-quoting: everything is literal inside '…', and an embedded
+  # quote closes, escapes, and reopens. Tokens are opaque vendor strings, so
+  # nothing here may assume they are shell-safe.
+  #
+  # The block form of gsub is required, not cosmetic: in a replacement STRING
+  # `\'` is the post-match back-reference, so the escape would expand to the
+  # rest of the token instead of a quote.
+  def shell_quote(value)
+    "'#{value.to_s.gsub("'") { "'\\''" }}'"
   end
 
   # npx re-parses arguments and drops shell quoting,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -133,13 +133,17 @@ github:
   app_slug: <%= ENV['GITHUB_APP_SLUG'] %>
   private_key: "<%= ENV['GITHUB_APP_PRIVATE_KEY'] %>"
   webhook_secret: <%= ENV['GITHUB_WEBHOOK_SECRET'] %>
-  # OPTIONAL, and unrelated to the GitHub App above. A read-only token used only to
-  # list PUBLIC repository trees while describing the skills catalog
-  # (Skills::GithubSkillTree). Unauthenticated api.github.com allows 60 requests/hour
-  # for the whole deployment, which caps the catalog backfill at a couple of dozen
-  # publishers per run; any token raises that to 5,000/hour. Needs no scopes —
-  # public_repo read is enough, and a tenant's installation token must NOT be used
-  # here, since this reads repositories no customer installed the app on.
+  # OPTIONAL, and unrelated to the GitHub App above. A read-only token for the two
+  # paths that read PUBLIC repositories nobody installed the app on:
+  # listing repository trees while describing the skills catalog
+  # (Skills::GithubSkillTree), and resolving BMAD external-module tags during an
+  # agent-container install (BmadMethodInjector). Unauthenticated api.github.com
+  # allows 60 requests/hour PER SOURCE IP — one budget for the whole deployment,
+  # since agent containers NAT through a single address. That caps the catalog
+  # backfill at a couple of dozen publishers per run and makes BMAD installs fail
+  # once a busy project drains it; any token raises the limit to 5,000/hour. Needs
+  # no scopes — public_repo read is enough, and a tenant's installation token must
+  # NOT be used here.
   read_token: <%= ENV['GITHUB_PUBLIC_READ_TOKEN'] %>
 
 gitlab:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -178,7 +178,7 @@ an env var.
 
 | Variable                   | Purpose                                                                  |
 | -------------------------- | ------------------------------------------------------------------------ |
-| `GITHUB_PUBLIC_READ_TOKEN` | Optional — raises the `api.github.com` rate limit for the public skills catalog from 60 to 5,000 requests/hour. Needs no scopes; a tenant installation token must not be used. |
+| `GITHUB_PUBLIC_READ_TOKEN` | Optional — raises the `api.github.com` rate limit from 60 to 5,000 requests/hour for the public skills catalog and for BMAD external-module tag resolution during agent-container installs. The anonymous 60/hour is counted per source IP, so every agent container shares one budget; without a token a busy deployment drains it and BMAD installs start failing with a 403. Needs no scopes; a tenant installation token must not be used. |
 
 The Skills.sh registry needs no key: its v1 API authenticates with Vercel OIDC
 only, so the catalog is browsed through the local mirror instead.

--- a/test/models/terminal_session_test.rb
+++ b/test/models/terminal_session_test.rb
@@ -84,7 +84,7 @@ class TerminalSessionTest < ActiveSupport::TestCase
 
   test "bmad_modules returns default modules when not specified" do
     session = build(:terminal_session, user: @user, session_config: { "bmad_enabled" => true })
-    assert_equal %w[bmm bmb cis wds], session.bmad_modules
+    assert_equal %w[bmm wds], session.bmad_modules
   end
 
   test "bmad_modules returns custom modules when specified" do
@@ -97,17 +97,17 @@ class TerminalSessionTest < ActiveSupport::TestCase
 
   test "bmad_modules returns default when session_config is nil" do
     session = build(:terminal_session, user: @user, session_config: nil)
-    assert_equal %w[bmm bmb cis wds], session.bmad_modules
+    assert_equal %w[bmm wds], session.bmad_modules
   end
 
   test "bmad_modules returns default when bmad_modules key is absent" do
     session = build(:terminal_session, user: @user, session_config: {})
-    assert_equal %w[bmm bmb cis wds], session.bmad_modules
+    assert_equal %w[bmm wds], session.bmad_modules
   end
 
   test "BMAD_DEFAULT_MODULES constant is frozen" do
     assert TerminalSession::BMAD_DEFAULT_MODULES.frozen?
-    assert_equal %w[bmm bmb cis wds], TerminalSession::BMAD_DEFAULT_MODULES
+    assert_equal %w[bmm wds], TerminalSession::BMAD_DEFAULT_MODULES
   end
 
   # == mode and initial_prompt columns ==

--- a/test/services/bmad_method_injector_test.rb
+++ b/test/services/bmad_method_injector_test.rb
@@ -90,10 +90,24 @@ class BmadMethodInjectorTest < ActiveSupport::TestCase
     BmadMethodInjector.new("cid-1", session, runtime: @runtime).inject!
   end
 
-  test "uses default modules (bmm) when bmad_modules is absent" do
+  # Asserted as the exact list, not a substring: every module past `bmm` is cloned
+  # from GitHub and spends a shared per-IP api.github.com budget, so which ones
+  # install by default is a deliberate choice rather than an incidental default.
+  test "installs only the default modules when bmad_modules is absent" do
     session = build_bmad_session(agent_type: "cursor_cli")
 
-    expect_exec_matching("--modules bmm")
+    expect_exec_matching("--modules bmm,wds ")
+
+    BmadMethodInjector.new("cid-1", session, runtime: @runtime).inject!
+  end
+
+  test "does not install the bmb or cis authoring modules by default" do
+    session = build_bmad_session(agent_type: "cursor_cli")
+
+    @runtime.expects(:exec).with do |_cid, cmd|
+      modules = cmd[2].to_s[/--modules (\S+)/, 1].to_s.split(",")
+      (modules & %w[bmb cis]).empty?
+    end.returns([ [], [], 0 ])
 
     BmadMethodInjector.new("cid-1", session, runtime: @runtime).inject!
   end
@@ -507,6 +521,93 @@ class BmadMethodInjectorTest < ActiveSupport::TestCase
 
   test "INSTALL_TIMEOUT is 300 seconds" do
     assert_equal 300, BmadMethodInjector::INSTALL_TIMEOUT
+  end
+
+  # ====================================================================
+  # GitHub authentication for external-module tag resolution
+  # ====================================================================
+
+  test "authenticates the install with the public read token when one is configured" do
+    Settings.github.stubs(:read_token).returns("ghp_public_read")
+    session = build_bmad_session(agent_type: "cursor_cli")
+
+    expect_exec_matching("GITHUB_TOKEN='ghp_public_read' npx -y bmad-method@")
+
+    BmadMethodInjector.new("cid-1", session, runtime: @runtime).inject!
+  end
+
+  test "runs the install unauthenticated when no public read token is configured" do
+    Settings.github.stubs(:read_token).returns(nil)
+    session = build_bmad_session(agent_type: "cursor_cli")
+
+    expect_exec_not_matching("GITHUB_TOKEN")
+
+    BmadMethodInjector.new("cid-1", session, runtime: @runtime).inject!
+  end
+
+  test "treats a blank public read token as unauthenticated" do
+    Settings.github.stubs(:read_token).returns("   ")
+    session = build_bmad_session(agent_type: "cursor_cli")
+
+    expect_exec_not_matching("GITHUB_TOKEN")
+
+    BmadMethodInjector.new("cid-1", session, runtime: @runtime).inject!
+  end
+
+  # A token is an opaque vendor string; nothing may assume it is shell-safe.
+  test "shell-quotes a token containing a single quote" do
+    Settings.github.stubs(:read_token).returns("gh'p")
+    session = build_bmad_session(agent_type: "cursor_cli")
+
+    expect_exec_matching(%q(GITHUB_TOKEN='gh'\''p' npx))
+
+    BmadMethodInjector.new("cid-1", session, runtime: @runtime).inject!
+  end
+
+  # ====================================================================
+  # Failure reason carries the installer's own explanation
+  # ====================================================================
+
+  test "records the installer's stdout explanation, not just npm's stderr noise" do
+    session = build_bmad_session(agent_type: "cursor_cli")
+
+    @runtime.stubs(:exec).returns([
+      [ "Could not resolve stable tag for 'cis' (GitHub API 403: API rate limit exceeded)." ],
+      [ "npm warn deprecated glob@11.1.0: Old versions of glob are not supported" ],
+      1
+    ])
+
+    BmadMethodInjector.new("cid-1", session, runtime: @runtime).inject!
+
+    session.reload
+    error = session.context_metadata["bmad_install_error"]
+    assert_includes error, "rate limit exceeded"
+    assert_includes error, "npm warn deprecated"
+  end
+
+  test "reports no output captured when the install fails silently" do
+    session = build_bmad_session(agent_type: "cursor_cli")
+
+    @runtime.stubs(:exec).returns([ [], [], 1 ])
+
+    BmadMethodInjector.new("cid-1", session, runtime: @runtime).inject!
+
+    session.reload
+    assert_includes session.context_metadata["bmad_install_error"], "no output captured"
+  end
+
+  test "redacts the token from a failure reason that echoes it back" do
+    Settings.github.stubs(:read_token).returns("ghp_secret_value")
+    session = build_bmad_session(agent_type: "cursor_cli")
+
+    @runtime.stubs(:exec).returns([ [ "bad credentials for ghp_secret_value" ], [], 1 ])
+
+    BmadMethodInjector.new("cid-1", session, runtime: @runtime).inject!
+
+    session.reload
+    error = session.context_metadata["bmad_install_error"]
+    refute_includes error, "ghp_secret_value"
+    assert_includes error, "[REDACTED]"
   end
 
   private


### PR DESCRIPTION
## Why

BMAD installs into agent containers fail in bursts in production. Over the last
seven days the busiest project recorded **52 failed installs against 541
successful** ones; a failed session carries `bmad_install_status: "failed"`, has no
`/workspace/_bmad` and no `/workspace/.claude/skills`, and every BMAD slash command
in it comes back as `Unknown command`. Quieter projects are unaffected, which is
the tell: this is a shared budget being drained, not a broken installer.

The cause is a rate limit, not a bug in the installer. Since bmad-method 6.10.0 the
`bmb`, `cis` and `wds` modules are cloned from GitHub at install time, and the
installer resolves each one's stable tag through `api.github.com`
(`tools/installer/modules/channel-resolver.js`). That API allows **60 requests/hour
per source IP** unauthenticated, and every agent container NATs through a single
address — so when many containers start in the same hour they drain the whole
cluster's budget and every install after that aborts until the window resets.
Observed directly from a production agent pod:

```
$ curl https://api.github.com/rate_limit
core: { limit: 60, remaining: 0, used: 60 }

$ curl https://api.github.com/repos/bmad-code-org/BMAD-METHOD
403 {"message":"API rate limit exceeded for 3.217.219.60. ..."}
```

The installer's own error text names the fix: *"Set a GITHUB_TOKEN env var (any
personal access token with public-repo read) to raise the 60-req/hour anonymous
limit."*

## What changed

**1. The install authenticates to GitHub.** `BmadMethodInjector` passes
`GITHUB_TOKEN` from the existing scopeless `Settings.github.read_token`
(`GITHUB_PUBLIC_READ_TOKEN`), lifting the budget to 5,000/hour. With no token
configured the install runs exactly as before, on the anonymous budget.

**2. Fewer modules installed by default.** `BMAD_DEFAULT_MODULES` drops `bmb`
(builder) and `cis` (creative intelligence suite) — authoring toolkits the
pipeline sessions never invoke — leaving `bmm` (bundled in the npm package, no
network) and `wds`. That is one GitHub tag lookup per install instead of three.
A session that wants them still names them in `session_config.bmad_modules`.

**3. Install failures now say what actually happened.** `run_bmad_install` raised
with stderr only, and the installer writes its explanation to stdout while npm
writes deprecation warnings to stderr. So the recorded reason for every real
failure was:

```
npx bmad-method install failed with exit code 1: npm warn deprecated glob@11.1.0: ...
```

That is why a 403 hid behind a glob warning for two days. Both streams are now
captured, stdout first, with the token scrubbed from anything logged or stored.

## Deploy note

No secret work needed — `GITHUB_PUBLIC_READ_TOKEN` is **already set in production
and valid**. Verified from a `worker-ruby` pod:

```
authenticated core.limit = 5000     anonymous core.limit = 60
GET /user                                            -> 200
GET /repos/bmad-code-org/bmad-method-wds-expansion/tags -> 200   (the installer's own call)
```

The token was simply never handed to the install, so the installer kept resolving
tags on the anonymous per-IP budget. Installs become authenticated on merge.

## Testing

`docker compose exec -T web make check_all` — green.

New coverage in `test/services/bmad_method_injector_test.rb`: token present /
absent / blank, a token containing a single quote (the argv is shell-quoted),
stdout-carried failure reasons, and redaction of a token echoed back in output.
`test/models/terminal_session_test.rb` asserts the new default module list
exactly, since which modules install by default is now a deliberate cost choice.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
