### PR TITLE
fix(auth): unblock re-authentication when a credential is marked broken

### DIFF
--- a/app/services/agents/base_adapter.rb
+++ b/app/services/agents/base_adapter.rb
@@ -428,9 +428,13 @@ module Agents
     # concurrent live session's cleanup can't race the read-merge-write.
     #
     # @param credential [AgentCredential]
-    # @return [Hash] { status: :refreshed | :not_needed | :error, detail: String | nil }
+    # @return [Hash] { status: :refreshed | :not_needed | :error, detail: String | nil,
+    #   permanent: Boolean } — `permanent` tells the refresh sweep whether the failure
+    #   makes the credential unusable (flip it to `error`, forcing a re-login) or is a
+    #   transient/partial one. Optional: an adapter that omits it falls back to the
+    #   sweep's invalid_grant check.
     def refresh!(_credential)
-      { status: :not_needed, detail: nil }
+      { status: :not_needed, detail: nil, permanent: false }
     end
 
     # Persist a freshly-refreshed credential blob under a row lock, guarding

--- a/app/services/agents/claude_code_adapter.rb
+++ b/app/services/agents/claude_code_adapter.rb
@@ -189,6 +189,9 @@ module Agents
     # (a) adding designOauth isn't skipped just because claudeAiOauth didn't change, and
     # (b) a session without design access never wipes a stored designOauth.
     OAUTH_BLOCKS = %w[claudeAiOauth designOauth].freeze
+    # The base login. Every other block is an add-on layered onto it, so only this
+    # one going bad makes the whole credential unusable.
+    BASE_OAUTH_BLOCK = "claudeAiOauth"
 
     # Proactive server-side token refresh (Temporal sweep).
     REFRESH_MARGIN_MS = 15 * 60 * 1000 # refresh a block if it expires within 15 min (or already expired)
@@ -227,7 +230,9 @@ module Agents
     # via merge_refreshed_credentials + from_artifacts so a concurrent live session's
     # cleanup can't clobber the rotated token.
     # @param credential [AgentCredential]
-    # @return [Hash] { status: :refreshed | :not_needed | :error, detail: String | nil }
+    # @return [Hash] { status: :refreshed | :not_needed | :error, detail: String | nil,
+    #   permanent: Boolean } — `permanent` is true only when the BASE login is the block
+    #   the server rejected; a dead add-on (designOauth) leaves the credential usable.
     def refresh!(credential)
       current = credential.config_data
       now_ms  = (Time.current.to_f * 1000).to_i
@@ -247,12 +252,15 @@ module Agents
         new_block = request_oauth_refresh(client_id: client_id, refresh_token: block["refreshToken"],
                                           previous: block, now_ms: now_ms)
         if new_block == :invalid_grant
-          # Server has permanently rejected the refresh token. Clear accessToken so
-          # config_files does not write a stale token into the next container — which
-          # would cause DesignSync (or base inference) to fail with an opaque 401.
-          # refreshToken is preserved so the block stays in the DB and the UI shows
-          # "Reconnect Design" rather than losing the Design connection entirely.
-          invalidated_blocks[block_name] = block.except("accessToken")
+          # Server has permanently rejected the refresh token. Strip every piece of
+          # token material: accessToken so config_files does not write a stale token
+          # into the next container (DesignSync or base inference would fail with an
+          # opaque 401), and refreshToken + expiresAt so the sweep stops retrying a
+          # grant the server will never honour again. Retrying it forever is what
+          # pinned expires_at in the past and re-failed the credential every 5 minutes.
+          # The block itself stays so the UI still offers "Reconnect Design" rather
+          # than losing the Design connection entirely.
+          invalidated_blocks[block_name] = block.except("accessToken", "refreshToken", "expiresAt")
           error ||= "#{block_name} invalid_grant — reconnection required"
         elsif new_block
           refreshed_blocks[block_name] = new_block
@@ -275,11 +283,19 @@ module Agents
         end
       end
 
-      return { status: :error,      detail: error } if changes.empty? && error
-      return { status: :not_needed, detail: nil }   if changes.empty?
-      return { status: :error,      detail: error } if invalidated_blocks.any? && refreshed_blocks.empty?
+      # Only a rejected BASE login makes the credential unusable, and only that may
+      # flip it to `error`: a session runs on claudeAiOauth alone, so a dead
+      # designOauth must not take the user's whole Claude login down with it.
+      permanent = invalidated_blocks.key?(BASE_OAUTH_BLOCK)
 
