### PR TITLE
fix(agents): clear stale designOauth token on invalid_grant to restore DesignSync

### DIFF
--- a/app/services/agents/claude_code_adapter.rb
+++ b/app/services/agents/claude_code_adapter.rb
@@ -232,6 +232,7 @@ module Agents
       current = credential.config_data
       now_ms  = (Time.current.to_f * 1000).to_i
       refreshed_blocks = {}
+      invalidated_blocks = {}
       error = nil
 
       OAUTH_BLOCKS.each do |block_name|
@@ -245,22 +246,38 @@ module Agents
         client_id = block_name == "designOauth" ? block["clientId"] : base_oauth_client_id
         new_block = request_oauth_refresh(client_id: client_id, refresh_token: block["refreshToken"],
                                           previous: block, now_ms: now_ms)
-        if new_block
+        if new_block == :invalid_grant
+          # Server has permanently rejected the refresh token. Clear accessToken so
+          # config_files does not write a stale token into the next container — which
+          # would cause DesignSync (or base inference) to fail with an opaque 401.
+          # refreshToken is preserved so the block stays in the DB and the UI shows
+          # "Reconnect Design" rather than losing the Design connection entirely.
+          invalidated_blocks[block_name] = block.except("accessToken")
+          error ||= "#{block_name} invalid_grant — reconnection required"
+        elsif new_block
           refreshed_blocks[block_name] = new_block
         else
           error ||= "#{block_name} refresh failed"
         end
       end
 
-      return { status: :error,      detail: error } if refreshed_blocks.empty? && error
-      return { status: :not_needed, detail: nil }   if refreshed_blocks.empty?
+      changes = refreshed_blocks.merge(invalidated_blocks)
 
-      credential.with_lock do
-        fresh    = credential.config_data
-        incoming = fresh.merge(refreshed_blocks)                # only the blocks we refreshed change
-        merged   = merge_refreshed_credentials(fresh, incoming) # existing per-block freshest guard
-        AgentCredential.from_artifacts(credential.user_id, credential.company_id, "claude_code", merged) if merged != fresh
+      if changes.any?
+        credential.with_lock do
+          fresh    = credential.config_data
+          incoming = fresh.merge(changes)
+          merged   = merge_refreshed_credentials(fresh, incoming)
+          # Invalidated blocks must bypass the freshest-token guard: the cleared block
+          # has no expiresAt and would lose to the stored stale one.
+          invalidated_blocks.each_key { |k| merged[k] = incoming[k] }
+          AgentCredential.from_artifacts(credential.user_id, credential.company_id, "claude_code", merged) if merged != fresh
+        end
       end
+
+      return { status: :error,      detail: error } if changes.empty? && error
+      return { status: :not_needed, detail: nil }   if changes.empty?
+      return { status: :error,      detail: error } if invalidated_blocks.any? && refreshed_blocks.empty?
 
       { status: :refreshed, detail: error } # partial failure (one block ok, one failed) still counts as refreshed
     end

--- a/app/services/agents/claude_code_adapter.rb
+++ b/app/services/agents/claude_code_adapter.rb
@@ -876,7 +876,12 @@ module Agents
       )
       response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true, open_timeout: 5, read_timeout: 10) { |h| h.request(req) }
       unless response.is_a?(Net::HTTPSuccess)
-        Rails.logger.warn("[ClaudeCodeAdapter] Token refresh failed: #{response.code} #{response.body.to_s.truncate(200)}")
+        body = response.body.to_s
+        Rails.logger.warn("[ClaudeCodeAdapter] Token refresh failed: #{response.code} #{body.truncate(200)}")
+        if response.code == "400"
+          parsed = JSON.parse(body) rescue {}
+          return :invalid_grant if parsed["error"] == "invalid_grant"
+        end
         return nil
       end
       data = JSON.parse(response.body)

