### PR TITLE
fix(board): persist column reorder and fix collapsed-column drag

### DIFF
--- a/app/frontend/pages/Projects/Board/BoardPage.test.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.test.tsx
@@ -1074,6 +1074,22 @@ describe('Projects/Board/BoardPage', () => {
     fetchSpy.mockRestore();
   });
 
+  // Regression for #580: the collapsed column's own drag handle used to be dropped entirely —
+  // `useSortable`'s `listeners` were destructured but never spread anywhere in the collapsed
+  // render, so a collapsed column could be expanded/collapsed by click but never reordered by
+  // drag. The fix wires them onto the vertical column-name label, mirroring the expanded
+  // header's title, which is where dnd-kit's pointer sensor needs an onPointerDown handler.
+  it('wires the collapsed column name as a drag handle so the column itself can still be reordered', async () => {
+    renderAuthedPage(<BoardPage />, { props: populatedProps });
+
+    const toggles = screen.getAllByRole('button', { name: 'Collapse column' });
+    await userEvent.click(toggles[0]);
+    await waitFor(() => expect(screen.queryByText('Wire up authentication')).not.toBeInTheDocument());
+
+    const label = screen.getByText('Backlog');
+    expect(label).toHaveStyle({ cursor: 'grab', touchAction: 'none' });
+  });
+
   it('keeps a collapsed non-empty column’s tickets draggable so they can be moved out', async () => {
     renderAuthedPage(<BoardPage />, { props: populatedProps });
 

--- a/app/frontend/pages/Projects/Board/BoardPage.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.tsx
@@ -1123,6 +1123,7 @@ function BoardColumn({
           padding: '12px 0',
           gap: 12,
           ...overStyle,
+          ...colStyle,
         }}
       >
         {/* Expand chevrons button */}
@@ -1141,9 +1142,12 @@ function BoardColumn({
           <IconChevronsRight size={14} />
         </Box>
 
-        {/* Column name — vertical-rl, no rotation, reads naturally */}
+        {/* Column name — vertical-rl, no rotation, reads naturally. Carries the drag
+            listeners (mirroring the expanded header's title) so a collapsed column can
+            still be reordered instead of only being expandable/collapsible. */}
         <Tooltip label={column.name} position="right">
           <div
+            {...colListeners}
             style={{
               writingMode: 'vertical-rl',
               color: 'var(--mantine-color-text)',
@@ -1151,7 +1155,8 @@ function BoardColumn({
               fontSize: 13,
               letterSpacing: '-0.01em',
               userSelect: 'none',
-              cursor: 'pointer',
+              cursor: 'grab',
+              touchAction: 'none',
               overflow: 'hidden',
             }}
           >
@@ -4773,7 +4778,13 @@ const BoardPage = () => {
       body: JSON.stringify({ boardColumn: { name: 'New column' } }),
     });
     if (res.ok) {
-      router.reload({ only: ['columns'] });
+      // Append the created column straight from the response instead of reloading the
+      // `columns` prop: a reload fired here is an async Inertia partial reload with no
+      // ordering guarantee against another one, so it can race a column-reorder reload
+      // fired moments later (e.g. the user immediately drags the new column) and land
+      // second, clobbering the persisted reorder with this stale, pre-drag order (#580).
+      const created = (await res.json()) as Column;
+      setLocalColumns((prev) => [...prev, created]);
     }
   }, [project.id]);
 
@@ -5069,28 +5080,32 @@ const BoardPage = () => {
                   onMoveLeft={
                     idx > 0
                       ? () => {
-                          const ids = localColumns.map((c) => c.id);
-                          const next = [...ids];
-                          [next[idx - 1], next[idx]] = [next[idx], next[idx - 1]];
+                          const reordered = [...localColumns];
+                          [reordered[idx - 1], reordered[idx]] = [reordered[idx], reordered[idx - 1]];
+                          setLocalColumns(reordered);
+                          // No follow-up reload: the optimistic order above already matches what
+                          // gets persisted, and a reload here could race another in-flight one
+                          // and clobber it with stale data (#580) — see useBoardDnd's column
+                          // reorder for the full explanation.
                           apiFetch(reorderApiV1ProjectColumnsPath(project.id), {
                             method: 'PATCH',
                             headers: jsonHeaders,
-                            body: JSON.stringify({ columnIds: next }),
-                          }).then(() => router.reload({ only: ['columns'] }));
+                            body: JSON.stringify({ columnIds: reordered.map((c) => c.id) }),
+                          }).catch(() => setLocalColumns(localColumns));
                         }
                       : undefined
                   }
                   onMoveRight={
                     idx < localColumns.length - 1
                       ? () => {
-                          const ids = localColumns.map((c) => c.id);
-                          const next = [...ids];
-                          [next[idx], next[idx + 1]] = [next[idx + 1], next[idx]];
+                          const reordered = [...localColumns];
+                          [reordered[idx], reordered[idx + 1]] = [reordered[idx + 1], reordered[idx]];
+                          setLocalColumns(reordered);
                           apiFetch(reorderApiV1ProjectColumnsPath(project.id), {
                             method: 'PATCH',
                             headers: jsonHeaders,
-                            body: JSON.stringify({ columnIds: next }),
-                          }).then(() => router.reload({ only: ['columns'] }));
+                            body: JSON.stringify({ columnIds: reordered.map((c) => c.id) }),
+                          }).catch(() => setLocalColumns(localColumns));
                         }
                       : undefined
                   }