-      { status: :refreshed, detail: error } # partial failure (one block ok, one failed) still counts as refreshed
+      return { status: :not_needed, detail: nil, permanent: false } if changes.empty? && error.nil?
+      # A rejected base login is a failure even when an add-on block rotated fine in
+      # the same pass — reporting :refreshed there would clear the error the user
+      # has to act on.
+      return { status: :error, detail: error, permanent: permanent } if error && (permanent || refreshed_blocks.empty?)
+
+      # partial failure (add-on block failed, base rotated) still counts as refreshed
+      { status: :refreshed, detail: error, permanent: false }
     end
 
     # Extract only the credentials we need to persist

--- a/app/services/session_service.rb
+++ b/app/services/session_service.rb
@@ -16,7 +16,7 @@ class SessionService
       # this user, instead of starting a session that fails silently at provisioning.
       preflight_oauth!(user, params[:mcp_server_ids])
       preflight_cloud!(user, company || project&.company)
-      preflight_agent_credential!(user, company || project&.company, agent_type)
+      preflight_agent_credential!(user, company || project&.company, agent_type, session_type: session_type)
       preflight_url_safety!(params[:mcp_server_ids])
 
       # auth_kind ("design") is carried in metadata so AgentAuthStrategy can run the
@@ -196,11 +196,15 @@ class SessionService
       raise CloudAuth::PreflightError, broken if broken.any?
     end
 
-    # Re-validate selected custom MCP server URLs right before launch (F34). The
-    # model validates at create/update, but DNS (rebinding) or the stored value
-    # may have changed since — a host that now resolves to a private/internal IP
-    # must not be dialed. Cheap: url_safety uses local resolvers only.
-    def preflight_agent_credential!(user, company, agent_type)
+    # Block a launch whose agent credential the refresh sweep has marked broken, so
+    # the user gets "sign in again" instead of a container that fails on an expired
+    # token.
+    #
+    # An auth_setup session is exempt: it exists to REPLACE the broken credential,
+    # so gating it on that credential locks the user out of the only flow that can
+    # clear the error.
+    def preflight_agent_credential!(user, company, agent_type, session_type: nil)
+      return if session_type == "auth_setup"
       return unless agent_type.present? && company.present?
 
       credential = AgentCredential.find_by(user_id: user.id, company_id: company.id, agent_type: agent_type)
@@ -209,6 +213,10 @@ class SessionService
       raise AgentCredential::PreflightError, credential
     end
 
+    # Re-validate selected custom MCP server URLs right before launch (F34). The
+    # model validates at create/update, but DNS (rebinding) or the stored value
+    # may have changed since — a host that now resolves to a private/internal IP
+    # must not be dialed. Cheap: url_safety uses local resolvers only.
     def preflight_url_safety!(mcp_server_ids)
       return if mcp_server_ids.blank?
 

--- a/app/temporal/activities/agent_credentials/refresh_expiring_tokens_activity.rb
+++ b/app/temporal/activities/agent_credentials/refresh_expiring_tokens_activity.rb
@@ -21,7 +21,10 @@ module Activities
             credential.clear_refresh_error! if credential.refresh_error.present?
             refreshed += 1
           when :error
-            permanent = result[:detail].to_s.include?("invalid_grant")
+            # The adapter classifies the failure when it can tell an add-on block
+            # apart from the base login; the string match stays as the fallback for
+            # single-block agents, where any invalid_grant is terminal.
+            permanent = result.fetch(:permanent) { result[:detail].to_s.include?("invalid_grant") }
             credential.mark_refresh_error!(result[:detail], permanent: permanent)
             errors += 1
             log(:warn, "credential #{credential.id} (#{credential.agent_type}) refresh error: #{result[:detail]}")

--- a/test/services/agents/base_adapter_test.rb
+++ b/test/services/agents/base_adapter_test.rb
@@ -290,7 +290,7 @@ module Agents
 
     test "refresh! defaults to a not_needed no-op" do
       # Agents whose credentials carry no refreshable OAuth token never refresh.
-      assert_equal({ status: :not_needed, detail: nil }, @adapter.refresh!(Object.new))
+      assert_equal({ status: :not_needed, detail: nil, permanent: false }, @adapter.refresh!(Object.new))
     end
 
     # == Retired Model Mapping ==

--- a/test/services/agents/claude_code_adapter_test.rb
+++ b/test/services/agents/claude_code_adapter_test.rb
@@ -587,7 +587,7 @@ module Agents
       cred = create(:agent_credential, :claude_code, user: @user,
                     config_data: { "primaryApiKey" => "sk" })
 
-      assert_equal({ status: :not_needed, detail: nil }, @adapter.refresh!(cred))
+      assert_equal({ status: :not_needed, detail: nil, permanent: false }, @adapter.refresh!(cred))
     end
 
     test "refresh! returns not_needed when the token is not near expiry" do
