### PR TITLE
fix(sidebar): scroll the project switcher dropdown instead of overflowing

### DIFF
--- a/app/frontend/shared/ui/AppSidebar.module.css
+++ b/app/frontend/shared/ui/AppSidebar.module.css
@@ -351,11 +351,15 @@
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.7) !important;
   width: 216px !important;
   left: 4px !important;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 88px);
 }
 
 .swSearch {
   padding: 10px 12px;
   border-bottom: 1px solid var(--app-border-default);
+  flex: none;
 }
 
 .swSearchInput {
@@ -377,6 +381,21 @@
 
 .swSection {
   padding: 10px 10px 8px;
+  flex: none;
+}
+
+.swProjectsSection {
+  padding: 10px 10px 8px;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.swProjectsList {
+  overflow-y: auto;
+  min-height: 0;
+  scrollbar-width: thin;
 }
 
 .dpLabel {
@@ -453,6 +472,7 @@
 .dpFooter {
   padding: 8px 10px 12px;
   border-top: 1px solid var(--app-border-default);
+  flex: none;
 }
 
 .dpNewProject {

--- a/app/frontend/shared/ui/AppSidebar.tsx
+++ b/app/frontend/shared/ui/AppSidebar.tsx
@@ -508,27 +508,29 @@ function SidebarWorkspaceSwitcher({
             />
           </div>
 
-          <div className={classes.swSection}>
+          <div className={classes.swProjectsSection}>
             <span className={classes.dpLabel}>PROJECTS</span>
-            {filteredProjects.map((project) => {
-              const isActive = String(project.id) === currentProjectId;
-              return (
-                <UnstyledButton
-                  key={project.id}
-                  component={Link}
-                  href={companyProjectPath(String(project.id))}
-                  aria-current={isActive ? 'page' : undefined}
-                  className={`${classes.dpItem} ${isActive ? classes.dpItemActive : ''}`}
-                  onClick={handleProjectClick}
-                >
-                  <div className={classes.dpIco}>
-                    <span className={classes.dpIcoLetter}>{(project.name?.[0] ?? 'P').toUpperCase()}</span>
-                  </div>
-                  <span className={classes.dpName}>{project.name}</span>
-                  {isActive && <IconCheck size={12} className={classes.dpCheck} />}
-                </UnstyledButton>
-              );
-            })}
+            <div className={classes.swProjectsList}>
+              {filteredProjects.map((project) => {
+                const isActive = String(project.id) === currentProjectId;
+                return (
+                  <UnstyledButton
+                    key={project.id}
+                    component={Link}
+                    href={companyProjectPath(String(project.id))}
+                    aria-current={isActive ? 'page' : undefined}
+                    className={`${classes.dpItem} ${isActive ? classes.dpItemActive : ''}`}
+                    onClick={handleProjectClick}
+                  >
+                    <div className={classes.dpIco}>
+                      <span className={classes.dpIcoLetter}>{(project.name?.[0] ?? 'P').toUpperCase()}</span>
+                    </div>
+                    <span className={classes.dpName}>{project.name}</span>
+                    {isActive && <IconCheck size={12} className={classes.dpCheck} />}
+                  </UnstyledButton>
+                );
+              })}
+            </div>
           </div>
 
           <div className={classes.swSection}>


### PR DESCRIPTION
## Problem
The project switcher dropdown in the sidebar rendered as a single unbounded block: the `Popover.Dropdown` had no `max-height`, and the `PROJECTS` list inside it had no scroll behavior of its own. For a company with many projects, the dropdown grew taller than the viewport and simply clipped — items below the fold were unreachable by mouse or trackpad, leaving Search as the only way to reach them.

## Fix

`app/frontend/shared/ui/AppSidebar.tsx` / `AppSidebar.module.css` (`SidebarWorkspaceSwitcher`):

- The dropdown (`.swDropdown`) is now a flex column capped at `calc(100vh - 88px)`, so it scales with the viewport instead of overflowing or using an arbitrary fixed height.
- The `PROJECTS` list moved into its own scrollable region (`.swProjectsList`, inside a flex-growing `.swProjectsSection`) so only the list scrolls.
- Search, `ADMIN` / All Projects, and `+ New project` are non-shrinking flex siblings, so they stay pinned in place while the project list scrolls underneath.
- With a short (or filtered) list, nothing forces extra height, so the dropdown still shrinks to fit its content — no empty scroll area or unnecessary scrollbar.

## Testing

- Seeded the local dev DB with 32 projects for the demo company to reproduce the original overflow, then verified in the browser:
  - Dropdown no longer overflows the viewport.
  - Project list scrolls with mouse wheel; items at the bottom (e.g. "Zebra Migration") are reachable.
  - Search input stays visible and functional while scrolling.
  - `ADMIN` / All Projects and `+ New project` stay visible without scrolling.
  - Typing in Search filters the list down to a short result set with no leftover scroll area.
- `docker compose exec -T web make check_all`: rails-test, rubocop, brakeman, eslint, typescript, fe-test (vitest), and system-test all pass. `vite-build` fails, but reproduces identically on `develop` with this diff stashed out — pre-existing environment issue, unrelated to this change.