### PR TITLE
docs(portal): publish the product user guide and product-area snapshots at /docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to Aixle Flow are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/) once
-tagged releases begin.
+tagged releases begin. User-visible entries are tagged with a product area from
+[docs/product/changelog-product-areas.md](docs/product/changelog-product-areas.md).
 
 > Versioning and tagged releases begin with the open-source launch. The first
 > tag will be **`v0.1.0`** (the project is pre-1.0), cut from the *Unreleased*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to Aixle Flow are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/) once
-tagged releases begin. User-visible entries are tagged with a product area from
-[docs/product/changelog-product-areas.md](docs/product/changelog-product-areas.md).
+tagged releases begin. Entries a *user* sees in the product carry a product
+area from
+[docs/product/changelog-product-areas.md](docs/product/changelog-product-areas.md)
+as their prefix; repository-level entries a *contributor* needs — licensing,
+governance, community health — carry none.
 
 > Versioning and tagged releases begin with the open-source launch. The first
 > tag will be **`v0.1.0`** (the project is pre-1.0), cut from the *Unreleased*
@@ -19,7 +22,7 @@ tagged releases begin. User-visible entries are tagged with a product area from
   inventory (`THIRD-PARTY-LICENSES.md`, `NOTICES.md`).
 - Contributor model: Contributor License Agreement (`CLA.md`) and Developer
   Certificate of Origin (`DCO`) sign-off, documented in `CONTRIBUTING.md`.
-- Public documentation portal at `/docs`.
+- **Docs**: public documentation portal at `/docs`.
 - Open-source documentation layer: README, ROADMAP, quickstart, user guide, and
   reference content.
 - Community health files: Code of Conduct, Security Policy, Governance, issue

--- a/app/controllers/web/docs_controller.rb
+++ b/app/controllers/web/docs_controller.rb
@@ -24,6 +24,6 @@ class Web::DocsController < Web::ApplicationController
   def page_exists?(slug)
     %w[user-guide quick-start agents runtimes tools mcp board workflows
        triggers-and-gates integrations configuration reference cli-ref api-guide
-       config-schema].include?(slug)
+       config-schema user-guide-outline changelog-product-areas].include?(slug)
   end
 end

--- a/app/controllers/web/docs_controller.rb
+++ b/app/controllers/web/docs_controller.rb
@@ -22,7 +22,10 @@ class Web::DocsController < Web::ApplicationController
   private
 
   def page_exists?(slug)