@@ -595,7 +595,7 @@ module Agents
         "claudeAiOauth" => { "accessToken" => "a", "refreshToken" => "r", "expiresAt" => ms_from_now(60 * 60 * 1000) }
       })
 
-      assert_equal({ status: :not_needed, detail: nil }, @adapter.refresh!(cred))
+      assert_equal({ status: :not_needed, detail: nil, permanent: false }, @adapter.refresh!(cred))
     end
 
     test "refresh! refreshes a claudeAiOauth block near expiry and persists rotated tokens" do
@@ -683,7 +683,39 @@ module Agents
       assert_equal "d-a", reloaded.dig("designOauth", "accessToken") # failed block left intact
     end
 
-    test "refresh! clears designOauth accessToken on invalid_grant and returns error" do
+    # The reverse of the partial-success case: a rotated add-on block must not launder
+    # a rejected base login into :refreshed, which would clear the very error telling
+    # the user to sign in again.
+    test "refresh! reports error when the base login is rejected even if another block rotated" do
+      soon = ms_from_now(5 * 60 * 1000)
+      cred = create(:agent_credential, :claude_code, user: @user, config_data: {
+        "claudeAiOauth" => { "accessToken" => "base-a", "refreshToken" => "base-r", "expiresAt" => soon },
+        "designOauth" => { "accessToken" => "d-a", "refreshToken" => "d-r", "expiresAt" => soon, "clientId" => "design-client" }
+      })
+      stub_request(:post, ClaudeCodeAdapter::OAUTH_TOKEN_URL)
+        .with(body: { grant_type: "refresh_token", client_id: ClaudeCodeAdapter::BASE_OAUTH_CLIENT_ID, refresh_token: "base-r" })
+        .to_return(status: 400,
+                   body: { error: "invalid_grant", error_description: "Refresh token expired" }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+      stub_request(:post, ClaudeCodeAdapter::OAUTH_TOKEN_URL)
+        .with(body: { grant_type: "refresh_token", client_id: "design-client", refresh_token: "d-r" })
+        .to_return(status: 200,
+                   body: { access_token: "d-a2", refresh_token: "d-r2", expires_in: 3_600 }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+
+      result = @adapter.refresh!(cred)
+
+      assert_equal :error, result[:status]
+      assert result[:permanent], "a rejected base login condemns the credential regardless of the add-on"
+      reloaded = cred.reload.config_data
+      refute_predicate reloaded.dig("claudeAiOauth", "accessToken"), :present?
+      assert_equal "d-a2", reloaded.dig("designOauth", "accessToken")
+    end
+
+    # designOauth is an add-on layered onto the base login, so its death is reported
+    # as a non-permanent error: the sweep must leave the credential `active` or the
+    # user loses Claude Code entirely — including the auth session that would fix it.
+    test "refresh! strips designOauth token material on invalid_grant without condemning the credential" do
       soon = ms_from_now(5 * 60 * 1000)
       cred = create(:agent_credential, :claude_code, user: @user, config_data: {
         "designOauth" => {
@@ -702,10 +734,14 @@ module Agents
 
       assert_equal :error, result[:status]
       assert_match(/designOauth/, result[:detail])
+      refute result[:permanent], "a dead add-on block must not condemn the whole credential"
       block = cred.reload.config_data["designOauth"]
       refute_predicate block["accessToken"], :present?, "accessToken must be cleared after invalid_grant"
-      assert_equal "stale-dr", block["refreshToken"]
-      assert_equal "design-client", block["clientId"]
+      refute_predicate block["refreshToken"], :present?,
+                       "a grant the server rejected must not be retried by the next sweep"
+      refute_predicate block["expiresAt"], :present?,
+                       "a stale expiry would keep the credential permanently refresh-due"
+      assert_equal "design-client", block["clientId"], "the block stays so the UI still offers Reconnect Design"
     end
 
     test "refresh! clears claudeAiOauth accessToken on invalid_grant" do
@@ -724,9 +760,11 @@ module Agents
       result = @adapter.refresh!(cred)
 
       assert_equal :error, result[:status]
+      assert result[:permanent], "a rejected base login makes the credential unusable"
       block = cred.reload.config_data["claudeAiOauth"]
       refute_predicate block["accessToken"], :present?, "accessToken must be cleared after invalid_grant"
-      assert_equal "stale-r", block["refreshToken"]
+      refute_predicate block["refreshToken"], :present?,
+                       "a grant the server rejected must not be retried by the next sweep"
     end
 
     test "refresh! does not clear accessToken on transient 5xx error" do

--- a/test/services/session_service_test.rb
+++ b/test/services/session_service_test.rb
@@ -244,6 +244,22 @@ class SessionServiceTest < ActiveSupport::TestCase
     assert_equal 0, @user.terminal_sessions.count
   end
 
+  # The catch-22 this guards: the refresh sweep marks a credential broken, and the
+  # only flow that can replace it is an auth_setup session — so gating that session
+  # on the same credential locks the user out for good.
+  test "create_and_start lets an auth_setup session run on a credential in error status" do
+    mock_temporal_start
+    cred = AgentCredential.from_artifacts(@user.id, @company.id, "claude_code", { "primaryApiKey" => "sk-test" })
+    cred.mark_refresh_error!("invalid_grant", permanent: true)
+
+    session = SessionService.create_and_start(
+      user: @user, company: @company, session_type: "auth_setup",
+      agent_type: "claude_code", params: {}
+    )
+
+    assert session.persisted?, "re-authentication must not be gated on the credential it replaces"
+  end
+
   test "create_and_start proceeds when agent credential is active" do
     mock_temporal_start
     AgentCredential.from_artifacts(@user.id, @company.id, "claude_code", { "primaryApiKey" => "sk-test" })

--- a/test/temporal/activities/agent_credentials/refresh_expiring_tokens_activity_test.rb
+++ b/test/temporal/activities/agent_credentials/refresh_expiring_tokens_activity_test.rb
@@ -89,6 +89,27 @@ module Activities
         assert_equal 1, result[:errors]
       end
 
+      # A dead designOauth add-on must not take the base Claude login down with it:
+      # the adapter says so with permanent: false, and that has to win over the
+      # invalid_grant text in the detail.
+      test "honours the adapter's permanent flag over the invalid_grant text" do
+        credential = mock("credential")
+        adapter = mock("adapter")
+        adapter.stubs(:refresh!).returns({ status: :error, permanent: false,
+                                           detail: "designOauth invalid_grant — reconnection required" })
+        credential.stubs(:id).returns(1)
+        credential.stubs(:agent_type).returns("claude_code")
+        credential.stubs(:adapter).returns(adapter)
+        credential.expects(:mark_refresh_error!)
+                  .with("designOauth invalid_grant — reconnection required", permanent: false)
+
+        stub_due([ credential ])
+
+        result = run_activity(RefreshExpiringTokensActivity)
+
+        assert_equal 1, result[:errors]
+      end
+
       test "marks credential with transient error on non-invalid_grant failure" do
         credential = mock("credential")
         adapter = mock("adapter")


### PR DESCRIPTION
## Incident

Production users hit **"Authentication session failed to start."** on every re-authentication attempt, with no way out.

Two bugs compounded:

**1. The re-auth flow was gated on the credential it repairs.** `SessionService.create_and_start` ran `preflight_agent_credential!` for every session type, including `auth_setup`. A credential in `error` status therefore blocked the only flow that could replace it — a permanent lockout, since nothing else clears the status.

**2. A dead Design token condemned the whole Claude login.** The refresh sweep treated any `invalid_grant` as terminal for the entire credential. But `designOauth` is an add-on layered onto `claudeAiOauth`; sessions run on the base block alone. In production 4 credentials sat in `error`, and 3 of them had a **valid** base login — killed by an expired Design token.

It also never settled: an invalidated block kept its `refreshToken` and `expiresAt`, and `expires_at` is the minimum expiry across blocks, so the row stayed permanently refresh-due. Every 5-minute sweep retried a grant the server had permanently rejected and re-failed the credential.

## Changes

- `auth_setup` sessions skip the agent-credential preflight.
- On `invalid_grant`, strip `refreshToken` + `expiresAt` along with `accessToken`. The block stays in the blob, so the UI still shows "Reconnect Design".
- `refresh!` returns `permanent:` — true only when the **base** login is the rejected block. The sweep honours it over the `invalid_grant` string match, which stays as the fallback for single-block agents (Codex, Cursor).
- A rejected base login reports `:error` even when an add-on block rotated successfully in the same pass, instead of reporting `:refreshed` and clearing the error the user must act on.

## Tests

`docker compose exec -T web make check_all` — green (backend 92.17%, frontend 80.79%).

New/updated coverage: auth_setup starts on an errored credential; a design-block `invalid_grant` is non-permanent and leaves the block inert-but-present; a base-block `invalid_grant` is permanent; base rejection wins over a rotated add-on; the sweep honours the adapter's `permanent` flag.

## Production note

The 4 affected credentials need their dead `designOauth` block cleared and `status` reset — the code fix prevents recurrence but does not repair rows already marked `error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