--- a/test/services/agents/claude_code_adapter_test.rb
+++ b/test/services/agents/claude_code_adapter_test.rb
@@ -703,7 +703,7 @@ module Agents
       assert_equal :error, result[:status]
       assert_match(/designOauth/, result[:detail])
       block = cred.reload.config_data["designOauth"]
-      refute block["accessToken"].present?, "accessToken must be cleared after invalid_grant"
+      refute_predicate block["accessToken"], :present?, "accessToken must be cleared after invalid_grant"
       assert_equal "stale-dr", block["refreshToken"]
       assert_equal "design-client", block["clientId"]
     end
@@ -725,7 +725,7 @@ module Agents
 
       assert_equal :error, result[:status]
       block = cred.reload.config_data["claudeAiOauth"]
-      refute block["accessToken"].present?, "accessToken must be cleared after invalid_grant"
+      refute_predicate block["accessToken"], :present?, "accessToken must be cleared after invalid_grant"
       assert_equal "stale-r", block["refreshToken"]
     end
 

--- a/test/services/agents/claude_code_adapter_test.rb
+++ b/test/services/agents/claude_code_adapter_test.rb
@@ -683,6 +683,34 @@ module Agents
       assert_equal "d-a", reloaded.dig("designOauth", "accessToken") # failed block left intact
     end
 