-    %w[user-guide quick-start agents runtimes tools mcp board workflows
+    %w[using-flow getting-started project-home tasks running-workflows starting-work
+       sessions-and-runs assets personas agent-capabilities repositories ai-builder
+       people-and-access secrets analytics company-workspace examples
+       user-guide quick-start agents runtimes tools mcp board workflows
        triggers-and-gates integrations configuration reference cli-ref api-guide
        config-schema].include?(slug)
   end

--- a/app/frontend/pages/Docs/data/navStructure.test.ts
+++ b/app/frontend/pages/Docs/data/navStructure.test.ts
@@ -16,6 +16,7 @@ describe('findNavSection', () => {
   it('returns the section that contains the slug', () => {
     expect(findNavSection('api-guide')?.label).toBe('Reference');
     expect(findNavSection('agents')?.label).toBe('User guide');
+    expect(findNavSection('changelog-product-areas')?.label).toBe('Product');
   });
 });
 
@@ -27,9 +28,15 @@ describe('getPrevNext', () => {
   });
 
   it('last item has no next', () => {
-    const { prev, next } = getPrevNext('config-schema');
+    const { prev, next } = getPrevNext('changelog-product-areas');
     expect(next).toBeNull();
+    expect(prev?.slug).toBe('user-guide-outline');
+  });
+
+  it('crosses a section boundary', () => {
+    const { prev, next } = getPrevNext('config-schema');
     expect(prev?.slug).toBe('api-guide');
+    expect(next?.slug).toBe('user-guide-outline');
   });
 
   it('a middle item has both neighbours', () => {

--- a/app/frontend/pages/Docs/data/navStructure.test.ts
+++ b/app/frontend/pages/Docs/data/navStructure.test.ts
@@ -16,13 +16,20 @@ describe('findNavSection', () => {
   it('returns the section that contains the slug', () => {
     expect(findNavSection('api-guide')?.label).toBe('Reference');
     expect(findNavSection('agents')?.label).toBe('User guide');
+    expect(findNavSection('tasks')?.label).toBe('Using Flow');
   });
 });
 
 describe('getPrevNext', () => {
   it('first item has no prev', () => {
-    const { prev, next } = getPrevNext('user-guide');
+    const { prev, next } = getPrevNext('using-flow');
     expect(prev).toBeNull();
+    expect(next?.slug).toBe('getting-started');
+  });
+
+  it('walks from the end of the product guide into the operator guide', () => {
+    const { prev, next } = getPrevNext('user-guide');
+    expect(prev?.slug).toBe('examples');
     expect(next?.slug).toBe('quick-start');
   });
 

--- a/app/frontend/pages/Docs/data/navStructure.ts
+++ b/app/frontend/pages/Docs/data/navStructure.ts
@@ -11,6 +11,30 @@ export interface NavSection {
 }
 
 export const NAV_STRUCTURE: NavSection[] = [
+  // The product guide comes first: most readers arrive wanting to use Flow, not to
+  // install it. The operator sections below keep their slugs so existing links hold.
+  {
+    label: 'Using Flow',
+    items: [
+      { slug: 'using-flow', label: 'What Flow is' },
+      { slug: 'getting-started', label: 'Getting started' },
+      { slug: 'project-home', label: 'Project home & settings' },
+      { slug: 'tasks', label: 'Tasks & the board' },
+      { slug: 'running-workflows', label: 'Building workflows' },
+      { slug: 'starting-work', label: 'Triggers & gates' },
+      { slug: 'sessions-and-runs', label: 'Sessions & Runs' },
+      { slug: 'assets', label: 'Assets' },
+      { slug: 'personas', label: 'Agent personas' },
+      { slug: 'agent-capabilities', label: 'Wrappers, Skills & Connectors' },
+      { slug: 'repositories', label: 'Repositories & Integrations' },
+      { slug: 'ai-builder', label: 'AI Builder' },
+      { slug: 'people-and-access', label: 'Team & access' },
+      { slug: 'secrets', label: 'Secrets & Variables' },
+      { slug: 'analytics', label: 'Analytics & cost' },
+      { slug: 'company-workspace', label: 'Company workspace' },
+      { slug: 'examples', label: 'Worked examples' },
+    ],
+  },
   {
     label: 'User guide',
     items: [

--- a/app/frontend/pages/Docs/data/navStructure.ts
+++ b/app/frontend/pages/Docs/data/navStructure.ts
@@ -40,6 +40,13 @@ export const NAV_STRUCTURE: NavSection[] = [
       { slug: 'config-schema', label: 'Configuration reference' },
     ],
   },
+  {
+    label: 'Product',
+    items: [
+      { slug: 'user-guide-outline', label: 'User guide outline' },
+      { slug: 'changelog-product-areas', label: 'Changelog product areas' },
+    ],
+  },
 ];
 
 export function findNavItem(slug: string): NavItem | null {

--- a/app/frontend/pages/Docs/data/pages/agent-capabilities.md
+++ b/app/frontend/pages/Docs/data/pages/agent-capabilities.md
@@ -1,0 +1,47 @@
+# Wrappers, Skills & Connectors
+
+Three ways to give agents more than their own reasoning. They are easy to
+confuse, so start here:
+
+| | It gives the agent | Use when |
+| --- | --- | --- |
+| **Wrappers** | An action *you* define — a script or API turned into a callable tool | You have an internal service with no ready-made integration |
+| **Skills** | Know-how — packaged instructions loaded during a session | The same expertise keeps being retyped into prompts |
+| **Connectors** | Tools from an external server, ready-made | The agent must act on a system someone else built |
+
+## Wrappers
+
+The **Wrappers** page lists the project's custom tools. Each row shows how it
+runs — a container image you specify, or one of Flow's built-ins — and the list
+filters by name.
+
+Define a wrapper once, attach it to the steps that need it, and it becomes a
+capability the agent can call during a run. Deleting one asks for confirmation
+first, because a step that expects it will notice.
+
+## Skills
+
+The **Skills** page has two ways in:
+
+- **Catalog** — browse what is published, install what fits. Each entry shows
+  how many times it has been installed.
+- **Write one by hand** — the authoring form from the page header, for
+  know-how that is specific to your team: "how we write migrations", "our
+  review checklist", "our commit conventions".
+
+Installed skills are listed with their install counts. Attach a skill where it
+should apply, and agents follow it when the work matches.
+
+## Connectors
+
+The **Connectors** page manages external tool servers. Add one from the
+catalog, or by hand when you know the server you want. Servers you added
+yourself can be edited; the list filters by name.
+
+Credentials belong in [Secrets & Variables](/docs/secrets), not in the
+connector's own fields or in a task description — that is what keeps them out
+of prompts and logs.
+
+> tip If you are unsure which of the three you need: it is a **connector** if
+> someone else already runs it, a **wrapper** if you have to write it, and a
+> **skill** if there is nothing to call at all — only knowledge to apply.

--- a/app/frontend/pages/Docs/data/pages/ai-builder.md
+++ b/app/frontend/pages/Docs/data/pages/ai-builder.md
@@ -1,0 +1,39 @@
+# AI Builder
+
+Describe a process in plain language and let Flow build it: board columns,
+workflows, steps, and the tools they need. The sidebar entry is **AI Builder**
+with a **Build with AI** button; inside, the feature calls itself **Aixle
+Builder**.
+
+## Before you start
+
+The builder runs on a real agent, so the project needs at least one configured
+runtime — it says so plainly if none is connected. Viewers do not get the start
+control, since they cannot execute work in the project.
+
+## A builder session
+
+1. **Say what you want.** "When a card lands in Triage, summarise it, label it,
+   and draft a reply for review." Pick the model, and attach project assets if
+   the builder should read something first.
+2. **Watch it work.** The session shows its terminal live and an activity feed
+   naming each thing it creates as it creates it.
+3. **Check what it made.** The **Workflows** and **Board** tabs show the result
+   — workflows with their steps, columns with their auto-trigger bindings —
+   while the session is still open.
+4. **Finish Session** when it looks right.
+
+Previous builder sessions stay in a list; an unfinished one offers to continue
+where it stopped. A session that ended badly keeps its error, so you can see
+what it failed on rather than guessing.
+
+## Afterwards
+
+Everything the builder made is ordinary: the workflows open in the
+[workflow editor](/docs/running-workflows), the columns behave like any other
+[board](/docs/tasks) columns. Adjust by hand — the builder is a starting point,
+not a black box you have to accept whole.
+
+> tip The builder is at its best on a process you can describe in a paragraph.
+> For a seven-stage release pipeline, build the first two stages with it and
+> extend by hand.

--- a/app/frontend/pages/Docs/data/pages/analytics.md
+++ b/app/frontend/pages/Docs/data/pages/analytics.md
@@ -1,0 +1,41 @@
+# Analytics & Cost
+
+Agent work costs money per run, so Flow counts it everywhere: per card, per
+project, per company.
+
+## Project analytics
+
+The project's **Analytics** page answers "what did this cost us, and where did
+it go?"
+
+- **Period** — pick the window; every panel follows it.
+- **Scope** — switch between all sessions and workflow-driven ones, so ad-hoc
+  experiments do not muddy the numbers for an automated process.
+- **Participant** — narrow to one person's work.
+- **Cost & token usage** — spend and tokens over the period.
+- **Agent activity** — sessions and cost per runtime, so you can see what your
+  Claude Code and Codex usage actually cost side by side.
+- **Workflow breakdown** — per workflow, which is how you find the process that
+  is quietly expensive.
+- **Contribution heatmap** — activity over time at a glance.
+
+## Company analytics
+
+Admins get the same questions asked across every project: a per-project
+breakdown, and a **sources** panel showing where sessions came from — the
+board, a schedule, Slack, a webhook, a person — each as a share of the total.
+
+Large numbers are abbreviated (thousands of tokens, thousands of dollars) so a
+row stays readable.
+
+## Where else cost shows up
+
+- On a **card**, in its Analytics tab — what this one piece of work cost.
+- On a **run**, in the header totals and per step.
+- In your **Profile → Usage** — your own consumption, and the time left on any
+  usage window that applies to you.
+
+> tip Two numbers explain most surprises: cost per session on
+> [Overview](/docs/project-home), and the workflow breakdown here. A workflow
+> with a retry loop shows up in the second long before anyone notices in the
+> first.

--- a/app/frontend/pages/Docs/data/pages/assets.md
+++ b/app/frontend/pages/Docs/data/pages/assets.md
@@ -1,0 +1,30 @@
+# Assets
+
+**Assets** is the project's file shelf: what people upload for agents to work
+from, and what agents produce.
+
+## Uploading
+
+**Upload** takes files from your machine into the project. Anything here can be
+handed to a step as an input in the workflow editor's Data Flow section, or
+attached to a card so the agent working that card sees it.
+
+## What agents produce
+
+A run's output starts inside the run. Two ways it reaches the project:
+
+1. **Promote** a file from the run's Assets tab — a deliberate "this one
+   matters" gesture.
+2. **Review outputs** on the run in the list, keeping what you select.
+
+That two-step shape is on purpose: a long run can touch dozens of files, and
+most of them are scratch.
+
+## Finding and versioning
+
+Search narrows the list by name. Every asset keeps its **version history** —
+open it to see the earlier revisions and where each came from, which matters
+when the same report is regenerated weekly by the same workflow.
+
+> info Assets are per project. Files the whole company should reach live in
+> **Company Assets** — see [Company workspace](/docs/company-workspace).

--- a/app/frontend/pages/Docs/data/pages/changelog-product-areas.md
+++ b/app/frontend/pages/Docs/data/pages/changelog-product-areas.md
@@ -1,0 +1,154 @@
+# Aixle Flow Product Snapshot — Changelog Taxonomy
+
+> Deliverable for issue #551. A user-facing map of Aixle Flow as it exists
+> today, frozen as the changelog taxonomy: after a release, every user-visible
+> change is tagged with one **product area** from the tables below, so each
+> release reads as a change to a named part of the product — not as a list of
+> tickets.
+>
+> **Snapshot date:** 2026-08-20. Area names are verified against the product
+> UI on `develop` (sidebar labels, page titles, and on-screen control copy),
+> not internal engineering names.
+
+## What Aixle Flow is
+
+Aixle Flow is the team layer on top of personal AI coding agents. A person puts
+work on a board. An agent picks it up, does the work, and the team sees the
+run, the output, and the cost — without anyone opening a terminal.
+
+A **Company** is the workspace. Inside it, each **Project** has one board. Move
+a card into a column that is bound to a workflow, and the workflow starts. A
+workflow is a sequence of steps; each step is one agent doing one job. Steps
+can run in parallel, wait for each other, retry, or pause for a human. Every
+run leaves a trail: status, log, artifacts, tokens, and cost.
+
+Supported agent runtimes: Claude Code, Cursor CLI, Codex, Gemini CLI, Grok.
+
+## Product areas (changelog taxonomy)
+
+Use the names in **bold** in changelog entries. They match what people see in
+the product — or, where no single sidebar label exists (sign-in, triggers),
+they name a flow users would recognize.
+
+### Workspace
+
+| Area | What it covers |
+| --- | --- |
+| **Companies & projects** | Workspaces, switching between companies, creating and listing projects |
+| **Sign-in & onboarding** | Login, invitations, first-run setup: role, language, connecting an agent |
+| **Profile** | Personal agent credentials (connecting a runtime account), personal usage, personal access so Aixle can be used from an external agent |
+
+### Project — Work
+
+| Area | What it covers |
+| --- | --- |
+| **Overview** | Project home: activity, task distribution, spend, workflow run status |
+| **Tasks** | The board: columns, cards, subtasks, comments, attachments, waits, activity. Column → workflow binding (auto or manual). Board templates (Simple Kanban, Dev Team, Full SDLC) offered on an empty board |
+| **Workflows** | Named processes made of steps: instructions, which agent runs, dependencies, on-failure behavior (fail / retry / skip), human approval, inputs/outputs. Publishing and duplicating |
+| **Triggers & gates** | When a workflow starts (task enters column, manual run, schedule, Slack message, incoming webhook) and what can pause a run: a gate waiting on CI (waiting / passed / failed / stale) or a step waiting on a person |
+| **Sessions & Runs** | One list for both: workflow runs (step timeline, parallel waves, approve / retry / skip, cost) and the agent sessions inside them (status, live terminal, log, tokens, artifacts, cost) |
+| **Assets** | Files the team uploads and files agents produce; versioning and review |
+
+### Project — Resources
+
+| Area | What it covers |
+| --- | --- |
+| **Agents** | Personas (who the agent is, how it talks, what rules it follows). The same persona can run on any supported runtime |
+| **Wrappers** | Custom tools the team writes so agents can call services that have no connector |
+| **Skills** | Reusable know-how installed from a catalog or written by hand |
+| **Connectors** | External tool servers agents can call, from a catalog or added by hand |
+| **Repositories** | Linked Git repos the agent can work in and push to |
+| **Integrations** | Connected accounts: GitHub, GitLab, Linear, Slack, Coder |
+
+### Project — Admin
+
+| Area | What it covers |
+| --- | --- |
+| **Secrets & Variables** | Credentials and config values agents and connectors use |
+| **Members** | Who is on the project and with what access (roles: Admin, Employee, Viewer) |
+| **Analytics** | Spend, sessions, tokens, success — by project, agent, and source |
+| **Settings** | Project name, language, archive, delete |
+
+### Build with AI
+
+| Area | What it covers |
+| --- | --- |
+| **Aixle Builder** | Describe a process in plain language; the product creates workflows, steps, tools, and board setup. (Sidebar entry point is labeled "AI Builder" / "Build with AI"; the feature's pages are titled "Aixle Builder" — this taxonomy uses **Aixle Builder**) |
+
+### Company library & monitoring
+
+| Area | What it covers |
+| --- | --- |
+| **Workflow Catalog** | Shared workflows the team can copy into a project |
+| **Company analytics** | Spend and activity across projects (admins) |
+| **Company sessions** | Cross-project run visibility (admins) |
+| **Company assets** | Workspace-level files (admins) |
+| **Company members** | Who belongs to the company |
+
+### Help
+
+| Area | What it covers |
+| --- | --- |
+| **Docs** | The in-product documentation, linked from the public site as **Documentation** |
+
+## How the pieces fit (for changelog writers)
+
+Tasks (board) → card enters a bound column → Workflow starts → each Step is one
+Agent session → results, status, and cost come back to the board and to
+Sessions & Runs.
+
+Agents do not work in a vacuum. A run can receive: the card (title,
+description, comments, files, column purpose), workflow instructions, skills,
+wrappers, connectors, repositories, and secrets.
+
+## Changelog rules
+
+1. One entry maps to **one product area** from the tables above. If a change
+   spans two areas, split it or pick the one users notice first.
+2. Write for a user who never opens a terminal. Say what they can do now, not
+   how it was built.
+3. Preferred shape: **Added / Changed / Fixed / Removed** × product area, e.g.
+   `Added — Tasks: attach files directly to a card`.
+4. Do not mention implementation. If the only change is internal and users
+   cannot see it, it does not belong in the product changelog.
+5. Repository-level changes that a *contributor* must know about — licensing,
+   governance, community health files, contribution rules — stay in
+   `CHANGELOG.md` untagged. They are not product areas, and forcing one on
+   them would be a lie about where the change shows up.
+6. Keep this snapshot as the baseline. When a release adds a new area (a new
+   nav item or a new first-class object), update this snapshot in the same
+   change as the changelog entry — and add the matching chapter to
+   the [user guide outline](/docs/user-guide-outline).
+
+## Area → guide chapter
+
+Every area above is documented in one chapter of the
+[user guide outline](/docs/user-guide-outline). Keep the two in step.
+
+| Area | Chapter |
+| --- | --- |
+| Companies & projects | 20. The company workspace |
+| Sign-in & onboarding | 2. Your first session |
+| Profile | 2. Your first session |
+| Overview | 4. Overview |
+| Tasks | 5. Tasks — the board |
+| Workflows | 6. Workflows |
+| Triggers & gates | 7. Triggers & gates |
+| Sessions & Runs | 8. Sessions & Runs |
+| Assets | 9. Assets |
+| Agents | 10. Agents |
+| Wrappers | 11. Wrappers |
+| Skills | 12. Skills |
+| Connectors | 13. Connectors |
+| Repositories, Integrations | 14. Repositories & Integrations |
+| Aixle Builder | 15. AI Builder |
+| Members | 16. Team |
+| Secrets & Variables | 17. Secrets & Variables |
+| Analytics | 18. Analytics |
+| Settings | 19. Settings |
+| Workflow Catalog, Company analytics / sessions / assets / members | 20. The company workspace |
+| Docs | Not a chapter — the operator portal at `/docs` is a separate document set |
+
+## Out of scope
+
+Internals, APIs, ops, and anything not visible in the product.

--- a/app/frontend/pages/Docs/data/pages/company-workspace.md
+++ b/app/frontend/pages/Docs/data/pages/company-workspace.md
@@ -1,0 +1,37 @@
+# Company Workspace
+
+Above projects sits the company: the shared layer where things that should not
+be reinvented per project live.
+
+## Projects
+
+The **Projects** page lists what you have access to and is where new ones are
+created. If you belong to more than one company, a switcher on the far left
+moves between workspaces — each with its own projects, members, and numbers.
+
+## Workflow Catalog
+
+Workflows published from a project land in the catalog, with their publisher
+named. Anyone can search it and **Copy & Configure** one into a project of
+their choice — the copy is theirs to edit, so adjusting the steps does not
+touch the original.
+
+If you are not on any project yet, the catalog says so instead of offering a
+project to copy into.
+
+## Company-wide monitoring (admins)
+
+- **Analytics** — spend and activity across every project, with a per-project
+  breakdown and where sessions originate.
+- **Sessions** — every session in the workspace, with the same review controls
+  as a project's list: keep the artifacts worth keeping, dismiss the rest.
+
+## Company Assets and Members
+
+- **Assets** — files that belong to the workspace rather than to one project.
+  Upload and search work as they do in a project.
+- **Members** — everyone in the company, searchable, with role changes
+  available to admins. See [Team & access](/docs/people-and-access).
+
+> info Company analytics, sessions, and assets are admin-only. Members is not —
+> everyone can see who they work with.

--- a/app/frontend/pages/Docs/data/pages/examples.md
+++ b/app/frontend/pages/Docs/data/pages/examples.md
@@ -1,0 +1,50 @@
+# Worked Examples
+
+Two end-to-end stories. Each names every screen it touches, so you can replay
+it in your own workspace.
+
+## Drop a card, get a pull request back
+
+**The setup.** A lead connects the GitHub integration and links the service's
+repository ([Repositories & Integrations](/docs/repositories)). The board uses
+the **Dev Team** template, and its *Implementation* column is bound to an
+implementation workflow in board settings, set to **Auto**.
+
+**The work.** They write a card describing a small feature and drag it into
+*Implementation*.
+
+1. The run starts on its own. In [Sessions & Runs](/docs/sessions-and-runs) it
+   shows four steps: one plans, two run in parallel — implementation and tests
+   — and a final step waits for a person.
+2. The lead watches the implementing step's terminal live on the run page.
+3. The agent posts a summary of the diff to the card as a comment; the card's
+   CI gate goes to **waiting** while the pipeline runs, then **passed**.
+4. The waiting step shows **Approve & continue**. The lead approves, and the
+   final step opens the pull request in the team's own repo.
+5. The card moves to *Code Review*. Its Analytics tab shows what the whole
+   thing cost.
+
+**What made it work.** The column's purpose told the agent what
+*Implementation* means here; the persona told it how the team reviews; the
+repository resource is what let it push at all.
+
+## Build a workflow from one prompt
+
+**The setup.** An operator has a support inbox landing on the board and no
+process for it yet.
+
+1. They open [AI Builder](/docs/ai-builder) and type: *"When a card lands in
+   Triage, summarise it, label it, and draft a reply for review."*
+2. The builder proposes a *Triage* column with an auto binding, a three-step
+   workflow, and the connector it needs to read the ticketing system. The
+   Workflows and Board tabs show all of it before anything is final.
+3. The operator finishes the session, adds the connector's credential in
+   [Secrets & Variables](/docs/secrets), and drops a test card into *Triage*.
+4. The run appears in Sessions & Runs; the draft reply lands on the card as a
+   comment.
+5. They edit the second step by hand — the label set was too broad — and leave
+   the rest as generated.
+
+**What made it work.** The builder produced ordinary objects. Nothing about the
+workflow it wrote is special: it is edited, run, and measured like anything
+built by hand.

--- a/app/frontend/pages/Docs/data/pages/getting-started.md
+++ b/app/frontend/pages/Docs/data/pages/getting-started.md
@@ -1,0 +1,53 @@
+# Getting Started
+
+From an invitation to your first running workflow.
+
+## Sign in
+
+Accept the invitation you were emailed, or sign in if an account already exists
+for you. Flow supports email sign-in and Google.
+
+## Onboarding
+
+First-run onboarding is two steps and takes a minute.
+
+**1. About you.** Pick the role card that matches how you will work, and choose
+the language you want agents to write in — task summaries, review notes, and
+generated documents follow it. Continue stays disabled until both are set.
+
+**2. Connect agents.** Five cards, one per supported runtime: Claude Code,
+Cursor CLI, Codex, Gemini CLI, and Grok. Click **Connect** on the one whose
+account you already have. A terminal opens inline, the runtime's own login runs
+in it, and Flow keeps the resulting credential for you.
+
+You need at least one connected agent to finish onboarding — nothing can run on
+your behalf until then.
+
+> info Invited as a **viewer**? The connect step is replaced by a short tour.
+> Viewers read boards, runs and results; they do not start work, so they do not
+> need a credential.
+
+## Your profile
+
+Everything personal lives in **Profile**, on three tabs.
+
+| Tab | What is there |
+| --- | --- |
+| **Account** | Your display name, your connected agent credentials, default models, and the companies you belong to |
+| **Usage** | Your own sessions, tokens and spend — plus any usage window that applies to you, with the time left on it |
+| **MCP** | Personal access: generate a token so an agent you run *outside* Flow (your own Claude Code, for example) can reach your Aixle projects |
+
+Credentials expire the way the underlying product's do. Reconnect from the same
+place — the Account tab — and runs pick the new credential up.
+
+## Open your first project
+
+Go to **Projects**, pick one, and you land on its **Overview**: recent
+activity, how tasks are spread across the board, runs, sessions, success rate,
+and spend. From there, **Tasks** is the board where work actually happens.
+
+## What to read next
+
+1. [Tasks & the board](/docs/tasks) — where work enters and results land
+2. [Building workflows](/docs/running-workflows) — turning a process into steps
+3. [Sessions & Runs](/docs/sessions-and-runs) — watching and steering a run

--- a/app/frontend/pages/Docs/data/pages/index.ts
+++ b/app/frontend/pages/Docs/data/pages/index.ts
@@ -1,6 +1,7 @@
 import agents from './agents.md?raw';
 import apiGuide from './api-guide.md?raw';
 import board from './board.md?raw';
+import changelogProductAreas from './changelog-product-areas.md?raw';
 import cliRef from './cli-ref.md?raw';
 import configSchema from './config-schema.md?raw';
 import configuration from './configuration.md?raw';
@@ -11,6 +12,7 @@ import reference from './reference.md?raw';
 import runtimes from './runtimes.md?raw';
 import tools from './tools.md?raw';
 import triggersAndGates from './triggers-and-gates.md?raw';
+import userGuideOutline from './user-guide-outline.md?raw';
 import userGuide from './user-guide.md?raw';
 import workflows from './workflows.md?raw';
 
@@ -141,6 +143,18 @@ export const DOC_PAGES: Record<string, DocPage & { toc: TocItem[] }> = {
     section: 'Reference',
     content: configSchema,
     toc: extractToc(configSchema),
+  },
+  'user-guide-outline': {
+    title: 'User guide outline',
+    section: 'Product',
+    content: userGuideOutline,
+    toc: extractToc(userGuideOutline),
+  },
+  'changelog-product-areas': {
+    title: 'Changelog product areas',
+    section: 'Product',
+    content: changelogProductAreas,
+    toc: extractToc(changelogProductAreas),
   },
 };
 

--- a/app/frontend/pages/Docs/data/pages/index.ts
+++ b/app/frontend/pages/Docs/data/pages/index.ts
@@ -1,17 +1,34 @@
+import agentCapabilities from './agent-capabilities.md?raw';
 import agents from './agents.md?raw';
+import aiBuilder from './ai-builder.md?raw';
+import analytics from './analytics.md?raw';
 import apiGuide from './api-guide.md?raw';
+import assets from './assets.md?raw';
 import board from './board.md?raw';
 import cliRef from './cli-ref.md?raw';
+import companyWorkspace from './company-workspace.md?raw';
 import configSchema from './config-schema.md?raw';
 import configuration from './configuration.md?raw';
+import examples from './examples.md?raw';
+import gettingStarted from './getting-started.md?raw';
 import integrations from './integrations.md?raw';
 import mcp from './mcp.md?raw';
+import peopleAndAccess from './people-and-access.md?raw';
+import personas from './personas.md?raw';
+import projectHome from './project-home.md?raw';
 import quickStart from './quick-start.md?raw';
 import reference from './reference.md?raw';
+import repositories from './repositories.md?raw';
+import runningWorkflows from './running-workflows.md?raw';
 import runtimes from './runtimes.md?raw';
+import secrets from './secrets.md?raw';
+import sessionsAndRuns from './sessions-and-runs.md?raw';
+import startingWork from './starting-work.md?raw';
+import tasks from './tasks.md?raw';
 import tools from './tools.md?raw';
 import triggersAndGates from './triggers-and-gates.md?raw';
 import userGuide from './user-guide.md?raw';
+import usingFlow from './using-flow.md?raw';
 import workflows from './workflows.md?raw';
 
 export interface TocItem {
@@ -52,6 +69,108 @@ function slugify(text: string): string {
 }
 
 export const DOC_PAGES: Record<string, DocPage & { toc: TocItem[] }> = {
+  'using-flow': {
+    title: 'What Flow is',
+    section: 'Using Flow',
+    content: usingFlow,
+    toc: extractToc(usingFlow),
+  },
+  'getting-started': {
+    title: 'Getting started',
+    section: 'Using Flow',
+    content: gettingStarted,
+    toc: extractToc(gettingStarted),
+  },
+  'project-home': {
+    title: 'Project home & settings',
+    section: 'Using Flow',
+    content: projectHome,
+    toc: extractToc(projectHome),
+  },
+  tasks: {
+    title: 'Tasks & the board',
+    section: 'Using Flow',
+    content: tasks,
+    toc: extractToc(tasks),
+  },
+  'running-workflows': {
+    title: 'Building workflows',
+    section: 'Using Flow',
+    content: runningWorkflows,
+    toc: extractToc(runningWorkflows),
+  },
+  'starting-work': {
+    title: 'Triggers & gates',
+    section: 'Using Flow',
+    content: startingWork,
+    toc: extractToc(startingWork),
+  },
+  'sessions-and-runs': {
+    title: 'Sessions & Runs',
+    section: 'Using Flow',
+    content: sessionsAndRuns,
+    toc: extractToc(sessionsAndRuns),
+  },
+  assets: {
+    title: 'Assets',
+    section: 'Using Flow',
+    content: assets,
+    toc: extractToc(assets),
+  },
+  personas: {
+    title: 'Agent personas',
+    section: 'Using Flow',
+    content: personas,
+    toc: extractToc(personas),
+  },
+  'agent-capabilities': {
+    title: 'Wrappers, Skills & Connectors',
+    section: 'Using Flow',
+    content: agentCapabilities,
+    toc: extractToc(agentCapabilities),
+  },
+  repositories: {
+    title: 'Repositories & Integrations',
+    section: 'Using Flow',
+    content: repositories,
+    toc: extractToc(repositories),
+  },
+  'ai-builder': {
+    title: 'AI Builder',
+    section: 'Using Flow',
+    content: aiBuilder,
+    toc: extractToc(aiBuilder),
+  },
+  'people-and-access': {
+    title: 'Team & access',
+    section: 'Using Flow',
+    content: peopleAndAccess,
+    toc: extractToc(peopleAndAccess),
+  },
+  secrets: {
+    title: 'Secrets & Variables',
+    section: 'Using Flow',
+    content: secrets,
+    toc: extractToc(secrets),
+  },
+  analytics: {
+    title: 'Analytics & cost',
+    section: 'Using Flow',
+    content: analytics,
+    toc: extractToc(analytics),
+  },
+  'company-workspace': {
+    title: 'Company workspace',
+    section: 'Using Flow',
+    content: companyWorkspace,
+    toc: extractToc(companyWorkspace),
+  },
+  examples: {
+    title: 'Worked examples',
+    section: 'Using Flow',
+    content: examples,
+    toc: extractToc(examples),
+  },
   'user-guide': {
     title: 'User Guide',
     section: 'User guide',

--- a/app/frontend/pages/Docs/data/pages/people-and-access.md
+++ b/app/frontend/pages/Docs/data/pages/people-and-access.md
@@ -1,0 +1,35 @@
+# Team & Access
+
+Membership has two levels, and they answer different questions: *who belongs to
+the company* and *who works on this project*.
+
+## Roles
+
+| Role | Can |
+| --- | --- |
+| **Admin** | Everything an employee can, plus members, integrations, settings, and the company-wide analytics, sessions, and assets |
+| **Employee** | Work inside the projects they are on: cards, workflows, runs, resources |
+| **Viewer** | Read. Boards, runs and results are visible; nothing is started or changed |
+
+A role is per company. Being a viewer in one workspace and an employee in
+another is normal, and onboarding adapts: a viewer is never asked to connect an
+agent.
+
+## Company members
+
+**Members** under the company lists everyone in the workspace, searchable by
+name. An admin can promote an employee to admin from the row menu.
+
+## Project members
+
+A project's **Members** page controls who is on this project. **Add
+Collaborator** opens a picker listing only company users who are not already
+here, so you cannot add someone twice. The project owner is badged and cannot
+be removed; removing anyone else asks first.
+
+Members are matched by name *and* email when you search, which is the quicker
+route in a company where several people share a first name.
+
+> info Adding someone to a project does not give them a credential. They still
+> connect their own agent in [Profile](/docs/getting-started) before they can
+> run anything.

--- a/app/frontend/pages/Docs/data/pages/personas.md
+++ b/app/frontend/pages/Docs/data/pages/personas.md
@@ -1,0 +1,31 @@
+# Agent Personas
+
+**Agents** in the sidebar is not a list of running agents — it is the personas
+your team has defined. A persona says *who* the agent is: how it works, what
+tone it takes, what rules it must follow.
+
+## Why personas exist
+
+Without them, every workflow step carries its own copy of "review this code
+carefully, be strict about tests, comment in English". Personas let you say it
+once: "our reviewer", "our implementer", "our release writer". Change the
+persona, and every workflow step that references it changes with it.
+
+## A persona is not a product
+
+A persona is independent of the runtime. The same "our reviewer" can run on
+Claude Code today and on Codex tomorrow — the step's Execution section decides
+that, not the persona.
+
+## Working with them
+
+- **Create** a persona, give it a name and its instructions.
+- **Search** the list by name.
+- Each persona carries a **scope badge**: defined in this project, or shared
+  from the company.
+- Pick one in a workflow step's Resources section.
+
+> info A persona describes behaviour, not permission. What an agent can reach —
+> repositories, connectors, secrets — comes from the step's resources, and the
+> credential it runs under comes from the person who connected it in
+> [Profile](/docs/getting-started).

--- a/app/frontend/pages/Docs/data/pages/project-home.md
+++ b/app/frontend/pages/Docs/data/pages/project-home.md
@@ -1,0 +1,37 @@
+# Project Home & Settings
+
+## Overview
+
+**Overview** is the project's front page and the fastest answer to "what is
+this project doing, and what is it costing?"
+
+- **KPI cards** — board tasks, sessions launched, workflow runs, total spend,
+  each with a delta against the previous period, plus an average cost per
+  session once sessions have run.
+- **Workflow Runs** — a donut of run outcomes with a success rate, total, and a
+  legend; failures that need a look are called out rather than buried.
+- **Board Task Distribution** — how many cards sit in each column, as a bar
+  list. A long bar on one column is usually a queue, not progress.
+- **Recent Activity** — the latest things people and agents did in this
+  project, newest first.
+
+Each block links to the screen that explains it: the board, Sessions & Runs, or
+Analytics.
+
+## Settings
+
+**Settings** holds the few project-level things that are not resources.
+
+- **Project name** and **description** — Save stays disabled until you actually
+  change something, and a *Saved* chip confirms the write.
+- **Artifacts Language** — the language agents write their output in. New
+  projects default to English.
+- **Danger Zone** — **Archive** takes a finished project out of the way but
+  keeps its history; **Delete** removes it. Both ask for confirmation first,
+  and both return you to the projects list when they succeed.
+
+> warning Delete is not archive. If you only want the project out of the daily
+> list, archive it — an archived project keeps its board, runs, and numbers.
+
+Whether you see the delete control at all depends on your role; see
+[Team & access](/docs/people-and-access).

--- a/app/frontend/pages/Docs/data/pages/repositories.md
+++ b/app/frontend/pages/Docs/data/pages/repositories.md
@@ -1,0 +1,38 @@
+# Repositories & Integrations
+
+Two pages that together decide what an agent can touch outside Flow.
+
+## Integrations
+
+An **integration** is an account Flow connects to on the team's behalf:
+GitHub, GitLab, Linear, Slack, and Coder. Connect one from the page's
+**Connect** menu — GitHub through its app install, GitLab with a token, and so
+on.
+
+The table lists project integrations and company-wide ones together, each with
+a **Scope** badge, so it is always clear whether a connection is yours alone or
+inherited from the company. Removing one asks for confirmation.
+
+## Repositories
+
+A **repository** is a Git repo agents can read, work in, and push to. Each row
+shows the branch the project works from, and company-wide repositories appear
+in the same table with their scope marked.
+
+Link the repos a project actually needs — not every repo the company owns. A
+step only reaches the repositories its Resources section lists.
+
+## What this unlocks
+
+With a repository linked and an integration connected, a run can:
+
+- read the codebase it is asked about,
+- push a branch and open a pull request in your own remote,
+- move the ticket that started the work.
+
+Nothing in Flow rewrites your Git history behind your back: agents work on
+branches, and what lands is what your review process lets land.
+
+> warning Access is inherited by every step that lists the repository. If a
+> workflow should not be able to push, do not give its steps the repo — that is
+> the control, not an agent instruction asking it politely.

--- a/app/frontend/pages/Docs/data/pages/running-workflows.md
+++ b/app/frontend/pages/Docs/data/pages/running-workflows.md
@@ -1,0 +1,52 @@
+# Building Workflows
+
+A **workflow** is a named process made of ordered **steps**. Each step is one
+agent session doing one job. Write the process once, and every card that enters
+the bound column is handled the same way.
+
+## Create a workflow
+
+**Workflows → New Workflow**, give it a name and a description. Then add steps.
+An empty name is rejected, and cancelling posts nothing.
+
+Steps show up as a tree on the left: the run order top to bottom, with
+sub-steps nested underneath a step that needs breaking down. Click a step to
+open its editor on the right.
+
+## What a step holds
+
+The step editor is grouped into sections. Most steps only need the first two.
+
+| Section | What you set |
+| --- | --- |
+| **Definition** | The step's name and its instructions — what the agent is being asked to do |
+| **Execution** | The runtime the step must run on, and optionally a preferred model. Changing the runtime resets the model choice, since model names are per-product |
+| **Resources** | What the agent gets: an agent persona, assets, skills, wrappers, connectors, repositories, and secrets & variables. A step can inherit everything the project has, or take a named subset |
+| **Data Flow** | Input and output asset specs — the files this step expects, and the files it is expected to leave behind, matched by pattern |
+| **Dependencies** | Which other steps must finish first. Steps with no dependency between them run at the same time |
+| **Behavior** | **On Failure**: Fail, Retry, or Skip. **Skip Policy**: Never, If outputs exist, or Manual. Whether the step waits for a person before the run continues |
+
+> info Dependencies are what make a run parallel. Two steps that both depend
+> only on "plan" will run side by side, and the run detail shows both consoles
+> at once.
+
+## Approval steps
+
+Mark a step as needing a person, and the run stops there and waits. The waiting
+step shows **Approve & continue** in [Sessions & Runs](/docs/sessions-and-runs).
+Use it where the cost of being wrong is higher than the cost of waiting:
+merging, releasing, anything that touches customers.
+
+## Reusing a workflow
+
+- **Duplicate** — copy it inside the project and edit the copy.
+- **Publish to the catalog** — offer it to the whole company. It then appears
+  in the [Workflow Catalog](/docs/company-workspace) with a **Copy & Configure**
+  action, so another project can take it and adjust the details.
+- **Run it by hand** — **Run workflow** starts a run without a card moving.
+
+## Starting it automatically
+
+Binding it to a board column is the common case, but a workflow can also start
+on a schedule, from a Slack message, or from an incoming webhook. That is the
+subject of [Triggers & gates](/docs/starting-work).

--- a/app/frontend/pages/Docs/data/pages/secrets.md
+++ b/app/frontend/pages/Docs/data/pages/secrets.md
@@ -1,0 +1,31 @@
+# Secrets & Variables
+
+Values a run needs at the moment it runs: API keys, tokens, endpoints, flags.
+They live here instead of in task descriptions and workflow instructions.
+
+## How it works
+
+Add an item, name it, and attach it to the steps that need it. During a run the
+agent receives the value through the session's own channel — it never has to
+appear in a prompt, and a secret's value is masked in the list.
+
+Search narrows the list by name. Deleting an item goes through the row menu and
+asks for confirmation, because a step that expects it will fail without it.
+
+## What belongs here
+
+- Credentials for [connectors](/docs/agent-capabilities) and
+  [wrappers](/docs/agent-capabilities)
+- Tokens for services a workflow calls
+- Configuration that differs between projects — an environment name, a base URL
+
+## What does not
+
+- Your personal agent credential. That is connected in
+  [Profile](/docs/getting-started) and belongs to you, not to the project.
+- Anything you would not want an agent to be able to read. A step that lists a
+  secret can use it.
+
+> warning Pasting a key into a card description or a step's instructions puts
+> it in the prompt, the run log, and everyone's screen. Put it here instead —
+> that is the whole point of the page.

--- a/app/frontend/pages/Docs/data/pages/sessions-and-runs.md
+++ b/app/frontend/pages/Docs/data/pages/sessions-and-runs.md
@@ -1,0 +1,67 @@
+# Sessions & Runs
+
+One sidebar item, one list. A **run** is one execution of a workflow; a
+**session** is one agent working. Every step of a run is a session, and a
+session can also stand on its own, with no workflow behind it.
+
+## The list
+
+Three tabs:
+
+- **All** — everything, and both create actions: **New Session** and
+  **Run workflow**.
+- **Standalone** — sessions started by hand. Only **New Session** here.
+- **Workflow runs** — runs. Only **Run workflow** here.
+
+Filter by agent, status, type, or the person who started it, or search by name.
+A workflow-step session links back to the run it belongs to; a standalone
+session has nothing to expand.
+
+Sessions someone kept private show as locked. You can see that they exist and
+what they cost; you cannot read them.
+
+## Starting a session by hand
+
+**New Session** asks for a name and an agent runtime — the Start control stays
+disabled until you pick one you actually have a credential for — and drops you
+straight into the session it creates. Finished a session and want another like
+it? A finished session offers to start a fresh one from the same setup.
+
+## Watching a run
+
+Open a run and you get one card per step, in run order, with the run's status,
+id, and totals in the header.
+
+- A **running step shows its terminal live**, embedded in the page. Before the
+  container is ready it reads *Session starting…*, then *Connecting to
+  terminal…*, then you are watching the agent work.
+- A **parallel run shows every active step at once**, each with its own console
+  and its own action bar.
+- Expand a step card for its prompt, its sub-steps, and the note it left
+  behind. A failed step shows its error there, and the header names *where* the
+  run stopped rather than when it started.
+
+## Steering a run
+
+| Action | When |
+| --- | --- |
+| **Approve & continue** | A step is waiting for a person. This is the approval you set on the step |
+| **Retry** | A step failed, or is waiting on input and should have another go |
+| **Skip** | A step should not run. You are asked for a reason, which stays on the record |
+| **Cancel run** | The whole run should stop. Offered only while it is still active |
+
+If a run stopped because the workspace hit a usage limit, the run says so in a
+banner and offers to run it again once there is room.
+
+## What a run leaves behind
+
+The **Assets** tab of a run lists the files the agents produced, with download
+and **promote** controls — promoting lifts a file out of the run and into the
+project's [Assets](/docs/assets), where the rest of the team can find it.
+
+Back in the list, a run with unreviewed output offers **Review outputs**: tick
+what to keep and **Save selected**, or **Dismiss all** if the run produced
+nothing worth keeping.
+
+Every run keeps its status, log, artifacts, tokens, and cost — including the
+runs that failed. That record is what [Analytics](/docs/analytics) counts.

--- a/app/frontend/pages/Docs/data/pages/starting-work.md
+++ b/app/frontend/pages/Docs/data/pages/starting-work.md
@@ -1,0 +1,43 @@
+# Triggers & Gates
+
+Two halves of one question: what starts a run, and what holds one up.
+
+## Triggers
+
+A trigger is attached to a workflow. Add one from the workflow's Triggers
+panel, pick its kind, and fill in what that kind needs. Any trigger can be
+switched off with **Enabled** without deleting it.
+
+| Kind | Fires when | Worth knowing |
+| --- | --- | --- |
+| **Task enters column** | A card lands in the chosen column | The mode decides whether it runs on its own (**Auto**) or offers a button (**Manual**) |
+| **On schedule** | A cron expression matches, in the timezone you pick | Use it for recurring work with no card behind it — a nightly report, a weekly sweep |
+| **Slack message** | A message in a channel matches your text pattern | Optionally limited to one channel; a cooldown stops a busy channel from starting a run per message |
+| **Incoming webhook** | An external system posts to the trigger's request URL | The workflow becomes a start API for anything that can send an HTTP request |
+
+Triggers that create a card as they fire let you template its title and give
+the run a subject, so the board does not fill up with rows called *Run 41*.
+
+> tip Manual mode on a column trigger is the safest way to introduce
+> automation: the process is bound and visible, but a person still decides when
+> a card is ready for it.
+
+## Gates
+
+A **gate** is a check a card waits on before work moves on — usually CI. The
+card shows a compact chip:
+
+| Chip | Meaning |
+| --- | --- |
+| **waiting** | The check is still running. The chip pulses like a live run |
+| **passed** | The check reported success |
+| **failed** | The check reported failure — a verdict, so fix the code |
+| **stale** | No verdict ever arrived. Something never reported; a tooltip explains why and offers to clear the gate |
+
+**failed** and **stale** need different reactions, which is why they do not
+share a colour. A failure means the work is wrong; a stale gate means you do
+not know yet, and should look at why CI went quiet.
+
+A collapsed column keeps this visible: a card that is gated shows as waiting
+rather than as its running run, so a blocked card cannot hide behind a busy
+one.

--- a/app/frontend/pages/Docs/data/pages/tasks.md
+++ b/app/frontend/pages/Docs/data/pages/tasks.md
@@ -1,0 +1,72 @@
+# Tasks & the Board
+
+**Tasks** in the sidebar opens the project's board. This is where work enters
+Flow and where results come back, so most people spend their day here.
+
+## Columns
+
+A board is ordered columns. Each column has a **purpose** — a sentence saying
+what happens to a card while it sits there. That sentence is not decoration:
+when a workflow runs from this column, the agent receives it as context.
+
+A new project's board is empty and offers three templates:
+
+| Template | Columns |
+| --- | --- |
+| **Simple Kanban** | Backlog · In Progress · Done |
+| **Dev Team** | Backlog · Tech Design · Implementation · Code Review · QA · Ready for Release · Done |
+| **Full SDLC** | The long form — design, tech design, development, QA, UAT, release, each with its own waiting column |
+
+Pick one with **Use this template**, then add, rename, reorder, or remove
+columns as the team's process changes. Columns collapse individually from the
+header toggle or the column's ⋯ menu, and all at once with **Collapse all** —
+a collapsed column still shows its cards as chips, coloured by their latest run.
+
+## Cards
+
+Create a card from a column's **+** button, or press **n** anywhere on the
+board. A card carries a title, a description, a type, an assignee, tags, an
+optional parent epic, subtasks, comments, and attachments.
+
+Open a card and the detail drawer has tabs:
+
+- **Details** — description, assignee, tags, the column it sits in (moving it
+  from the **Column** select is the same as dragging it), and a *Latest run*
+  tile.
+- **Runs** — every workflow run this card has triggered, newest first. Click
+  one to jump into the session.
+- **Comments** — the conversation. Agents comment here too, so you can filter
+  by author type to read only what people wrote, or only what agents produced.
+- **Analytics** — what this single card has cost: run time, tokens, spend.
+
+**Activity** (top of the board) opens a slide-over with everything that has
+happened on the board recently — it stays open while you keep working.
+
+## Finding things
+
+- **Search** — press **/** to jump into it; it searches the whole board, not
+  just loaded cards.
+- **Type**, **Assignee**, **Tags** — filters that narrow the board; clicking a
+  tag on a card filters by it, clicking again clears it.
+- **Archived** — hidden by default, revealed with the toggle.
+- **Presets** — saved views. Two are built in: **My Work** (only your cards)
+  and **All Bugs**. Save your own filter combination as a preset and share it
+  with the team, or keep it to yourself.
+
+## Starting work from the board
+
+Binding a column to a workflow is what turns a board into an assembly line.
+Board settings (the toolbar's settings button, or a column's ⋯ menu) is where a
+column gets its workflow and whether it fires **automatically** on entry or
+waits for a person to press **Run workflow** on the card.
+
+Once bound:
+
+- Dropping a card into the column starts the run (auto), or offers the button
+  (manual).
+- A failed run offers **Retry run** from the card.
+- The card's chips show the state of its latest runs and of any CI gate it is
+  waiting on — see [Triggers & gates](/docs/starting-work).
+
+> tip A column with no binding is still useful. Plenty of teams automate two
+> columns out of seven and leave the rest as an ordinary Kanban board.

--- a/app/frontend/pages/Docs/data/pages/user-guide-outline.md
+++ b/app/frontend/pages/Docs/data/pages/user-guide-outline.md
@@ -1,0 +1,345 @@
+# Aixle Flow User Guide — Outline
+
+> Deliverable for issue #550. This is the outline of the end-user product guide —
+> the skeleton a writer expands into full chapters. It follows the product
+> sidebar, uses the names a person sees on screen, and stays at product level:
+> no architecture, no APIs, no configuration, no file paths.
+
+**Audience.** People who will run work in Aixle Flow: engineering leads,
+developers, and operators. Assume they know Git and task boards. Do not assume
+they know how agents, containers, or orchestration work.
+
+**Rules for the writer.**
+
+- Every section answers four questions: *what this is · when to use it ·
+  what the person does · what they see afterwards.*
+- Use the names from the product UI, not internal engineering names
+  (see [Terminology notes](#terminology-notes) at the end).
+- The operator-level documentation — the [User Guide overview](/docs/user-guide)
+  and the pages under it — is written for people installing and operating Flow:
+  it is too technical for this guide. Do not reuse its structure or copy; link
+  to it only where a reader needs the operator-level detail.
+- Every area named in the
+  [changelog product-area snapshot](/docs/changelog-product-areas) has a chapter
+  here. If a release adds an area, add the chapter in the same change.
+
+---
+
+## 1. What Aixle Flow is
+
+Open with the loop, not a feature list.
+
+- **What it is.** The team layer above personal AI coding agents — Claude Code,
+  Cursor CLI, Codex, Gemini CLI, and Grok. Not a personal chat with an agent:
+  team control of AI coding work.
+- **The loop.** A person moves a card on the board into a column that is bound
+  to a workflow. Agents start working. When the run finishes, status, files,
+  and cost come back to the board. The team sees what is running, what it
+  produced, and what it cost — without anyone opening a terminal.
+- **The three levels.** A **company** is the shared workspace. Inside it, each
+  **project** has a board and its own resources. Your **profile** holds what is
+  personal: your agent credentials and your usage.
+- One diagram: board → workflow → agent → results back to the board.
+
+## 2. Your first session
+
+The reader goes from an invite email to their first open project.
+
+- **Getting in.** Accept an invitation or sign in. First-run onboarding walks
+  through role, language, and connecting an agent (the agent step is skipped
+  for viewer-only users).
+- **Connect an agent.** During onboarding — or any time later in **Profile** —
+  connect the account of the agent product you already use (Claude Code,
+  Cursor CLI, Codex, Gemini CLI, or Grok). Connecting happens in a terminal
+  embedded in the page: the product starts a session, you complete the
+  runtime's own login in it, and the credential is stored for you. Nothing can
+  run on your behalf until this is done — say this plainly and early.
+- **Your Profile.** Three tabs: **Account** (agent credentials and personal
+  settings), **Usage** (your own sessions, tokens, spend, and any limits that
+  apply to you), and **MCP** (personal access, so an agent you run outside
+  Aixle — your own Claude Code, for example — can reach your Aixle projects).
+- **Find your work.** Open **Projects**, pick a project, land on **Overview**.
+- **More than one company?** The workspace switcher moves you between
+  companies; each company has its own projects, members, and analytics.
+- *Afterwards:* you are inside a project, an agent is connected, and the board
+  is one click away.
+
+## 3. The main loop
+
+A single guided walkthrough, before any reference material. Everything later in
+the guide hangs off this chapter.
+
+1. Open **Tasks** and create a card (or pick one up from the backlog).
+2. Move the card into a column bound to a workflow — the workflow starts
+   automatically, or from a button if the column is set to manual.
+3. Watch progress in **Sessions & Runs**: live status, the agent's terminal as
+   it works, cost accumulating.
+4. Review what came back: files in **Assets**, results and comments on the
+   card.
+5. Move the card forward — or send it back with a comment and run again.
+
+- *Afterwards:* the reader has seen the whole product once, end to end.
+
+## 4. Overview
+
+- **What it is.** The project's home page: recent activity, how tasks are
+  distributed across the board, workflow runs, sessions launched, success rate,
+  and total spend.
+- **When to use it.** The daily "what is this project doing right now, and what
+  is it costing" check — before drilling into a specific run.
+- **What you do.** Read the tiles; follow one into Tasks, Sessions & Runs, or
+  Analytics.
+- *Afterwards:* the reader knows where the numbers on this page come from and
+  which screen answers the next question.
+
+## 5. Tasks — the board
+
+- **What it is.** The project's board: columns, cards, subtasks, comments,
+  attachments.
+- **When to use it.** This is where work enters the system and where results
+  land; most people live here.
+- **What you do.** Create and move cards; comment; attach files; bind a column
+  to a workflow so that entering the column starts it (automatically or from a
+  button).
+- **Board templates.** A new project's board starts empty; pick a template —
+  **Simple Kanban** (Backlog / In Progress / Done), **Dev Team** (a
+  seven-column engineering flow), or **Full SDLC** (the long form) — and
+  customize columns later.
+- **Reading a card at a glance.** A card carries chips for its runs and for any
+  checks it is waiting on (see [Triggers & gates](#7-triggers-gates)).
+- *Afterwards:* cards carry their own history — comments, attachments, runs,
+  and activity.
+
+## 6. Workflows
+
+- **What it is.** A named process made of ordered **steps**; each step is one
+  agent session doing one job.
+- **When to use it.** Whenever the same kind of work should run the same way
+  every time.
+- **What you do.** Create a workflow; add steps with instructions and an
+  assigned agent; set what each step depends on (independent steps run in
+  parallel); choose what happens on failure (fail, retry, or skip); mark where
+  a person must approve before the run continues. Publish it, duplicate it, or
+  copy a ready-made one from the **Workflow Catalog**.
+- *Afterwards:* the workflow appears as an option when binding columns, and
+  every run of it is tracked.
+
+## 7. Triggers & gates
+
+Two halves of the same question: what starts a run, and what holds one up.
+
+- **What it is.** **Triggers** are the ways a workflow begins: a task enters a
+  bound column, someone runs it by hand, a schedule fires, a Slack message
+  matches, or an external system posts to an incoming webhook. **Gates** are
+  checks a card waits on — typically CI — before work moves on.
+- **When to use it.** Triggers: whenever a process should start without anyone
+  remembering to press a button. Gates: whenever "the tests must be green"
+  belongs in the process rather than in someone's head.
+- **What you do.** Add a trigger to a workflow and pick its kind; for a column
+  trigger, choose Auto or Manual. Watch a gate on the card: it reads
+  **waiting** while CI runs, then **passed**, **failed**, or **stale** when CI
+  never reported at all.
+- *Afterwards:* work starts on its own, and a card that is blocked says what it
+  is blocked on instead of silently sitting still.
+
+## 8. Sessions & Runs
+
+One sidebar item, one chapter. **Runs** are workflow runs; **sessions** are the
+individual agent sessions inside them (each step of a run is one session, and
+sessions can also run on their own). They share a single list.
+
+- **What it is.** Live and past agent work.
+- **When to use it.** To answer "what is happening right now?" and "what
+  happened, what did it produce, what did it cost?"
+- **What you do.** Open a run to see its steps, which ran in parallel, and
+  where it is waiting; watch a running step's terminal live, embedded in the
+  page (it shows *Session starting…* until the agent's container is ready);
+  approve a step that waits for a person (**Approve & continue**); retry or
+  skip a step; open a finished session to read its full log.
+- *Afterwards:* every run leaves a trail — status, log, artifacts, tokens, and
+  cost.
+
+## 9. Assets
+
+- **What it is.** Files: what the team uploads and what agents produce.
+- **When to use it.** Give agents input material; collect and review what they
+  made.
+- **What you do.** Upload files; attach them to tasks; open what a run
+  produced; track versions.
+- *Afterwards:* outputs are reviewable in one place instead of scattered
+  across runs.
+
+## 10. Agents
+
+- **What it is.** Reusable personas: who the agent is, how it talks, what
+  rules it follows. A persona is not a product choice — the same persona can
+  run on any of the supported runtimes (Claude Code, Cursor CLI, Codex, Gemini
+  CLI, Grok).
+- **When to use it.** To make agent behavior consistent across workflows —
+  "our reviewer", "our implementer" — instead of re-writing instructions per
+  step.
+- **What you do.** Create a persona, write its instructions and rules, pick it
+  in workflow steps. Remind: runs happen under credentials people connect in
+  **Profile**.
+- *Afterwards:* steps reference personas by name, and changing a persona
+  changes every workflow that uses it.
+
+## 11. Wrappers
+
+- **What it is.** A way to turn a script or an API into something an agent can
+  call, when no connector exists for that service.
+- **When to use it.** Your internal service, an odd API, a one-off script.
+- **What you do.** Define the wrapper once; agents in this project can then
+  call it during runs.
+- *Afterwards:* the wrapper shows up in run logs as a capability the agents
+  actually called.
+
+## 12. Skills
+
+- **What it is.** Packaged instructions an agent can load during a session —
+  know-how, not tools.
+- **When to use it.** Recurring expertise: "how we write migrations", "our
+  review checklist".
+- **What you do.** Install a skill from the catalog or write one by hand;
+  attach it where it should be available.
+- *Afterwards:* agents follow the skill's instructions when the work matches.
+
+## 13. Connectors
+
+- **What it is.** Connections that give agents extra tools — issue trackers
+  and other external services.
+- **When to use it.** The agent needs to act on a system outside the codebase.
+- **What you do.** Add a connector from the catalog (or by hand); supply its
+  credentials via **Secrets & Variables**.
+- *Afterwards:* the connected service's actions appear among what agents can
+  do.
+
+## 14. Repositories & Integrations
+
+- **What it is.** **Repositories** are the Git repos agents work in and push
+  to. **Integrations** are the accounts Flow connects to on the team's behalf:
+  GitHub, GitLab, Linear, Slack, and Coder.
+- **When to use it.** Any workflow that should read code, open pull requests,
+  or touch tickets.
+- **What you do.** Connect the integration, link the repositories the project
+  needs.
+- *Afterwards:* runs can produce branches and pull requests in your own
+  repos, and tickets can flow both ways.
+
+## 15. AI Builder
+
+- **What it is.** Describe a process in plain language; the product builds the
+  tasks, board setup, and workflows from that prompt. (This guide uses **AI
+  Builder**, matching the sidebar entry point; the builder's own pages — and
+  the changelog taxonomy — say **Aixle Builder**. Show both names once, then
+  stick to AI Builder.)
+- **When to use it.** Setting up a new process — instead of configuring
+  columns, workflows, and steps by hand.
+- **What you do.** Write what you want to automate; review what the builder
+  proposes; accept, then adjust by hand where needed. While it works you can
+  watch its terminal, and open its workspace in an editor.
+- *Afterwards:* the board and workflows exist and are editable like anything
+  built manually.
+
+## 16. Team
+
+- **What it is.** **Members** at two levels: who is in the company, and who is
+  on each project.
+- **Roles.** **Admin** manages members, integrations, and settings;
+  **Employee** works within projects; **Viewer** looks without touching.
+- **What you do.** Invite people by email, set their role, add them to
+  projects.
+- *Afterwards:* each person sees what their role allows — admins additionally
+  see company-wide analytics and sessions.
+
+## 17. Secrets & Variables
+
+- **What it is.** Values agents and connectors need at runtime — credentials
+  and configuration — kept out of task text and workflow instructions.
+- **When to use it.** Any time a run needs a key, token, or setting.
+- **What you do.** Add the value once, name it, reference it where needed.
+- *Afterwards:* runs use the value without anyone pasting it into a card.
+
+## 18. Analytics
+
+- **What it is.** Usage and cost: spend, sessions, tokens, success — by
+  project, agent, and source.
+- **Two levels.** Project **Analytics** for the team; company **Analytics**
+  and company **Sessions** for admins, across all projects.
+- **What you do.** Answer "what did this cost us?", "which workflows work?",
+  "where does agent time go?"
+- *Afterwards:* cost conversations happen with numbers, per project and per
+  company.
+
+## 19. Settings
+
+- **What it is.** The project's own settings: its name, its language, and the
+  end of its life — archive or delete.
+- **When to use it.** Renaming a project, changing the language agents write
+  in, retiring a project that is finished.
+- **What you do.** Edit and save; archive when work stops; delete when nothing
+  should remain. Say plainly what delete takes with it.
+- *Afterwards:* an archived project is out of the way without losing its
+  history.
+
+## 20. The company workspace
+
+Round off with the shared layer above projects.
+
+- **Projects** — create and switch between them.
+- **Workflow Catalog** — reusable workflows the team can copy into any
+  project.
+- **Company Assets** and **Company Members** — workspace-level files and
+  people. Company Assets, like company Analytics and Sessions, is visible to
+  admins only.
+- Switching companies when you belong to more than one workspace.
+
+---
+
+## End-to-end stories
+
+Two closing chapters that retell the loop as narratives. Each one names every
+screen it touches, so the reader can replay it.
+
+### Story 1 — drop a card, get a pull request back
+
+A lead links a repository (Integrations → Repositories), binds the
+"Implementation" column of a **Dev Team** board to an implementation workflow,
+and writes a card describing a small feature. They drag the card into the
+column. The workflow starts: one step plans, two parallel steps implement and
+write tests, a final step waits for a human. The lead watches the run in
+**Sessions & Runs** — the implementing step's terminal live on the page — reads
+the diff summary the agent posted to the card, approves the waiting step, and a
+pull request appears in the linked repo. The card's CI gate goes from
+**waiting** to **passed**. The cost of the whole run is on the card and in
+Analytics.
+
+### Story 2 — build a workflow from one prompt
+
+An operator opens **AI Builder** and types: "When a card lands in *Triage*,
+summarize it, label it, and draft a reply for review." The builder proposes a
+board column, a three-step workflow, and the connector it needs. The operator
+accepts, adds the connector credential in **Secrets & Variables**, and drops a
+test card into *Triage*. The run appears in **Sessions & Runs**; the draft reply
+lands on the card as a comment — written by an agent, reviewed by a person.
+
+---
+
+## Terminology notes
+
+For guide writers — where the UI's names differ from what you might expect, or
+from each other. Verified against the product as of 2026-08.
+
+| Guide term | On screen |
+| --- | --- |
+| Tasks | Sidebar item **Tasks**; the page itself is titled **Board** |
+| Sessions & Runs | One sidebar item, **Sessions & Runs**: agent sessions and workflow runs share a single list. The standalone **Sessions** item in the company nav is the cross-project, admin-only view |
+| AI Builder | Sidebar card **AI Builder** with button **Build with AI**; the feature's own pages are titled **Aixle Builder** |
+| Board templates | Offered on an empty board (not at project creation); UI says "template" (**Use this template**), preset names **Simple Kanban**, **Dev Team**, **Full SDLC** |
+| Workflow start | Trigger labels on screen: **Task enters column** (Auto or Manual mode), **On schedule**, **Slack message**, **Incoming webhook** — plus running by hand from the workflow or task |
+| Gates | On a card, a gate chip reads **waiting**, **passed**, **failed**, or **stale** (CI never reported) |
+| Step failure options | **On Failure**: Fail / Retry / Skip; **Skip Policy**: Never / If outputs exist / Manual |
+| Human approval | A waiting step shows **Approve & continue** |
+| Live terminal | A running step embeds the agent's terminal; before the container is ready it reads **Session starting…**, then **Connecting to terminal…** |
+| Profile | Tabs **Account**, **Usage**, **MCP** — the last is personal access for agents run outside Aixle |
+| Docs | The operator documentation portal at `/docs`, reachable from the public site (**Documentation**); there is no docs item in the app sidebar |

--- a/app/frontend/pages/Docs/data/pages/user-guide.md
+++ b/app/frontend/pages/Docs/data/pages/user-guide.md
@@ -1,5 +1,9 @@
 # User Guide
 
+> info Using Flow rather than installing it? Start with
+> [What Flow is](/docs/using-flow). This section describes how Flow works
+> underneath — containers, DAGs, credentials — for the people who run it.
+
 Aixle Flow turns AI coding agents into a team workflow. The pieces fit
 together like this:
 

--- a/app/frontend/pages/Docs/data/pages/using-flow.md
+++ b/app/frontend/pages/Docs/data/pages/using-flow.md
@@ -1,0 +1,73 @@
+# What Flow Is
+
+Aixle Flow is the team layer on top of personal AI coding agents. One person
+puts work on a board. An agent picks it up, does the work, and the whole team
+sees the run, the output, and the cost — without anyone opening a terminal.
+
+If you are installing or operating Flow, read the [User Guide](/docs/user-guide)
+instead. This section is for people who *use* the product.
+
+## The loop
+
+```
+Board ── card enters a bound column ──► Workflow ── step by step ──► Agent
+  ▲                                                                    │
+  └──────────── status, files, comments and cost come back ◄───────────┘
+```
+
+1. A card moves into a column that is bound to a workflow.
+2. The workflow starts — automatically, or from a button if the column is set
+   to manual.
+3. Each step of the workflow is one agent session doing one job. Independent
+   steps run at the same time.
+4. Results come back: files in Assets, comments and status on the card, a full
+   trail in Sessions & Runs, and cost in Analytics.
+
+Nothing in that loop asks you to run a command yourself. Your part is writing
+the card, deciding the process once, and reviewing what comes back.
+
+## Company, project, profile
+
+Flow has exactly three levels, and almost every question about "where does this
+setting live?" is answered by one of them.
+
+| Level | Holds | Example |
+| --- | --- | --- |
+| **Company** | The shared workspace: projects, members, catalog, company-wide analytics | Your organisation |
+| **Project** | One board, its workflows, and its own resources and access | "Billing service" |
+| **Profile** | What is personal: your agent credentials, your usage, your personal access | You |
+
+You can belong to more than one company. A switcher on the far left moves you
+between them; each company has its own projects, members, and numbers.
+
+## What actually runs the work
+
+Flow does not ship its own model. It runs the agent products people already
+use, each in an isolated container:
+
+- Claude Code
+- Cursor CLI
+- Codex
+- Gemini CLI
+- Grok
+
+An agent runs under a credential *a person connected*, which is why
+[getting started](/docs/getting-started) begins with connecting one. A persona
+you define (see [Agent personas](/docs/personas)) is not tied to a product —
+the same persona can run on any of the five.
+
+## Where things live
+
+- **Work** — [Tasks](/docs/tasks), [Workflows](/docs/running-workflows),
+  [Sessions & Runs](/docs/sessions-and-runs), [Assets](/docs/assets)
+- **Resources** — [Agent personas](/docs/personas),
+  [Wrappers, Skills & Connectors](/docs/agent-capabilities),
+  [Repositories & Integrations](/docs/repositories)
+- **Admin** — [Secrets & Variables](/docs/secrets),
+  [Team & access](/docs/people-and-access),
+  [Analytics](/docs/analytics), [project settings](/docs/project-home)
+- **Company** — [the workspace above projects](/docs/company-workspace)
+
+> tip New to Flow? Read [Getting started](/docs/getting-started), then
+> [Tasks & the board](/docs/tasks), then the
+> [worked examples](/docs/examples). Everything else is reference.

--- a/app/frontend/pages/Docs/data/registration.test.ts
+++ b/app/frontend/pages/Docs/data/registration.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { NAV_STRUCTURE } from './navStructure';
+import { DOC_PAGES } from './pages';
+import { SEARCH_INDEX } from './searchIndex';
+
+// A docs page is registered in three places: the page registry (content + title),
+// the nav (where it appears), and the search index (how it is found). A page missing
+// from any one of them is invisible in a way no page-level test would catch — the
+// portal simply never links to it. These tests keep the three in step.
+
+const navSlugs = NAV_STRUCTURE.flatMap((section) =>
+  section.items.flatMap((item) => [item.slug, ...(item.children ?? []).map((child) => child.slug)]),
+);
+
+describe('docs page registration', () => {
+  it('gives every nav entry a page to render', () => {
+    const missing = navSlugs.filter((slug) => !(slug in DOC_PAGES));
+    expect(missing).toEqual([]);
+  });
+
+  it('puts every page in the nav', () => {
+    const missing = Object.keys(DOC_PAGES).filter((slug) => !navSlugs.includes(slug));
+    expect(missing).toEqual([]);
+  });
+
+  it('makes every page findable through search', () => {
+    const indexed = SEARCH_INDEX.map((entry) => entry.slug);
+    const missing = Object.keys(DOC_PAGES).filter((slug) => !indexed.includes(slug));
+    expect(missing).toEqual([]);
+  });
+
+  it('files each page under the section its nav entry lives in', () => {
+    const mismatched = NAV_STRUCTURE.flatMap((section) =>
+      section.items.filter((item) => DOC_PAGES[item.slug]?.section !== section.label).map((item) => item.slug),
+    );
+    expect(mismatched).toEqual([]);
+  });
+
+  it('describes every page in the search index it indexes', () => {
+    const unknown = SEARCH_INDEX.filter((entry) => !(entry.slug in DOC_PAGES)).map((e) => e.slug);
+    expect(unknown).toEqual([]);
+  });
+});

--- a/app/frontend/pages/Docs/data/searchIndex.ts
+++ b/app/frontend/pages/Docs/data/searchIndex.ts
@@ -96,6 +96,18 @@ export const SEARCH_INDEX: SearchResult[] = [
     section: 'Reference',
     desc: 'Every environment variable Aixle Flow reads, organized by subsystem.',
   },
+  {
+    slug: 'user-guide-outline',
+    title: 'User guide outline',
+    section: 'Product',
+    desc: 'The chapter-by-chapter skeleton of the end-user product guide, following the product sidebar.',
+  },
+  {
+    slug: 'changelog-product-areas',
+    title: 'Changelog product areas',
+    section: 'Product',
+    desc: 'The product-area taxonomy every user-visible changelog entry is tagged with.',
+  },
 ];
 
 export function searchDocs(query: string): SearchResult[] {

--- a/app/frontend/pages/Docs/data/searchIndex.ts
+++ b/app/frontend/pages/Docs/data/searchIndex.ts
@@ -7,6 +7,108 @@ export interface SearchResult {
 
 export const SEARCH_INDEX: SearchResult[] = [
   {
+    slug: 'using-flow',
+    title: 'What Flow is',
+    section: 'Using Flow',
+    desc: 'What Aixle Flow does for a team: the board → workflow → agent loop, the company/project/profile levels, and the supported agent runtimes.',
+  },
+  {
+    slug: 'getting-started',
+    title: 'Getting started',
+    section: 'Using Flow',
+    desc: 'From an invitation to a running workflow: onboarding, connecting an agent, and the Account, Usage and MCP tabs of your profile.',
+  },
+  {
+    slug: 'project-home',
+    title: 'Project home & settings',
+    section: 'Using Flow',
+    desc: 'The Overview page KPIs, run donut and task distribution, plus project name, artifacts language, archive and delete.',
+  },
+  {
+    slug: 'tasks',
+    title: 'Tasks & the board',
+    section: 'Using Flow',
+    desc: 'Columns and their purpose, board templates, cards and their tabs, filters and view presets, and binding a column to a workflow.',
+  },
+  {
+    slug: 'running-workflows',
+    title: 'Building workflows',
+    section: 'Using Flow',
+    desc: 'Creating a workflow, what a step holds, dependencies and parallel steps, on-failure behaviour, approval steps, and publishing to the catalog.',
+  },
+  {
+    slug: 'starting-work',
+    title: 'Triggers & gates',
+    section: 'Using Flow',
+    desc: 'The four ways a workflow starts — column, schedule, Slack, incoming webhook — and CI gates: waiting, passed, failed, stale.',
+  },
+  {
+    slug: 'sessions-and-runs',
+    title: 'Sessions & Runs',
+    section: 'Using Flow',
+    desc: 'The unified list of runs and agent sessions, the live step terminal, approve, retry, skip and cancel, and reviewing what a run produced.',
+  },
+  {
+    slug: 'assets',
+    title: 'Assets',
+    section: 'Using Flow',
+    desc: 'Uploading files for agents, promoting what a run produced into the project, search and version history.',
+  },
+  {
+    slug: 'personas',
+    title: 'Agent personas',
+    section: 'Using Flow',
+    desc: 'Reusable agent personas: what they define, why they are independent of the runtime, and how steps reference them.',
+  },
+  {
+    slug: 'agent-capabilities',
+    title: 'Wrappers, Skills & Connectors',
+    section: 'Using Flow',
+    desc: 'The three ways to extend an agent: wrappers you write, skills as packaged know-how, and connectors to external tool servers.',
+  },
+  {
+    slug: 'repositories',
+    title: 'Repositories & Integrations',
+    section: 'Using Flow',
+    desc: 'Linking the Git repositories agents work in, connecting the accounts a project needs, and what that lets a run do.',
+  },
+  {
+    slug: 'ai-builder',
+    title: 'AI Builder',
+    section: 'Using Flow',
+    desc: 'Describe a process in plain language and let the builder create the board columns, workflows and steps, then adjust them by hand.',
+  },
+  {
+    slug: 'people-and-access',
+    title: 'Team & access',
+    section: 'Using Flow',
+    desc: 'Admin, employee and viewer roles, company members, project collaborators, and what each role can see.',
+  },
+  {
+    slug: 'secrets',
+    title: 'Secrets & Variables',
+    section: 'Using Flow',
+    desc: 'Credentials and configuration a run needs, kept out of prompts, task text and logs.',
+  },
+  {
+    slug: 'analytics',
+    title: 'Analytics & cost',
+    section: 'Using Flow',
+    desc: 'Spend, tokens, sessions and success by project, agent, workflow and source — and where cost shows up elsewhere.',
+  },
+  {
+    slug: 'company-workspace',
+    title: 'Company workspace',
+    section: 'Using Flow',
+    desc: 'Projects, the Workflow Catalog, company-wide analytics and sessions, company assets and members, and switching companies.',
+  },
+  {
+    slug: 'examples',
+    title: 'Worked examples',
+    section: 'Using Flow',
+    desc: 'Two end-to-end stories: a card that comes back as a pull request, and a workflow built from a single prompt.',
+  },
+  {
     slug: 'user-guide',
     title: 'User Guide',
     section: 'User guide',

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,11 @@ The active workflow: a research report in `research/` feeds a frozen-intent spec
   - **[implementation-artifacts/spec-session-terminal-replay.md](./implementation-artifacts/spec-session-terminal-replay.md)** — Session terminal replay
   - **[implementation-artifacts/40-1-workflow-builder-ux-redesign.md](./implementation-artifacts/40-1-workflow-builder-ux-redesign.md)** — Workflow builder full UX redesign (story 40.1, shipped): tab layout, step editor sections, Base Resources move. Older BMAD story format, moved here from the retired `ai/` tree
 
+## Product
+
+- **[product/user-guide-outline.md](./product/user-guide-outline.md)** — Outline of the end-user product guide: the board → workflow → agent → results loop, section-by-section skeleton following the product sidebar, two end-to-end stories, terminology notes (issue #550)
+- **[product/changelog-product-areas.md](./product/changelog-product-areas.md)** — Frozen user-facing product map used as the changelog taxonomy: named product areas, changelog rules, snapshot baseline (issue #551)
+
 ## Strategy
 
 - **[strategy/](./strategy/)** — Business / open-source strategy documents

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,4 +68,8 @@ The active workflow: a research report in `research/` feeds a frozen-intent spec
 ## Related documentation elsewhere
 
 - `references/aixle-system-reference.md` — agent-facing platform reference (domain model, runtimes, container layout)
-- `app/frontend/pages/Docs/data/pages/` — end-user product docs rendered in the app
+- `app/frontend/pages/Docs/data/pages/` — the markdown the `/docs` portal renders. Two sections:
+  **Using Flow** (the product guide: what a user does on each screen) and **User guide /
+  Reference** (operator material: install, runtimes, MCP, API). Adding a page there means
+  registering it in `navStructure.ts`, `data/pages/index.ts`, `data/searchIndex.ts`, and the
+  allow-list in `Web::DocsController`

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,25 @@ The active workflow: a research report in `research/` feeds a frozen-intent spec
 ## Product
 
 - **[product/user-guide-outline.md](./product/user-guide-outline.md)** — Outline of the end-user product guide: the board → workflow → agent → results loop, section-by-section skeleton following the product sidebar, two end-to-end stories, terminology notes (issue #550)
-- **[product/changelog-product-areas.md](./product/changelog-product-areas.md)** — Frozen user-facing product map used as the changelog taxonomy: named product areas, changelog rules, snapshot baseline (issue #551)
+- **[product/changelog-product-areas.md](./product/changelog-product-areas.md)** — Frozen user-facing product map used as the changelog taxonomy: named product areas, changelog rules, area → guide-chapter map, snapshot baseline (issue #551)
+
+## Operator documentation
+
+The repository mirror of the in-app portal served at `/docs`
+(`app/frontend/pages/Docs/data/pages/`). Written for people installing and
+running Flow — the product-level guide outlined above is a separate document set.
+
+- **[user-guide/index.md](./user-guide/index.md)** — Entry point: the board → workflow → agent loop and the mental model
+- **[user-guide/board.md](./user-guide/board.md)** — Projects, columns, cards, and column → workflow bindings
+- **[user-guide/workflows.md](./user-guide/workflows.md)** — DAG steps, retries, approval gates, parallel runs
+- **[user-guide/agents.md](./user-guide/agents.md)** — Personas, the container, and how session context is built
+- **[user-guide/runtimes.md](./user-guide/runtimes.md)** — The five agent CLIs, their images, credentials, and cost tracking
+- **[user-guide/tools.md](./user-guide/tools.md)** — Tool kinds, execution modes, built-in board tools, resource resolution
+- **[user-guide/mcp.md](./user-guide/mcp.md)** — MCP transports, the internal `aixle-tools` server, config-item credentials
+- **[user-guide/integrations.md](./user-guide/integrations.md)** — GitHub, GitLab, Linear, Google OAuth, and webhooks
+- **[user-guide/configuration.md](./user-guide/configuration.md)** — Env vars, OAuth, agent credentials, and other knobs
+- **[quickstart.md](./quickstart.md)** — Get a local instance running and see one card move
+- **[reference/index.md](./reference/index.md)** — Reference set: [API](./reference/api.md), [CLI](./reference/cli.md), [configuration](./reference/configuration.md)
 
 ## Strategy
 
@@ -73,4 +91,4 @@ The active workflow: a research report in `research/` feeds a frozen-intent spec
 ## Related documentation elsewhere
 
 - `references/aixle-system-reference.md` — agent-facing platform reference (domain model, runtimes, container layout)
-- `app/frontend/pages/Docs/data/pages/` — end-user product docs rendered in the app
+- `app/frontend/pages/Docs/data/pages/` — the source the `/docs` portal renders; mirrored in this tree under [user-guide/](./user-guide/) and [reference/](./reference/)

--- a/docs/product/changelog-product-areas.md
+++ b/docs/product/changelog-product-areas.md
@@ -26,14 +26,15 @@ Supported agent runtimes: Claude Code, Cursor CLI, Codex, Gemini CLI, Grok.
 ## Product areas (changelog taxonomy)
 
 Use the names in **bold** in changelog entries. They match what people see in
-the product.
+the product — or, where no single sidebar label exists (sign-in, triggers),
+they name a flow users would recognize.
 
 ### Workspace
 
 | Area | What it covers |
 | --- | --- |
 | **Companies & projects** | Workspaces, switching between companies, creating and listing projects |
-| **Sign-in & onboarding** | Login, invitations, first-run setup, role, language |
+| **Sign-in & onboarding** | Login, invitations, first-run setup: role, language, connecting an agent |
 | **Profile** | Personal agent credentials (connecting a runtime account), personal usage, personal access so Aixle can be used from an external agent |
 
 ### Project — Work
@@ -42,7 +43,7 @@ the product.
 | --- | --- |
 | **Overview** | Project home: activity, task distribution, spend, workflow run status |
 | **Tasks** | The board: columns, cards, subtasks, comments, attachments, waits, activity. Column → workflow binding (auto or manual). Board templates (Simple Kanban, Dev Team, Full SDLC) offered on an empty board |
-| **Workflows** | Named processes made of steps: instructions, which agent runs, dependencies, on-failure behaviour (fail / retry / skip), human approval, inputs/outputs. Publishing and duplicating |
+| **Workflows** | Named processes made of steps: instructions, which agent runs, dependencies, on-failure behavior (fail / retry / skip), human approval, inputs/outputs. Publishing and duplicating |
 | **Triggers & gates** | When a workflow starts (task enters column, manual run, schedule, Slack message, inbound webhook) and what can pause a run (waiting on a check or a person) |
 | **Runs** | Workflow runs, live and past: step timeline, parallel waves, approve / retry / skip, cost |
 | **Sessions** | Individual agent sessions: status, log, cost, tokens, artifacts |
@@ -63,7 +64,7 @@ the product.
 
 | Area | What it covers |
 | --- | --- |
-| **Secrets & variables** | Credentials and config values agents and connectors use |
+| **Secrets & Variables** | Credentials and config values agents and connectors use |
 | **Members** | Who is on the project and with what access (roles: Admin, Employee, Viewer) |
 | **Analytics** | Spend, sessions, tokens, success — by project, agent, and source |
 | **Settings** | Project name, language, archive, delete |
@@ -88,7 +89,7 @@ the product.
 
 | Area | What it covers |
 | --- | --- |
-| **Docs** | Product documentation at `/docs` (linked from the public site) |
+| **Docs** | The in-product documentation, linked from the public site as **Documentation** |
 
 ## How the pieces fit (for changelog writers)
 

--- a/docs/product/changelog-product-areas.md
+++ b/docs/product/changelog-product-areas.md
@@ -1,0 +1,119 @@
+# Aixle Flow Product Snapshot — Changelog Taxonomy
+
+> Deliverable for issue #551. A user-facing map of Aixle Flow as it exists
+> today, frozen as the changelog taxonomy: after a release, every user-visible
+> change is tagged with one **product area** from the tables below, so each
+> release reads as a change to a named part of the product — not as a list of
+> tickets.
+>
+> **Snapshot date:** 2026-08-17. Area names are verified against the product
+> UI (sidebar labels and page titles), not internal engineering names.
+
+## What Aixle Flow is
+
+Aixle Flow is the team layer on top of personal AI coding agents. A person puts
+work on a board. An agent picks it up, does the work, and the team sees the
+run, the output, and the cost — without anyone opening a terminal.
+
+A **Company** is the workspace. Inside it, each **Project** has one board. Move
+a card into a column that is bound to a workflow, and the workflow starts. A
+workflow is a sequence of steps; each step is one agent doing one job. Steps
+can run in parallel, wait for each other, retry, or pause for a human. Every
+run leaves a trail: status, log, artifacts, tokens, and cost.
+
+Supported agent runtimes: Claude Code, Cursor CLI, Codex, Gemini CLI, Grok.
+
+## Product areas (changelog taxonomy)
+
+Use the names in **bold** in changelog entries. They match what people see in
+the product.
+
+### Workspace
+
+| Area | What it covers |
+| --- | --- |
+| **Companies & projects** | Workspaces, switching between companies, creating and listing projects |
+| **Sign-in & onboarding** | Login, invitations, first-run setup, role, language |
+| **Profile** | Personal agent credentials (connecting a runtime account), personal usage, personal access so Aixle can be used from an external agent |
+
+### Project — Work
+
+| Area | What it covers |
+| --- | --- |
+| **Overview** | Project home: activity, task distribution, spend, workflow run status |
+| **Tasks** | The board: columns, cards, subtasks, comments, attachments, waits, activity. Column → workflow binding (auto or manual). Board templates (Simple Kanban, Dev Team, Full SDLC) offered on an empty board |
+| **Workflows** | Named processes made of steps: instructions, which agent runs, dependencies, on-failure behaviour (fail / retry / skip), human approval, inputs/outputs. Publishing and duplicating |
+| **Triggers & gates** | When a workflow starts (task enters column, manual run, schedule, Slack message, inbound webhook) and what can pause a run (waiting on a check or a person) |
+| **Runs** | Workflow runs, live and past: step timeline, parallel waves, approve / retry / skip, cost |
+| **Sessions** | Individual agent sessions: status, log, cost, tokens, artifacts |
+| **Assets** | Files the team uploads and files agents produce; versioning and review |
+
+### Project — Resources
+
+| Area | What it covers |
+| --- | --- |
+| **Agents** | Personas (who the agent is, how it talks, what rules it follows). The same persona can run on any supported runtime |
+| **Wrappers** | Custom tools the team writes so agents can call services that have no connector |
+| **Skills** | Reusable know-how installed from a catalog or written by hand |
+| **Connectors** | External tool servers agents can call, from a catalog or added by hand |
+| **Repositories** | Linked Git repos the agent can work in and push to |
+| **Integrations** | GitHub, GitLab, Linear, and similar connections |
+
+### Project — Admin
+
+| Area | What it covers |
+| --- | --- |
+| **Secrets & variables** | Credentials and config values agents and connectors use |
+| **Members** | Who is on the project and with what access (roles: Admin, Employee, Viewer) |
+| **Analytics** | Spend, sessions, tokens, success — by project, agent, and source |
+| **Settings** | Project name, language, archive, delete |
+
+### Build with AI
+
+| Area | What it covers |
+| --- | --- |
+| **Aixle Builder** | Describe a process in plain language; the product creates workflows, steps, tools, and board setup. (Sidebar entry point is labeled "AI Builder" / "Build with AI"; the feature's pages are titled "Aixle Builder" — this taxonomy uses **Aixle Builder**) |
+
+### Company library & monitoring
+
+| Area | What it covers |
+| --- | --- |
+| **Workflow Catalog** | Shared workflows the team can copy into a project |
+| **Company analytics** | Spend and activity across projects (admins) |
+| **Company sessions** | Cross-project run visibility (admins) |
+| **Company assets** | Workspace-level files (admins) |
+| **Company members** | Who belongs to the company |
+
+### Help
+
+| Area | What it covers |
+| --- | --- |
+| **Docs** | Product documentation at `/docs` (linked from the public site) |
+
+## How the pieces fit (for changelog writers)
+
+Tasks (board) → card enters a bound column → Workflow starts → each Step is one
+Agent session → results, status, and cost come back to the board, to Runs, and
+to Sessions.
+
+Agents do not work in a vacuum. A run can receive: the card (title,
+description, comments, files, column purpose), workflow instructions, skills,
+wrappers, connectors, repositories, and secrets.
+
+## Changelog rules
+
+1. One entry maps to **one product area** from the tables above. If a change
+   spans two areas, split it or pick the one users notice first.
+2. Write for a user who never opens a terminal. Say what they can do now, not
+   how it was built.
+3. Preferred shape: **Added / Changed / Fixed / Removed** × product area, e.g.
+   `Added — Tasks: attach files directly to a card`.
+4. Do not mention implementation. If the only change is internal and users
+   cannot see it, it does not belong in the product changelog.
+5. Keep this snapshot as the baseline. When a release adds a new area (a new
+   nav item or a new first-class object), update this snapshot in the same
+   change as the changelog entry.
+
+## Out of scope
+
+Internals, APIs, ops, and anything not visible in the product.

--- a/docs/product/changelog-product-areas.md
+++ b/docs/product/changelog-product-areas.md
@@ -6,8 +6,9 @@
 > release reads as a change to a named part of the product — not as a list of
 > tickets.
 >
-> **Snapshot date:** 2026-08-17. Area names are verified against the product
-> UI (sidebar labels and page titles), not internal engineering names.
+> **Snapshot date:** 2026-08-20. Area names are verified against the product
+> UI on `develop` (sidebar labels, page titles, and on-screen control copy),
+> not internal engineering names.
 
 ## What Aixle Flow is
 
@@ -44,9 +45,8 @@ they name a flow users would recognize.
 | **Overview** | Project home: activity, task distribution, spend, workflow run status |
 | **Tasks** | The board: columns, cards, subtasks, comments, attachments, waits, activity. Column → workflow binding (auto or manual). Board templates (Simple Kanban, Dev Team, Full SDLC) offered on an empty board |
 | **Workflows** | Named processes made of steps: instructions, which agent runs, dependencies, on-failure behavior (fail / retry / skip), human approval, inputs/outputs. Publishing and duplicating |
-| **Triggers & gates** | When a workflow starts (task enters column, manual run, schedule, Slack message, inbound webhook) and what can pause a run (waiting on a check or a person) |
-| **Runs** | Workflow runs, live and past: step timeline, parallel waves, approve / retry / skip, cost |
-| **Sessions** | Individual agent sessions: status, log, cost, tokens, artifacts |
+| **Triggers & gates** | When a workflow starts (task enters column, manual run, schedule, Slack message, incoming webhook) and what can pause a run: a gate waiting on CI (waiting / passed / failed / stale) or a step waiting on a person |
+| **Sessions & Runs** | One list for both: workflow runs (step timeline, parallel waves, approve / retry / skip, cost) and the agent sessions inside them (status, live terminal, log, tokens, artifacts, cost) |
 | **Assets** | Files the team uploads and files agents produce; versioning and review |
 
 ### Project — Resources
@@ -58,7 +58,7 @@ they name a flow users would recognize.
 | **Skills** | Reusable know-how installed from a catalog or written by hand |
 | **Connectors** | External tool servers agents can call, from a catalog or added by hand |
 | **Repositories** | Linked Git repos the agent can work in and push to |
-| **Integrations** | GitHub, GitLab, Linear, and similar connections |
+| **Integrations** | Connected accounts: GitHub, GitLab, Linear, Slack, Coder |
 
 ### Project — Admin
 
@@ -94,8 +94,8 @@ they name a flow users would recognize.
 ## How the pieces fit (for changelog writers)
 
 Tasks (board) → card enters a bound column → Workflow starts → each Step is one
-Agent session → results, status, and cost come back to the board, to Runs, and
-to Sessions.
+Agent session → results, status, and cost come back to the board and to
+Sessions & Runs.
 
 Agents do not work in a vacuum. A run can receive: the card (title,
 description, comments, files, column purpose), workflow instructions, skills,
@@ -111,9 +111,43 @@ wrappers, connectors, repositories, and secrets.
    `Added — Tasks: attach files directly to a card`.
 4. Do not mention implementation. If the only change is internal and users
    cannot see it, it does not belong in the product changelog.
-5. Keep this snapshot as the baseline. When a release adds a new area (a new
+5. Repository-level changes that a *contributor* must know about — licensing,
+   governance, community health files, contribution rules — stay in
+   `CHANGELOG.md` untagged. They are not product areas, and forcing one on
+   them would be a lie about where the change shows up.
+6. Keep this snapshot as the baseline. When a release adds a new area (a new
    nav item or a new first-class object), update this snapshot in the same
-   change as the changelog entry.
+   change as the changelog entry — and add the matching chapter to
+   [user-guide-outline.md](./user-guide-outline.md).
+
+## Area → guide chapter
+
+Every area above is documented in one chapter of
+[user-guide-outline.md](./user-guide-outline.md). Keep the two in step.
+
+| Area | Chapter |
+| --- | --- |
+| Companies & projects | 20. The company workspace |
+| Sign-in & onboarding | 2. Your first session |
+| Profile | 2. Your first session |
+| Overview | 4. Overview |
+| Tasks | 5. Tasks — the board |
+| Workflows | 6. Workflows |
+| Triggers & gates | 7. Triggers & gates |
+| Sessions & Runs | 8. Sessions & Runs |
+| Assets | 9. Assets |
+| Agents | 10. Agents |
+| Wrappers | 11. Wrappers |
+| Skills | 12. Skills |
+| Connectors | 13. Connectors |
+| Repositories, Integrations | 14. Repositories & Integrations |
+| Aixle Builder | 15. AI Builder |
+| Members | 16. Team |
+| Secrets & Variables | 17. Secrets & Variables |
+| Analytics | 18. Analytics |
+| Settings | 19. Settings |
+| Workflow Catalog, Company analytics / sessions / assets / members | 20. The company workspace |
+| Docs | Not a chapter — the operator portal at `/docs` is a separate document set |
 
 ## Out of scope
 

--- a/docs/product/user-guide-outline.md
+++ b/docs/product/user-guide-outline.md
@@ -15,9 +15,14 @@ they know how agents, containers, or orchestration work.
   what the person does · what they see afterwards.*
 - Use the names from the product UI, not internal engineering names
   (see [Terminology notes](#terminology-notes) at the end).
-- The existing in-app documentation (linked from the public site as
-  **Documentation**) is too technical for this guide — do not reuse its
-  structure or copy.
+- The existing documentation — the in-app portal at `/docs`, mirrored in the
+  repository as [`docs/user-guide/`](../user-guide/) — is written for people
+  installing and operating Flow: it is too technical for this guide. Do not
+  reuse its structure or copy; link to it only where a reader needs the
+  operator-level detail.
+- Every area named in
+  [changelog-product-areas.md](./changelog-product-areas.md) has a chapter
+  here. If a release adds an area, add the chapter in the same change.
 
 ---
 
@@ -46,10 +51,14 @@ The reader goes from an invite email to their first open project.
   for viewer-only users).
 - **Connect an agent.** During onboarding — or any time later in **Profile** —
   connect the account of the agent product you already use (Claude Code,
-  Cursor CLI, Codex, Gemini CLI, or Grok). Nothing can run on your behalf
-  until this is done — say this plainly and early.
-- **Your Profile.** Besides agent credentials, Profile shows your personal
-  usage and personal settings.
+  Cursor CLI, Codex, Gemini CLI, or Grok). Connecting happens in a terminal
+  embedded in the page: the product starts a session, you complete the
+  runtime's own login in it, and the credential is stored for you. Nothing can
+  run on your behalf until this is done — say this plainly and early.
+- **Your Profile.** Three tabs: **Account** (agent credentials and personal
+  settings), **Usage** (your own sessions, tokens, spend, and any limits that
+  apply to you), and **MCP** (personal access, so an agent you run outside
+  Aixle — your own Claude Code, for example — can reach your Aixle projects).
 - **Find your work.** Open **Projects**, pick a project, land on **Overview**.
 - **More than one company?** The workspace switcher moves you between
   companies; each company has its own projects, members, and analytics.
@@ -64,15 +73,27 @@ the guide hangs off this chapter.
 1. Open **Tasks** and create a card (or pick one up from the backlog).
 2. Move the card into a column bound to a workflow — the workflow starts
    automatically, or from a button if the column is set to manual.
-3. Watch progress in **Runs** and **Sessions**: live status, the log as the
-   agent works, cost accumulating.
+3. Watch progress in **Sessions & Runs**: live status, the agent's terminal as
+   it works, cost accumulating.
 4. Review what came back: files in **Assets**, results and comments on the
    card.
 5. Move the card forward — or send it back with a comment and run again.
 
 - *Afterwards:* the reader has seen the whole product once, end to end.
 
-## 4. Tasks — the board
+## 4. Overview
+
+- **What it is.** The project's home page: recent activity, how tasks are
+  distributed across the board, workflow runs, sessions launched, success rate,
+  and total spend.
+- **When to use it.** The daily "what is this project doing right now, and what
+  is it costing" check — before drilling into a specific run.
+- **What you do.** Read the tiles; follow one into Tasks, Sessions & Runs, or
+  Analytics.
+- *Afterwards:* the reader knows where the numbers on this page come from and
+  which screen answers the next question.
+
+## 5. Tasks — the board
 
 - **What it is.** The project's board: columns, cards, subtasks, comments,
   attachments.
@@ -85,10 +106,12 @@ the guide hangs off this chapter.
   **Simple Kanban** (Backlog / In Progress / Done), **Dev Team** (a
   seven-column engineering flow), or **Full SDLC** (the long form) — and
   customize columns later.
+- **Reading a card at a glance.** A card carries chips for its runs and for any
+  checks it is waiting on (see [Triggers & gates](#7-triggers--gates)).
 - *Afterwards:* cards carry their own history — comments, attachments, runs,
   and activity.
 
-## 5. Workflows
+## 6. Workflows
 
 - **What it is.** A named process made of ordered **steps**; each step is one
   agent session doing one job.
@@ -99,29 +122,45 @@ the guide hangs off this chapter.
   parallel); choose what happens on failure (fail, retry, or skip); mark where
   a person must approve before the run continues. Publish it, duplicate it, or
   copy a ready-made one from the **Workflow Catalog**.
-- **How it starts.** From the board (a card enters a bound column), from the
-  workflow itself (Run), on a schedule, from a Slack message, or from an
-  inbound webhook.
 - *Afterwards:* the workflow appears as an option when binding columns, and
   every run of it is tracked.
 
-## 6. Sessions & Runs
+## 7. Triggers & gates
 
-Two sidebar pages, one chapter: **Runs** is workflow runs; **Sessions** is
-individual agent sessions (each step of a run is one session, and sessions can
-also run on their own).
+Two halves of the same question: what starts a run, and what holds one up.
+
+- **What it is.** **Triggers** are the ways a workflow begins: a task enters a
+  bound column, someone runs it by hand, a schedule fires, a Slack message
+  matches, or an external system posts to an incoming webhook. **Gates** are
+  checks a card waits on — typically CI — before work moves on.
+- **When to use it.** Triggers: whenever a process should start without anyone
+  remembering to press a button. Gates: whenever "the tests must be green"
+  belongs in the process rather than in someone's head.
+- **What you do.** Add a trigger to a workflow and pick its kind; for a column
+  trigger, choose Auto or Manual. Watch a gate on the card: it reads
+  **waiting** while CI runs, then **passed**, **failed**, or **stale** when CI
+  never reported at all.
+- *Afterwards:* work starts on its own, and a card that is blocked says what it
+  is blocked on instead of silently sitting still.
+
+## 8. Sessions & Runs
+
+One sidebar item, one chapter. **Runs** are workflow runs; **sessions** are the
+individual agent sessions inside them (each step of a run is one session, and
+sessions can also run on their own). They share a single list.
 
 - **What it is.** Live and past agent work.
 - **When to use it.** To answer "what is happening right now?" and "what
   happened, what did it produce, what did it cost?"
 - **What you do.** Open a run to see its steps, which ran in parallel, and
-  where it is waiting; approve a step that waits for a person
-  (**Approve & Continue**); retry or skip a step; open a session to read the
-  full log.
+  where it is waiting; watch a running step's terminal live, embedded in the
+  page (it shows *Session starting…* until the agent's container is ready);
+  approve a step that waits for a person (**Approve & continue**); retry or
+  skip a step; open a finished session to read its full log.
 - *Afterwards:* every run leaves a trail — status, log, artifacts, tokens, and
   cost.
 
-## 7. Assets
+## 9. Assets
 
 - **What it is.** Files: what the team uploads and what agents produce.
 - **When to use it.** Give agents input material; collect and review what they
@@ -131,7 +170,7 @@ also run on their own).
 - *Afterwards:* outputs are reviewable in one place instead of scattered
   across runs.
 
-## 8. Agents
+## 10. Agents
 
 - **What it is.** Reusable personas: who the agent is, how it talks, what
   rules it follows. A persona is not a product choice — the same persona can
@@ -146,7 +185,7 @@ also run on their own).
 - *Afterwards:* steps reference personas by name, and changing a persona
   changes every workflow that uses it.
 
-## 9. Wrappers
+## 11. Wrappers
 
 - **What it is.** A way to turn a script or an API into something an agent can
   call, when no connector exists for that service.
@@ -156,7 +195,7 @@ also run on their own).
 - *Afterwards:* the wrapper shows up in run logs as a capability the agents
   actually called.
 
-## 10. Skills
+## 12. Skills
 
 - **What it is.** Packaged instructions an agent can load during a session —
   know-how, not tools.
@@ -166,7 +205,7 @@ also run on their own).
   attach it where it should be available.
 - *Afterwards:* agents follow the skill's instructions when the work matches.
 
-## 11. Connectors
+## 13. Connectors
 
 - **What it is.** Connections that give agents extra tools — issue trackers
   and other external services.
@@ -176,11 +215,11 @@ also run on their own).
 - *Afterwards:* the connected service's actions appear among what agents can
   do.
 
-## 12. Repositories & Integrations
+## 14. Repositories & Integrations
 
 - **What it is.** **Repositories** are the Git repos agents work in and push
-  to. **Integrations** connect GitHub, GitLab — and Linear and Slack where
-  available.
+  to. **Integrations** are the accounts Flow connects to on the team's behalf:
+  GitHub, GitLab, Linear, Slack, and Coder.
 - **When to use it.** Any workflow that should read code, open pull requests,
   or touch tickets.
 - **What you do.** Connect the integration, link the repositories the project
@@ -188,7 +227,7 @@ also run on their own).
 - *Afterwards:* runs can produce branches and pull requests in your own
   repos, and tickets can flow both ways.
 
-## 13. AI Builder
+## 15. AI Builder
 
 - **What it is.** Describe a process in plain language; the product builds the
   tasks, board setup, and workflows from that prompt. (This guide uses **AI
@@ -198,11 +237,12 @@ also run on their own).
 - **When to use it.** Setting up a new process — instead of configuring
   columns, workflows, and steps by hand.
 - **What you do.** Write what you want to automate; review what the builder
-  proposes; accept, then adjust by hand where needed.
+  proposes; accept, then adjust by hand where needed. While it works you can
+  watch its terminal, and open its workspace in an editor.
 - *Afterwards:* the board and workflows exist and are editable like anything
   built manually.
 
-## 14. Team
+## 16. Team
 
 - **What it is.** **Members** at two levels: who is in the company, and who is
   on each project.
@@ -213,7 +253,7 @@ also run on their own).
 - *Afterwards:* each person sees what their role allows — admins additionally
   see company-wide analytics and sessions.
 
-## 15. Secrets & Variables
+## 17. Secrets & Variables
 
 - **What it is.** Values agents and connectors need at runtime — credentials
   and configuration — kept out of task text and workflow instructions.
@@ -221,7 +261,7 @@ also run on their own).
 - **What you do.** Add the value once, name it, reference it where needed.
 - *Afterwards:* runs use the value without anyone pasting it into a card.
 
-## 16. Analytics
+## 18. Analytics
 
 - **What it is.** Usage and cost: spend, sessions, tokens, success — by
   project, agent, and source.
@@ -232,7 +272,18 @@ also run on their own).
 - *Afterwards:* cost conversations happen with numbers, per project and per
   company.
 
-## 17. The company workspace
+## 19. Settings
+
+- **What it is.** The project's own settings: its name, its language, and the
+  end of its life — archive or delete.
+- **When to use it.** Renaming a project, changing the language agents write
+  in, retiring a project that is finished.
+- **What you do.** Edit and save; archive when work stops; delete when nothing
+  should remain. Say plainly what delete takes with it.
+- *Afterwards:* an archived project is out of the way without losing its
+  history.
+
+## 20. The company workspace
 
 Round off with the shared layer above projects.
 
@@ -258,9 +309,11 @@ A lead links a repository (Integrations → Repositories), binds the
 and writes a card describing a small feature. They drag the card into the
 column. The workflow starts: one step plans, two parallel steps implement and
 write tests, a final step waits for a human. The lead watches the run in
-**Runs**, reads the diff summary the agent posted to the card, approves the
-waiting step — and a pull request appears in the linked repo. The cost of the
-whole run is on the card and in Analytics.
+**Sessions & Runs** — the implementing step's terminal live on the page — reads
+the diff summary the agent posted to the card, approves the waiting step, and a
+pull request appears in the linked repo. The card's CI gate goes from
+**waiting** to **passed**. The cost of the whole run is on the card and in
+Analytics.
 
 ### Story 2 — build a workflow from one prompt
 
@@ -268,8 +321,8 @@ An operator opens **AI Builder** and types: "When a card lands in *Triage*,
 summarize it, label it, and draft a reply for review." The builder proposes a
 board column, a three-step workflow, and the connector it needs. The operator
 accepts, adds the connector credential in **Secrets & Variables**, and drops a
-test card into *Triage*. The run appears in **Runs**; the draft reply lands on
-the card as a comment — written by an agent, reviewed by a person.
+test card into *Triage*. The run appears in **Sessions & Runs**; the draft reply
+lands on the card as a comment — written by an agent, reviewed by a person.
 
 ---
 
@@ -281,10 +334,13 @@ from each other. Verified against the product as of 2026-08.
 | Guide term | On screen |
 | --- | --- |
 | Tasks | Sidebar item **Tasks**; the page itself is titled **Board** |
-| Sessions & Runs | Two sidebar items: **Runs** and **Sessions** |
-| AI Builder | Sidebar banner **AI Builder** with button **Build with AI**; the feature's own pages are titled **Aixle Builder** |
+| Sessions & Runs | One sidebar item, **Sessions & Runs**: agent sessions and workflow runs share a single list. The standalone **Sessions** item in the company nav is the cross-project, admin-only view |
+| AI Builder | Sidebar card **AI Builder** with button **Build with AI**; the feature's own pages are titled **Aixle Builder** |
 | Board templates | Offered on an empty board (not at project creation); UI says "template" (**Use this template**), preset names **Simple Kanban**, **Dev Team**, **Full SDLC** |
-| Workflow start | Trigger labels on screen: **Task enters column** (Auto or Manual mode), **On schedule**, **Slack message**, **Inbound webhook** — plus running by hand from the workflow or task |
+| Workflow start | Trigger labels on screen: **Task enters column** (Auto or Manual mode), **On schedule**, **Slack message**, **Incoming webhook** — plus running by hand from the workflow or task |
+| Gates | On a card, a gate chip reads **waiting**, **passed**, **failed**, or **stale** (CI never reported) |
 | Step failure options | **On Failure**: Fail / Retry / Skip; **Skip Policy**: Never / If outputs exist / Manual |
-| Human approval | A waiting step shows **Approve & Continue** |
-| Docs | Reachable from the public site (**Documentation**); there is no docs item in the app sidebar |
+| Human approval | A waiting step shows **Approve & continue** |
+| Live terminal | A running step embeds the agent's terminal; before the container is ready it reads **Session starting…**, then **Connecting to terminal…** |
+| Profile | Tabs **Account**, **Usage**, **MCP** — the last is personal access for agents run outside Aixle |
+| Docs | The operator documentation portal at `/docs`, reachable from the public site (**Documentation**); there is no docs item in the app sidebar |

--- a/docs/product/user-guide-outline.md
+++ b/docs/product/user-guide-outline.md
@@ -1,0 +1,284 @@
+# Aixle Flow User Guide — Outline
+
+> Deliverable for issue #550. This is the outline of the end-user product guide —
+> the skeleton a writer expands into full chapters. It follows the product
+> sidebar, uses the names a person sees on screen, and stays at product level:
+> no architecture, no APIs, no configuration, no file paths.
+
+**Audience.** People who will run work in Aixle Flow: engineering leads,
+developers, and operators. Assume they know Git and task boards. Do not assume
+they know how agents, containers, or orchestration work.
+
+**Rules for the writer.**
+
+- Every section answers four questions: *what this is · when to use it ·
+  what the person does · what they see afterwards.*
+- Use the names from the product UI, not internal engineering names
+  (see [Terminology notes](#terminology-notes) at the end).
+- The existing in-app docs at `/docs` are too technical for this guide — do not
+  reuse their structure or copy.
+
+---
+
+## 1. What Aixle Flow is
+
+Open with the loop, not a feature list.
+
+- **What it is.** The team layer above personal AI coding agents — Claude Code,
+  Cursor CLI, Codex, Gemini CLI, and Grok. Not a personal chat with an agent:
+  team control of AI coding work.
+- **The loop.** A person moves a card on the board into a column that is bound
+  to a workflow. Agents start working. When the run finishes, status, files,
+  and cost come back to the board. The team sees what is running, what it
+  produced, and what it cost — without anyone opening a terminal.
+- **The three levels.** A **company** is the shared workspace. Inside it, each
+  **project** has a board and its own resources. Your **profile** holds what is
+  personal: your agent credentials and your usage.
+- One diagram: board → workflow → agent → results back to the board.
+
+## 2. Your first session
+
+The reader goes from an invite email to their first open project.
+
+- **Getting in.** Accept an invitation or sign in. First-run onboarding: role
+  and language.
+- **Connect an agent.** In **Profile**, connect the account of the agent
+  product you already use (Claude Code, Cursor CLI, Codex, Gemini CLI, or
+  Grok). Nothing can run on your behalf until this is done — say this plainly
+  and early.
+- **Find your work.** Open **Projects**, pick a project, land on **Overview**.
+- **More than one company?** The workspace switcher moves you between
+  companies; each company has its own projects, members, and analytics.
+- *Afterwards:* you are inside a project, an agent is connected, and the board
+  is one click away.
+
+## 3. The main loop
+
+A single guided walkthrough, before any reference material. Everything later in
+the guide hangs off this chapter.
+
+1. Open **Tasks** and create a card (or pick one up from the backlog).
+2. Move the card into a column bound to a workflow — the workflow starts
+   automatically, or from a button if the column is set to manual.
+3. Watch progress in **Runs** and **Sessions**: live status, the log as the
+   agent works, cost accumulating.
+4. Review what came back: files in **Assets**, results and comments on the
+   card.
+5. Move the card forward — or send it back with a comment and run again.
+
+- *Afterwards:* the reader has seen the whole product once, end to end.
+
+## 4. Tasks — the board
+
+- **What it is.** The project's board: columns, cards, subtasks, comments,
+  attachments.
+- **When to use it.** This is where work enters the system and where results
+  land; most people live here.
+- **What you do.** Create and move cards; comment; attach files; bind a column
+  to a workflow so that entering the column starts it (automatically or from a
+  button).
+- **Board templates.** A new project's board starts empty; pick a template —
+  **Simple Kanban** (Backlog / In Progress / Done), **Dev Team** (a
+  seven-column engineering flow), or **Full SDLC** (the long form) — and
+  customize columns later.
+- *Afterwards:* cards carry their own history — comments, attachments, runs,
+  and activity.
+
+## 5. Workflows
+
+- **What it is.** A named process made of ordered **steps**; each step is one
+  agent session doing one job.
+- **When to use it.** Whenever the same kind of work should run the same way
+  every time.
+- **What you do.** Create a workflow; add steps with instructions and an
+  assigned agent; set what each step depends on (independent steps run in
+  parallel); choose what happens on failure (fail, retry, or skip); mark where
+  a person must approve before the run continues. Publish it, duplicate it, or
+  copy a ready-made one from the **Workflow Catalog**.
+- **How it starts.** From the board (a card enters a bound column), from the
+  workflow itself (Run), on a schedule, from a Slack message, or from an
+  inbound webhook.
+- *Afterwards:* the workflow appears as an option when binding columns, and
+  every run of it is tracked.
+
+## 6. Sessions & Runs
+
+Two sidebar pages, one chapter: **Runs** is workflow runs; **Sessions** is
+individual agent sessions (each step of a run is one session, and sessions can
+also run on their own).
+
+- **What it is.** Live and past agent work.
+- **When to use it.** To answer "what is happening right now?" and "what
+  happened, what did it produce, what did it cost?"
+- **What you do.** Open a run to see its steps, which ran in parallel, and
+  where it is waiting; approve a step that waits for a person
+  (**Approve & Continue**); retry or skip a step; open a session to read the
+  full log.
+- *Afterwards:* every run leaves a trail — status, log, artifacts, tokens, and
+  cost.
+
+## 7. Assets
+
+- **What it is.** Files: what the team uploads and what agents produce.
+- **When to use it.** Give agents input material; collect and review what they
+  made.
+- **What you do.** Upload files; attach them to tasks; open what a run
+  produced; track versions.
+- *Afterwards:* outputs are reviewable in one place instead of scattered
+  across runs.
+
+## 8. Agents
+
+- **What it is.** Reusable personas: who the agent is, how it talks, what
+  rules it follows. A persona is not a product choice — the same persona can
+  run on any of the supported runtimes (Claude Code, Cursor CLI, Codex, Gemini
+  CLI, Grok).
+- **When to use it.** To make agent behaviour consistent across workflows —
+  "our reviewer", "our implementer" — instead of re-writing instructions per
+  step.
+- **What you do.** Create a persona, write its instructions and rules, pick it
+  in workflow steps. Remind: runs happen under credentials people connect in
+  **Profile**.
+- *Afterwards:* steps reference personas by name, and changing a persona
+  changes every workflow that uses it.
+
+## 9. Wrappers
+
+- **What it is.** A way to turn a script or an API into something an agent can
+  call, when no connector exists for that service.
+- **When to use it.** Your internal service, an odd API, a one-off script.
+- **What you do.** Define the wrapper once; agents in this project can then
+  call it during runs.
+- *Afterwards:* the wrapper shows up as a capability agents actually use in
+  their logs.
+
+## 10. Skills
+
+- **What it is.** Packaged instructions an agent can load during a session —
+  know-how, not tools.
+- **When to use it.** Recurring expertise: "how we write migrations", "our
+  review checklist".
+- **What you do.** Install a skill from the catalog or write one by hand;
+  attach it where it should be available.
+- *Afterwards:* agents follow the skill's instructions when the work matches.
+
+## 11. Connectors
+
+- **What it is.** Connections that give agents extra tools — issue trackers
+  and other external services.
+- **When to use it.** The agent needs to act on a system outside the codebase.
+- **What you do.** Add a connector from the catalog (or by hand); supply its
+  credentials via **Secrets & Variables**.
+- *Afterwards:* the connected service's actions appear among what agents can
+  do.
+
+## 12. Repositories & Integrations
+
+- **What it is.** **Repositories** are the Git repos agents work in and push
+  to. **Integrations** connect GitHub, GitLab — and Linear and Slack where
+  available.
+- **When to use it.** Any workflow that should read code, open pull requests,
+  or touch tickets.
+- **What you do.** Connect the integration, link the repositories the project
+  needs.
+- *Afterwards:* runs can produce branches and pull requests in your own
+  repos, and tickets can flow both ways.
+
+## 13. AI Builder
+
+- **What it is.** Describe a process in plain language; the product builds the
+  tasks, board setup, and workflows from that prompt. (The sidebar button says
+  **AI Builder / Build with AI**; the builder's own pages are titled **Aixle
+  Builder** — the guide should show both once, then stick to one.)
+- **When to use it.** Setting up a new process — instead of configuring
+  columns, workflows, and steps by hand.
+- **What you do.** Write what you want to automate; review what the builder
+  proposes; accept, then adjust by hand where needed.
+- *Afterwards:* the board and workflows exist and are editable like anything
+  built manually.
+
+## 14. Team
+
+- **What it is.** **Members** at two levels: who is in the company, and who is
+  on each project.
+- **Roles.** **Admin** manages members, integrations, and settings;
+  **Employee** works within projects; **Viewer** looks without touching.
+- **What you do.** Invite people by email, set their role, add them to
+  projects.
+- *Afterwards:* each person sees what their role allows — admins additionally
+  see company-wide analytics and sessions.
+
+## 15. Secrets & Variables
+
+- **What it is.** Values agents and connectors need at runtime — credentials
+  and configuration — kept out of task text and workflow instructions.
+- **When to use it.** Any time a run needs a key, token, or setting.
+- **What you do.** Add the value once, name it, reference it where needed.
+- *Afterwards:* runs use the value without anyone pasting it into a card.
+
+## 16. Analytics
+
+- **What it is.** Usage and cost: spend, sessions, tokens, success — by
+  project, agent, and source.
+- **Two levels.** Project **Analytics** for the team; company **Analytics**
+  and company **Sessions** for admins, across all projects.
+- **What you do.** Answer "what did this cost us?", "which workflows work?",
+  "where does agent time go?"
+- *Afterwards:* cost conversations happen with numbers, per project and per
+  company.
+
+## 17. The company workspace
+
+Round off with the shared layer above projects.
+
+- **Projects** — create and switch between them.
+- **Workflow Catalog** — reusable workflows the team can copy into any
+  project.
+- **Company Assets** and **Company Members** — workspace-level files and
+  people.
+- Switching companies when you belong to more than one workspace.
+
+---
+
+## End-to-end stories
+
+Two closing chapters that retell the loop as narratives. Each one names every
+screen it touches, so the reader can replay it.
+
+### Story 1 — drop a card, get a pull request back
+
+A lead links a repository (Integrations → Repositories), binds the
+"Implementation" column of a **Dev Team** board to an implementation workflow,
+and writes a card describing a small feature. They drag the card into the
+column. The workflow starts: one step plans, a parallel pair implements and
+writes tests, a final step waits for a human. The lead watches the run in
+**Runs**, reads the diff summary the agent posted to the card, approves the
+waiting step — and a pull request appears in the linked repo. Cost of the whole
+run is on the card and in Analytics.
+
+### Story 2 — build a workflow from one prompt
+
+An operator opens **AI Builder** and types: "When a card lands in *Triage*,
+summarize it, label it, and draft a reply for review." The builder proposes a
+board column, a three-step workflow, and the connector it needs. The operator
+accepts, adds the connector credential in **Secrets & Variables**, and drops a
+test card into *Triage*. The run appears in **Runs**; the draft reply lands on
+the card as a comment — written by an agent, reviewed by a person.
+
+---
+
+## Terminology notes
+
+For guide writers — where the UI's names differ from what you might expect, or
+from each other. Verified against the product as of 2026-08.
+
+| Guide term | On screen |
+| --- | --- |
+| Tasks | Sidebar item **Tasks**; the page itself is titled **Board** |
+| Sessions & Runs | Two sidebar items: **Runs** and **Sessions** |
+| AI Builder | Sidebar banner **AI Builder** with button **Build with AI**; the feature's own pages are titled **Aixle Builder** |
+| Board templates | Offered on an empty board (not at project creation); UI says "template" (**Use this template**), preset names **Simple Kanban**, **Dev Team**, **Full SDLC** |
+| Workflow start | Trigger labels on screen: **Task enters column** (Auto or Manual mode), **On schedule**, **Slack message**, **Inbound webhook** — plus running by hand from the workflow or task |
+| Step failure options | **On Failure**: Fail / Retry / Skip; **Skip Policy**: Never / If outputs exist / Manual |
+| Human approval | A waiting step shows **Approve & Continue** |
+| Docs | Reachable from the public site (**Documentation**); there is no docs item in the app sidebar |

--- a/docs/product/user-guide-outline.md
+++ b/docs/product/user-guide-outline.md
@@ -15,8 +15,9 @@ they know how agents, containers, or orchestration work.
   what the person does · what they see afterwards.*
 - Use the names from the product UI, not internal engineering names
   (see [Terminology notes](#terminology-notes) at the end).
-- The existing in-app docs at `/docs` are too technical for this guide — do not
-  reuse their structure or copy.
+- The existing in-app documentation (linked from the public site as
+  **Documentation**) is too technical for this guide — do not reuse its
+  structure or copy.
 
 ---
 
@@ -40,12 +41,15 @@ Open with the loop, not a feature list.
 
 The reader goes from an invite email to their first open project.
 
-- **Getting in.** Accept an invitation or sign in. First-run onboarding: role
-  and language.
-- **Connect an agent.** In **Profile**, connect the account of the agent
-  product you already use (Claude Code, Cursor CLI, Codex, Gemini CLI, or
-  Grok). Nothing can run on your behalf until this is done — say this plainly
-  and early.
+- **Getting in.** Accept an invitation or sign in. First-run onboarding walks
+  through role, language, and connecting an agent (the agent step is skipped
+  for viewer-only users).
+- **Connect an agent.** During onboarding — or any time later in **Profile** —
+  connect the account of the agent product you already use (Claude Code,
+  Cursor CLI, Codex, Gemini CLI, or Grok). Nothing can run on your behalf
+  until this is done — say this plainly and early.
+- **Your Profile.** Besides agent credentials, Profile shows your personal
+  usage and personal settings.
 - **Find your work.** Open **Projects**, pick a project, land on **Overview**.
 - **More than one company?** The workspace switcher moves you between
   companies; each company has its own projects, members, and analytics.
@@ -133,7 +137,7 @@ also run on their own).
   rules it follows. A persona is not a product choice — the same persona can
   run on any of the supported runtimes (Claude Code, Cursor CLI, Codex, Gemini
   CLI, Grok).
-- **When to use it.** To make agent behaviour consistent across workflows —
+- **When to use it.** To make agent behavior consistent across workflows —
   "our reviewer", "our implementer" — instead of re-writing instructions per
   step.
 - **What you do.** Create a persona, write its instructions and rules, pick it
@@ -149,8 +153,8 @@ also run on their own).
 - **When to use it.** Your internal service, an odd API, a one-off script.
 - **What you do.** Define the wrapper once; agents in this project can then
   call it during runs.
-- *Afterwards:* the wrapper shows up as a capability agents actually use in
-  their logs.
+- *Afterwards:* the wrapper shows up in run logs as a capability the agents
+  actually called.
 
 ## 10. Skills
 
@@ -187,9 +191,10 @@ also run on their own).
 ## 13. AI Builder
 
 - **What it is.** Describe a process in plain language; the product builds the
-  tasks, board setup, and workflows from that prompt. (The sidebar button says
-  **AI Builder / Build with AI**; the builder's own pages are titled **Aixle
-  Builder** — the guide should show both once, then stick to one.)
+  tasks, board setup, and workflows from that prompt. (This guide uses **AI
+  Builder**, matching the sidebar entry point; the builder's own pages — and
+  the changelog taxonomy — say **Aixle Builder**. Show both names once, then
+  stick to AI Builder.)
 - **When to use it.** Setting up a new process — instead of configuring
   columns, workflows, and steps by hand.
 - **What you do.** Write what you want to automate; review what the builder
@@ -235,7 +240,8 @@ Round off with the shared layer above projects.
 - **Workflow Catalog** — reusable workflows the team can copy into any
   project.
 - **Company Assets** and **Company Members** — workspace-level files and
-  people.
+  people. Company Assets, like company Analytics and Sessions, is visible to
+  admins only.
 - Switching companies when you belong to more than one workspace.
 
 ---
@@ -250,11 +256,11 @@ screen it touches, so the reader can replay it.
 A lead links a repository (Integrations → Repositories), binds the
 "Implementation" column of a **Dev Team** board to an implementation workflow,
 and writes a card describing a small feature. They drag the card into the
-column. The workflow starts: one step plans, a parallel pair implements and
-writes tests, a final step waits for a human. The lead watches the run in
+column. The workflow starts: one step plans, two parallel steps implement and
+write tests, a final step waits for a human. The lead watches the run in
 **Runs**, reads the diff summary the agent posted to the card, approves the
-waiting step — and a pull request appears in the linked repo. Cost of the whole
-run is on the card and in Analytics.
+waiting step — and a pull request appears in the linked repo. The cost of the
+whole run is on the card and in Analytics.
 
 ### Story 2 — build a workflow from one prompt
 

--- a/test/integration/web/docs_render_test.rb
+++ b/test/integration/web/docs_render_test.rb
@@ -36,4 +36,33 @@ class Web::DocsRenderTest < ActionDispatch::IntegrationTest
       props[:slug] == "agents"
     end
   end
+
+  # The product guide is a second, user-facing section of the same portal. Its slugs
+  # are registered in three places that can drift apart (the controller allow-list,
+  # the page registry, and the nav); the frontend guards its own two, this covers
+  # the controller's.
+  PRODUCT_GUIDE_SLUGS = %w[
+    using-flow getting-started project-home tasks running-workflows starting-work
+    sessions-and-runs assets personas agent-capabilities repositories ai-builder
+    people-and-access secrets analytics company-workspace examples
+  ].freeze
+
+  test "show renders every product guide page" do
+    PRODUCT_GUIDE_SLUGS.each do |slug|
+      get docs_page_path(slug)
+      assert_response :success, "expected /docs/#{slug} to render"
+      assert_inertia_page "Docs/DocsPage"
+      assert_inertia_props do |props|
+        props[:slug] == slug
+      end
+    end
+  end
+
+  test "show answers 404 for a slug the portal does not publish" do
+    get docs_page_path("no-such-page")
+    assert_response :not_found
+    # Still the docs page, so the reader lands on the portal's own not-found view
+    # rather than the generic error page.
+    assert_inertia_component "Docs/DocsPage"
+  end
 end

--- a/test/integration/web/docs_render_test.rb
+++ b/test/integration/web/docs_render_test.rb
@@ -36,4 +36,13 @@ class Web::DocsRenderTest < ActionDispatch::IntegrationTest
       props[:slug] == "agents"
     end
   end
+
+  test "show renders the product-area snapshot pages" do
+    %w[user-guide-outline changelog-product-areas].each do |slug|
+      get docs_page_path(slug)
+      assert_response :success
+      assert_inertia_page "Docs/DocsPage"
+      assert_inertia_props { |props| props[:slug] == slug }
+    end
+  end
 end


### PR DESCRIPTION
Combines the two docs branches into one, cut fresh from `develop`:

- **`docs/product-guide-site-pages`** — user guide outline + changelog product-area snapshot, published at `/docs` (`user-guide-outline`, `changelog-product-areas`), mirrored under `docs/product/`.
- **`docs/product-user-guide`** — the full product user guide: a new **Using Flow** portal section with 17 pages (getting started, tasks & board, workflows, sessions & runs, assets, personas, capabilities, repositories, AI Builder, access, secrets, analytics, company workspace, worked examples).

## Merge notes

Merged both branches; resolved three additive conflicts (`navStructure.test.ts`, `docs/index.md`, `docs_render_test.rb`) by keeping both sides. The controller allow-list, nav structure, page registry, and search index now carry both page sets.

## Checks

`docker compose exec -T web make check_all` — all green (rails-test, rubocop, brakeman, system-test, eslint, typescript, fe-test, vite-build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