--- a/app/frontend/pages/Projects/Board/useBoardDnd.test.ts
+++ b/app/frontend/pages/Projects/Board/useBoardDnd.test.ts
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
+import { router } from '@inertiajs/react';
 import { useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -33,20 +34,32 @@ const dropOnCard = (task: BoardTask, overTask: BoardTask): DragEndEvent =>
     over: { id: `task-${overTask.id}`, data: { current: { type: 'task', task: overTask } } },
   }) as unknown as DragEndEvent;
 
+const pickUpColumn = (column: BoardColumn): DragStartEvent =>
+  ({ active: { id: `col-${column.id}`, data: { current: { type: 'column' } } } }) as unknown as DragStartEvent;
+
+const dropColumnOn = (dragged: BoardColumn, over: BoardColumn): DragEndEvent =>
+  ({
+    active: { id: `col-${dragged.id}`, data: { current: { type: 'column' } } },
+    over: { id: `col-${over.id}`, data: { current: { type: 'column' } } },
+  }) as unknown as DragEndEvent;
+
 // Mirrors how BoardPage wires the hook: the board owns the task/column state, the hook reads it and
 // writes back through the setters. Keeping real state here is what makes the "created after mount"
 // case meaningful — the hook must see the appended task, not the list it was first rendered with.
-const useBoardHarness = (initialTasks: BoardTask[]) => {
+const useBoardHarness = (initialTasks: BoardTask[], initialColumns: BoardColumn[] = [BACKLOG, IN_PROGRESS]) => {
   const [tasks, setTasks] = useState<BoardTask[]>(initialTasks);
-  const [columns, setColumns] = useState<BoardColumn[]>([BACKLOG, IN_PROGRESS]);
+  const [columns, setColumns] = useState<BoardColumn[]>(initialColumns);
   const dnd = useBoardDnd({ projectId: PROJECT_ID, enabled: true, tasks, setTasks, columns, setColumns });
-  return { tasks, setTasks, ...dnd };
+  return { tasks, setTasks, columns, setColumns, ...dnd };
 };
 
 type FetchCall = Parameters<typeof fetch>;
 
 const moveCalls = (calls: FetchCall[], taskId: number) =>
   calls.filter(([url]) => url === `/api/v1/projects/${PROJECT_ID}/tasks/${taskId}/move`);
+
+const reorderCalls = (calls: FetchCall[]) =>
+  calls.filter(([url]) => url === `/api/v1/projects/${PROJECT_ID}/columns/reorder`);
 
 const moveBody = (call: FetchCall) => JSON.parse((call[1] as RequestInit).body as string);
 
@@ -100,5 +113,46 @@ describe('useBoardDnd', () => {
     });
 
     await waitFor(() => expect(result.current.tasks.find((t) => t.id === task.id)?.boardColumnId).toBe(100));
+  });
+
+  // Regression for #580: dragging a column used to persist via `setColumns` *and* trigger a
+  // follow-up `router.reload({ only: ['columns'] })`. That reload is an async Inertia partial
+  // reload with no ordering guarantee against any other in-flight one (e.g. the reload the
+  // "add column" flow fires right after creating a column) — whichever response lands last wins,
+  // so a reload fired here could be clobbered by a slightly earlier, now-stale one and the drag
+  // would appear to revert. The fix drops the reload and trusts the optimistic order, which
+  // already matches what the server persists.
+  it('persists a column reorder without triggering a page reload', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    // A column "just created" in this session — the exact scenario the bug report calls out.
+    const created = buildBoardColumn({ id: 300, name: 'Done', position: 2 });
+    const { result } = renderHook(() => useBoardHarness([], [BACKLOG, IN_PROGRESS, created]));
+
+    act(() => result.current.handleDragStart(pickUpColumn(created)));
+    await act(async () => {
+      await result.current.handleDragEnd(dropColumnOn(created, BACKLOG));
+    });
+
+    await waitFor(() => expect(reorderCalls(fetchSpy.mock.calls)).toHaveLength(1));
+    expect(JSON.parse((reorderCalls(fetchSpy.mock.calls)[0][1] as RequestInit).body as string)).toEqual({
+      columnIds: [300, 100, 200],
+    });
+    expect(result.current.columns.map((c) => c.id)).toEqual([300, 100, 200]);
+    expect(router.reload).not.toHaveBeenCalled();
+  });
+
+  it('restores the pre-drag column order when the reorder request fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
+    const created = buildBoardColumn({ id: 300, name: 'Done', position: 2 });
+    const { result } = renderHook(() => useBoardHarness([], [BACKLOG, IN_PROGRESS, created]));
+
+    act(() => result.current.handleDragStart(pickUpColumn(created)));
+    await act(async () => {
+      await result.current.handleDragEnd(dropColumnOn(created, BACKLOG));
+    });
+
+    await waitFor(() => expect(result.current.columns.map((c) => c.id)).toEqual([100, 200, 300]));
   });
 });