+    test "request_oauth_refresh returns :invalid_grant on 400 invalid_grant response" do
+      stub_request(:post, ClaudeCodeAdapter::OAUTH_TOKEN_URL)
+        .to_return(status: 400,
+                   body: { error: "invalid_grant", error_description: "Refresh token expired" }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+
+      result = @adapter.send(:request_oauth_refresh,
+                             client_id: "some-client",
+                             refresh_token: "expired-rt",
+                             previous: { "scopes" => [] },
+                             now_ms: 0)
+
+      assert_equal :invalid_grant, result
+    end
+
+    test "request_oauth_refresh returns nil on non-2xx that is not invalid_grant" do
+      stub_request(:post, ClaudeCodeAdapter::OAUTH_TOKEN_URL)
+        .to_return(status: 500, body: "internal error")
+
+      result = @adapter.send(:request_oauth_refresh,
+                             client_id: "some-client",
+                             refresh_token: "rt",
+                             previous: { "scopes" => [] },
+                             now_ms: 0)
+
+      assert_nil result
+    end
+
     # == Amazon Bedrock (bring-your-own cloud account) ==
 
     test "config_files writes no aws config and no bedrock env without an awsBedrock block" do

--- a/test/services/agents/claude_code_adapter_test.rb
+++ b/test/services/agents/claude_code_adapter_test.rb
@@ -683,6 +683,68 @@ module Agents
       assert_equal "d-a", reloaded.dig("designOauth", "accessToken") # failed block left intact
     end
 
+    test "refresh! clears designOauth accessToken on invalid_grant and returns error" do
+      soon = ms_from_now(5 * 60 * 1000)
+      cred = create(:agent_credential, :claude_code, user: @user, config_data: {
+        "designOauth" => {
+          "accessToken" => "stale-d", "refreshToken" => "stale-dr",
+          "expiresAt" => soon, "clientId" => "design-client",
+          "scopes" => %w[user:design:read user:design:write]
+        }
+      })
+      stub_request(:post, ClaudeCodeAdapter::OAUTH_TOKEN_URL)
+        .with(body: { grant_type: "refresh_token", client_id: "design-client", refresh_token: "stale-dr" })
+        .to_return(status: 400,
+                   body: { error: "invalid_grant", error_description: "Refresh token expired" }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+
+      result = @adapter.refresh!(cred)
+
+      assert_equal :error, result[:status]
+      assert_match(/designOauth/, result[:detail])
+      block = cred.reload.config_data["designOauth"]
+      refute block["accessToken"].present?, "accessToken must be cleared after invalid_grant"
+      assert_equal "stale-dr", block["refreshToken"]
+      assert_equal "design-client", block["clientId"]
+    end
+
+    test "refresh! clears claudeAiOauth accessToken on invalid_grant" do
+      soon = ms_from_now(5 * 60 * 1000)
+      cred = create(:agent_credential, :claude_code, user: @user, config_data: {
+        "claudeAiOauth" => {
+          "accessToken" => "stale-a", "refreshToken" => "stale-r",
+          "expiresAt" => soon, "scopes" => %w[user:inference]
+        }
+      })
+      stub_request(:post, ClaudeCodeAdapter::OAUTH_TOKEN_URL)
+        .to_return(status: 400,
+                   body: { error: "invalid_grant", error_description: "Refresh token expired" }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+
+      result = @adapter.refresh!(cred)
+
+      assert_equal :error, result[:status]
+      block = cred.reload.config_data["claudeAiOauth"]
+      refute block["accessToken"].present?, "accessToken must be cleared after invalid_grant"
+      assert_equal "stale-r", block["refreshToken"]
+    end
+
+    test "refresh! does not clear accessToken on transient 5xx error" do
+      soon = ms_from_now(5 * 60 * 1000)
+      cred = create(:agent_credential, :claude_code, user: @user, config_data: {
+        "designOauth" => {
+          "accessToken" => "live-d", "refreshToken" => "live-dr",
+          "expiresAt" => soon, "clientId" => "design-client"
+        }
+      })
+      stub_request(:post, ClaudeCodeAdapter::OAUTH_TOKEN_URL).to_return(status: 500, body: "boom")
+
+      result = @adapter.refresh!(cred)
+
+      assert_equal :error, result[:status]
+      assert_equal "live-d", cred.reload.config_data.dig("designOauth", "accessToken")
+    end
+
     test "request_oauth_refresh returns :invalid_grant on 400 invalid_grant response" do
       stub_request(:post, ClaudeCodeAdapter::OAUTH_TOKEN_URL)
         .to_return(status: 400,


### PR DESCRIPTION
## Summary

- When Anthropic's OAuth endpoint returns `400 invalid_grant` (refresh token permanently expired), `refresh!` now clears `accessToken` from the affected block and persists the update
- This prevents a stale token from being injected into containers — DesignSync previously received it and failed with a silent 401 for weeks
- `request_oauth_refresh` distinguishes `invalid_grant` from transient errors (5xx / network) so transient failures never wipe a still-valid token

## Root cause (found in production)

`artem.petrov`'s `designOauth.accessToken` expired ~19 days ago. The Temporal sweep called `refresh!` every 5 minutes, got `400 invalid_grant`, logged a warning, and left the expired token in the DB. On each session start the stale token was written into `.credentials.json`, DesignSync called the OmeletteService gRPC API with it, got 401, and sync silently did nothing.

## What changes

`app/services/agents/claude_code_adapter.rb`:
- `request_oauth_refresh`: returns `:invalid_grant` sentinel on `400 invalid_grant`, `nil` on other non-2xx
- `refresh!`: tracks `invalidated_blocks` separately; on `:invalid_grant` stores `block.except("accessToken")`; bypasses the freshest-token guard for invalidated blocks so the cleared state is never overwritten by the stale stored one; returns `status: :error` when only invalidations occurred

`refreshToken` and `clientId` are preserved in the cleared block so the Profile page shows **"Reconnect Design"** rather than removing the entry entirely.

## Test plan

- [x] `request_oauth_refresh returns :invalid_grant on 400 invalid_grant response`
- [x] `request_oauth_refresh returns nil on non-2xx that is not invalid_grant`
- [x] `refresh! clears designOauth accessToken on invalid_grant and returns error`
- [x] `refresh! clears claudeAiOauth accessToken on invalid_grant`
- [x] `refresh! does not clear accessToken on transient 5xx error`
- [x] All 123 existing adapter tests pass
- [x] `make check_all` green