--- a/app/frontend/pages/Projects/Board/useBoardDnd.ts
+++ b/app/frontend/pages/Projects/Board/useBoardDnd.ts
@@ -1,6 +1,5 @@
 import type { DragEndEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
-import { router } from '@inertiajs/react';
 import { type Dispatch, type SetStateAction, useCallback, useRef, useState } from 'react';
 
 import { apiFetch } from 'shared/lib/apiFetch';
@@ -141,17 +140,20 @@ export function useBoardDnd<T extends DndTask, C extends DndColumn>({
         const newOrder = arrayMove(columns, oldIdx, newIdx);
         setColumns(newOrder);
 
-        // persist to server with error recovery
+        // Persist to the server. The optimistic `newOrder` above already matches what the
+        // server will store (it renumbers columns in the exact order sent), so success needs
+        // no follow-up reload — a `router.reload` here is an async Inertia partial reload with
+        // no ordering guarantee against any other in-flight reload (e.g. one from creating a
+        // column moments earlier), so it can land second and clobber this persisted order with
+        // stale data (#580). Only revert on failure.
         apiFetch(reorderApiV1ProjectColumnsPath(projectId), {
           method: 'PATCH',
           headers: jsonHeaders,
           body: JSON.stringify({ columnIds: newOrder.map((c) => c.id) }),
-        })
-          .then(() => router.reload({ only: ['columns'] }))
-          .catch(() => {
-            setColumns(columns); // revert on error
-            // Error toast would be shown by global error handler
-          });
+        }).catch(() => {
+          setColumns(columns); // revert on error
+          // Error toast would be shown by global error handler
+        });
         return;
       }
 


### PR DESCRIPTION
## Problem

Reported: after creating a new board column and dragging it to a new position in the UI, the reorder didn't persist — the column would appear to move, then snap back to its previous place on reload. Reordering *existing* columns worked, and reordering via Personal MCP worked; only a newly-created column dragged in the UI was affected. A second issue was also flagged: columns in the collapsed state couldn't be dragged at all.

## Root cause

**Reorder race (the main bug).** The backend `reorder` endpoint itself was correct — verified with a Rails test that creates a column, reorders it to the front, and re-fetches, which persisted correctly every time. The bug was purely client-side:

- Creating a column and reordering columns both finished by calling `router.reload({ only: ['columns'] })`.
- Inertia's async partial reloads (`asyncRequestStream`, `maxConcurrent: Infinity`, `interruptible: false`) have **no ordering guarantee or cancellation** against each other for reloads to the same page. Whichever response *arrives* last wins, regardless of which request was *sent* last.
- Sequence that triggers it: create a column → its reload fires and is still in flight → user immediately drags the new column → the reorder PATCH succeeds → its own reload fires and resolves *first* → but the earlier create-reload (reflecting the pre-drag order) can still resolve *after* it and silently overwrite the correct order with stale data.

This explains why it was hard to reproduce locally: on localhost both requests resolve fast enough, in order, that the race rarely manifests, but production latency makes the out-of-order arrival much more likely — and it only shows up right after creating a column because that's the only flow that fires two `columns` reloads close together.

**Collapsed-column drag.** `useSortable`'s `listeners` were destructured in `BoardColumn` but only ever spread onto the *expanded* header's title. The collapsed render never attached them anywhere, so a collapsed column could be expanded/collapsed by click but never dragged to reorder.

## Fix

- Removed the trailing `router.reload({ only: ['columns'] })` after column create, drag-reorder, and the move-left/move-right buttons. Each of these already has (or now uses) the exact data that gets persisted — the create endpoint's response, or the optimistic reordered array — so state is updated directly from that instead of racing a second reload against whatever else is in flight.
- Wired the collapsed column's drag listeners onto its vertical name label, mirroring how the expanded header's title already works as the drag handle.

## Testing

- Added a Rails test reproducing "create column → reorder → reload" to confirm the backend was never the problem (removed after confirming, not part of this diff).
- Added regression tests:
  - `useBoardDnd.test.ts`: column reorder persists without a page reload; reverts on request failure.
  - `BoardPage.test.tsx`: the collapsed column's name label carries the drag-handle listeners/style.
- `docker compose exec -T web make check_all`: all checks green (rails-test, rubocop, brakeman, system-test, eslint, typescript, fe-test). `vite-build` fails, but that's a pre-existing environment issue reproducible on a clean `develop` checkout, unrelated to this change.