### PR TITLE
feat(agents): refresh expiring tokens at launch, keep the sweep off held grants

### DIFF
--- a/app/models/agent_credential.rb
+++ b/app/models/agent_credential.rb
@@ -15,6 +15,12 @@ class AgentCredential < ApplicationRecord
 
   MAX_REFRESH_FAILURES = 3
 
+  # How much token life a session is guaranteed at launch. Sessions routinely run
+  # as long as the token itself lives, so a container handed a token with minutes
+  # left dies mid-run on an opaque 401. Anything below this is refreshed before the
+  # token is written into the container — see #refresh_if_expiring!.
+  SESSION_REFRESH_THRESHOLD = 60.minutes
+
   # Validations
   validates :agent_type, presence: true, inclusion: {
     in: CompanyMembership::AVAILABLE_AGENTS,
@@ -71,6 +77,14 @@ class AgentCredential < ApplicationRecord
                           .where("terminal_sessions.agent_type = agent_credentials.agent_type")
     where.not(held.arel.exists)
   }
+
+  # Whether a refresh result means the credential is now unusable. The adapter says
+  # so itself when it can tell an add-on block apart from the base login; the
+  # invalid_grant text is the fallback for single-block agents, where any rejected
+  # grant is terminal.
+  def self.permanent_failure?(result)
+    result.fetch(:permanent) { result[:detail].to_s.include?("invalid_grant") }
+  end
 
   class PreflightError < StandardError
     attr_reader :credential
@@ -178,6 +192,42 @@ class AgentCredential < ApplicationRecord
     result = service.write_to_container(container_id, config_data, workflow_config)
     touch(:last_used_at)
     result
+  end
+
+  def expiring_within?(within)
+    expires_at.present? && expires_at <= within.from_now
+  end
+
+  # Whether a running container currently holds a copy of this credential's tokens.
+  # `excluding_session_id` is the session being launched: it is the one asking, and
+  # its own container has not been handed anything yet.
+  def held_by_live_session?(excluding_session_id: nil)
+    scope = TerminalSession.active.where(user_id: user_id, company_id: company_id, agent_type: agent_type)
+    scope = scope.where.not(id: excluding_session_id) if excluding_session_id
+    scope.exists?
+  end
+
+  # Refresh a token that would otherwise die mid-session, at the last point before a
+  # container gets it. Returns the adapter's result Hash, or :not_needed / :held.
+  #
+  # Two guards, both about the single-use refresh token having more than one holder:
+  #
+  # - :held — another live container already holds these tokens. Rotating now would
+  #   invalidate the copy it is running on, turning one stale session into several.
+  #   That container refreshes for itself and cleanup merges the result back.
+  # - the re-check under the row lock — parallel launches of the same credential
+  #   would otherwise each fire a refresh, and every one after the first replays a
+  #   grant the server has already rotated out.
+  def refresh_if_expiring!(within: SESSION_REFRESH_THRESHOLD, excluding_session_id: nil)
+    return :not_needed unless expiring_within?(within)
+    return :held if held_by_live_session?(excluding_session_id: excluding_session_id)
+
+    with_lock do
+      reload
+      next :not_needed unless expiring_within?(within)
+
+      adapter.refresh!(self, margin_ms: within.in_milliseconds)
+    end
   end
 
   def mark_refresh_error!(message, permanent: false)

--- a/app/models/agent_credential.rb
+++ b/app/models/agent_credential.rb
@@ -55,6 +55,22 @@ class AgentCredential < ApplicationRecord
   scope :refresh_due, ->(within = 60.minutes) {
     where(status: :active).where.not(expires_at: nil).where(expires_at: ..within.from_now)
   }
+  # Credentials no live container currently holds.
+  #
+  # Launching a session writes the token blocks into the container, so the CLI in
+  # there becomes a second holder of the same single-use refresh token — and it
+  # rotates that grant whenever it renews. A sweep that refreshes the copy we still
+  # hold then replays a token the server has already rotated out, which the token
+  # endpoint answers with invalid_grant and, under OAuth reuse detection, can revoke
+  # the whole family. Leave those to the container: session cleanup merges the
+  # rotated blocks back (see AgentSessionStrategy#persist_refreshed_credentials).
+  scope :without_live_session, -> {
+    held = TerminalSession.active
+                          .where("terminal_sessions.user_id = agent_credentials.user_id")
+                          .where("terminal_sessions.company_id = agent_credentials.company_id")
+                          .where("terminal_sessions.agent_type = agent_credentials.agent_type")
+    where.not(held.arel.exists)
+  }
 
   class PreflightError < StandardError
     attr_reader :credential

--- a/app/services/agents/base_adapter.rb
+++ b/app/services/agents/base_adapter.rb
@@ -433,7 +433,10 @@ module Agents
     #   makes the credential unusable (flip it to `error`, forcing a re-login) or is a
     #   transient/partial one. Optional: an adapter that omits it falls back to the
     #   sweep's invalid_grant check.
-    def refresh!(_credential)
+    # @param margin_ms [Integer, nil] how close to expiry a token must be to be worth
+    #   refreshing. Only agents that store their own expiry (Claude, with a block per
+    #   login) can honour it; single-block agents refresh whenever they are called.
+    def refresh!(_credential, margin_ms: nil)
       { status: :not_needed, detail: nil, permanent: false }
     end
 

--- a/app/services/agents/claude_code_adapter.rb
+++ b/app/services/agents/claude_code_adapter.rb
@@ -250,7 +250,8 @@ module Agents
 
         client_id = block_name == "designOauth" ? block["clientId"] : base_oauth_client_id
         new_block = request_oauth_refresh(client_id: client_id, refresh_token: block["refreshToken"],
-                                          previous: block, now_ms: now_ms)
+                                          previous: block, now_ms: now_ms,
+                                          block_name: block_name, credential_id: credential.id)
         if new_block == :invalid_grant
           # Server has permanently rejected the refresh token. Strip every piece of
           # token material: accessToken so config_files does not write a stale token
@@ -871,7 +872,12 @@ module Agents
     # or nil on any network / non-2xx / parse failure (logged). Preserves the block's
     # refreshToken when the server omits a rotated one, and its clientId (designOauth
     # carries its own; claudeAiOauth's is typically nil and dropped by .compact).
-    def request_oauth_refresh(client_id:, refresh_token:, previous:, now_ms:)
+    # `block_name` and `credential_id` exist for the log line alone: a refresh failure
+    # is only diagnosable if it says WHICH block of WHICH credential died and how old
+    # the grant was. "invalid_grant" on a block still minutes from its own expiry means
+    # something else rotated the grant out from under us (a container holding the same
+    # token); on a long-stale block it means the grant simply aged out.
+    def request_oauth_refresh(client_id:, refresh_token:, previous:, now_ms:, block_name: nil, credential_id: nil)
       uri = URI(OAUTH_TOKEN_URL)
       req = Net::HTTP::Post.new(uri)
       req["Content-Type"] = "application/x-www-form-urlencoded"
@@ -883,7 +889,8 @@ module Agents
       response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true, open_timeout: 5, read_timeout: 10) { |h| h.request(req) }
       unless response.is_a?(Net::HTTPSuccess)
         body = response.body.to_s
-        Rails.logger.warn("[ClaudeCodeAdapter] Token refresh failed: #{response.code} #{body.truncate(200)}")
+        Rails.logger.warn("[ClaudeCodeAdapter] Token refresh failed: #{response.code} #{body.truncate(200)} " \
+                          "(#{refresh_context(block_name, credential_id, previous, now_ms)})")
         if response.code == "400"
           parsed = JSON.parse(body) rescue {}
           return :invalid_grant if parsed["error"] == "invalid_grant"
@@ -899,8 +906,23 @@ module Agents
         "clientId"     => previous["clientId"] # preserve (designOauth carries its own; claudeAiOauth may be nil → compacted)
       }.compact
     rescue StandardError => e
-      Rails.logger.warn("[ClaudeCodeAdapter] Token refresh error: #{e.class}: #{e.message}")
+      Rails.logger.warn("[ClaudeCodeAdapter] Token refresh error: #{e.class}: #{e.message} " \
+                        "(#{refresh_context(block_name, credential_id, previous, now_ms)})")
       nil
+    end
+
+    # Never carries token material — block name, credential id and expiry only.
+    def refresh_context(block_name, credential_id, previous, now_ms)
+      expires_at = previous["expiresAt"].to_i
+      parts = [ "block=#{block_name || 'unknown'}", "credential=#{credential_id || 'unknown'}" ]
+      if expires_at.positive?
+        minutes = ((expires_at - now_ms) / 60_000.0).round
+        parts << "expiresAt=#{Time.zone.at(expires_at / 1000.0).utc.iso8601}"
+        parts << (minutes.negative? ? "expired_#{minutes.abs}m_ago" : "expires_in_#{minutes}m")
+      else
+        parts << "expiresAt=none"
+      end
+      parts.join(" ")
     end
 
     def request_subscription_usage(token)

--- a/app/services/agents/claude_code_adapter.rb
+++ b/app/services/agents/claude_code_adapter.rb
@@ -233,7 +233,10 @@ module Agents
     # @return [Hash] { status: :refreshed | :not_needed | :error, detail: String | nil,
     #   permanent: Boolean } — `permanent` is true only when the BASE login is the block
     #   the server rejected; a dead add-on (designOauth) leaves the credential usable.
-    def refresh!(credential)
+    # @param margin_ms [Integer] refresh a block expiring within this many ms. The sweep
+    #   uses the default; a session launch passes its own, larger, threshold so the
+    #   container starts with a token that outlives the session.
+    def refresh!(credential, margin_ms: REFRESH_MARGIN_MS)
       current = credential.config_data
       now_ms  = (Time.current.to_f * 1000).to_i
       refreshed_blocks = {}
@@ -246,7 +249,7 @@ module Agents
 
         exp = block["expiresAt"].to_i
         # refresh if expired or within the margin
-        next unless exp.positive? && (exp - now_ms) <= REFRESH_MARGIN_MS
+        next unless exp.positive? && (exp - now_ms) <= margin_ms
 
         client_id = block_name == "designOauth" ? block["clientId"] : base_oauth_client_id
         new_block = request_oauth_refresh(client_id: client_id, refresh_token: block["refreshToken"],

--- a/app/services/agents/codex_adapter.rb
+++ b/app/services/agents/codex_adapter.rb
@@ -355,7 +355,9 @@ module Agents
     # refresh_access_token! which persists under a row lock via persist_refreshed!.
     # @param credential [AgentCredential]
     # @return [Hash] { status: :refreshed | :error, detail: String | nil }
-    def refresh!(credential)
+    # margin_ms is ignored: this agent stores no per-block expiry to compare it
+    # against, so a call is already the decision to refresh.
+    def refresh!(credential, margin_ms: nil) # rubocop:disable Lint/UnusedMethodArgument
       new_token = refresh_access_token!(credential)
       new_token ? { status: :refreshed, detail: nil }
                 : { status: :error, detail: "codex token refresh failed" }

--- a/app/services/agents/cursor_cli_adapter.rb
+++ b/app/services/agents/cursor_cli_adapter.rb
@@ -168,7 +168,9 @@ module Agents
     # refresh_cursor_token! which persists under a row lock via persist_refreshed!.
     # @param credential [AgentCredential]
     # @return [Hash] { status: :refreshed | :error, detail: String | nil }
-    def refresh!(credential)
+    # margin_ms is ignored: this agent stores no per-block expiry to compare it
+    # against, so a call is already the decision to refresh.
+    def refresh!(credential, margin_ms: nil) # rubocop:disable Lint/UnusedMethodArgument
       new_token = refresh_cursor_token!(credential)
       new_token ? { status: :refreshed, detail: nil }
                 : { status: :error, detail: "cursor token refresh failed" }

--- a/app/services/container_strategies/agent_session_strategy.rb
+++ b/app/services/container_strategies/agent_session_strategy.rb
@@ -94,6 +94,7 @@ module ContainerStrategies
 
       raise_unresolved_credential!(session) if credential.nil? && AgentCredentialsService.supported?(input[:agent_type])
 
+      refresh_expiring_credential!(credential, session)
       SessionContextService.assemble_session_context(container, session, credential: credential)
       run_credential_preflight!(adapter, container, cid)
       {}
@@ -173,6 +174,34 @@ module ContainerStrategies
       }
 
       raise ProvisioningError.new("credential_not_resolved", details)
+    end
+
+    # Give the container a token that outlives the session it is about to run. The
+    # 5-minute sweep only refreshes a token in the last stretch of its life, so a
+    # session starting just before that window would otherwise carry a token with
+    # minutes left and die halfway through on an opaque 401.
+    #
+    # A refresh that fails without condemning the credential is not fatal here: the
+    # token in hand is still valid, and the session is better off starting with it
+    # than not starting at all. A rejected BASE login is fatal — nothing in the
+    # container can recover from it, so say so now with the message that names the fix.
+    def refresh_expiring_credential!(credential, session)
+      return if credential.nil?
+
+      result = credential.refresh_if_expiring!(excluding_session_id: session.id)
+      return unless result.is_a?(Hash)
+
+      case result[:status]
+      when :refreshed
+        credential.clear_refresh_error! if credential.refresh_error.present?
+      when :error
+        permanent = AgentCredential.permanent_failure?(result)
+        credential.mark_refresh_error!(result[:detail], permanent: permanent)
+        raise AgentCredential::PreflightError, credential if permanent
+
+        Rails.logger.warn("[AgentSession] Pre-launch token refresh failed for credential " \
+                          "#{credential.id}: #{result[:detail]} — starting on the token in hand")
+      end
     end
 
     # Adapter hook for launch-time credential verification (e.g. Codex's

--- a/app/services/container_strategies/agent_session_strategy.rb
+++ b/app/services/container_strategies/agent_session_strategy.rb
@@ -189,6 +189,18 @@ module ContainerStrategies
       return if credential.nil?
 
       result = credential.refresh_if_expiring!(excluding_session_id: session.id)
+
+      # Deferring to the container that holds these tokens means this session starts
+      # on whatever is stored, which may be little. Say so: the alternative is finding
+      # out from a 401 halfway through a session and having nothing to correlate it to.
+      if result == :held
+        left = credential.expires_at ? ((credential.expires_at - Time.current) / 60).round : nil
+        Rails.logger.warn("[AgentSession] Starting session #{session.id} on credential #{credential.id} " \
+                          "with #{left || '?'}m of token life: another live session holds these tokens, " \
+                          "so refreshing now would invalidate the copy it is running on")
+        return
+      end
+
       return unless result.is_a?(Hash)
 
       case result[:status]

--- a/app/temporal/activities/agent_credentials/refresh_expiring_tokens_activity.rb
+++ b/app/temporal/activities/agent_credentials/refresh_expiring_tokens_activity.rb
@@ -7,7 +7,11 @@
 module Activities
   module AgentCredentials
     class RefreshExpiringTokensActivity < ::Activities::Base
-      REFRESH_WINDOW = 60.minutes
+      # Matches ClaudeCodeAdapter::REFRESH_MARGIN_MS: selecting rows the adapter will
+      # not act on just re-reads and decrypts them every 5 minutes. A session needing
+      # more headroom than this refreshes at launch instead
+      # (AgentCredential#refresh_if_expiring!).
+      REFRESH_WINDOW = 15.minutes
 
       def run(_input = nil)
         refreshed = 0
@@ -27,10 +31,7 @@ module Activities
             credential.clear_refresh_error! if credential.refresh_error.present?
             refreshed += 1
           when :error
-            # The adapter classifies the failure when it can tell an add-on block
-            # apart from the base login; the string match stays as the fallback for
-            # single-block agents, where any invalid_grant is terminal.
-            permanent = result.fetch(:permanent) { result[:detail].to_s.include?("invalid_grant") }
+            permanent = ::AgentCredential.permanent_failure?(result)
             credential.mark_refresh_error!(result[:detail], permanent: permanent)
             errors += 1
             log(:warn, "credential #{credential.id} (#{credential.agent_type}) refresh error: #{result[:detail]}")

--- a/app/temporal/activities/agent_credentials/refresh_expiring_tokens_activity.rb
+++ b/app/temporal/activities/agent_credentials/refresh_expiring_tokens_activity.rb
@@ -14,7 +14,13 @@ module Activities
         not_needed = 0
         errors = 0
 
-        ::AgentCredential.refreshable.refresh_due(REFRESH_WINDOW).find_each do |credential|
+        due = ::AgentCredential.refreshable.refresh_due(REFRESH_WINDOW)
+        # Skipped, not dropped: a credential a live container holds is refreshed by
+        # the CLI in that container, and its cleanup merges the rotated block back.
+        # Refreshing our own copy in parallel is what replays a rotated-out grant.
+        held = due.count - due.without_live_session.count
+
+        due.without_live_session.find_each do |credential|
           result = credential.adapter.refresh!(credential)
           case result[:status]
           when :refreshed
@@ -37,8 +43,9 @@ module Activities
           log(:warn, "credential #{credential.id} refresh raised: #{e.class}: #{e.message}")
         end
 
-        log(:info, "token refresh sweep: refreshed=#{refreshed} not_needed=#{not_needed} errors=#{errors}")
-        { refreshed: refreshed, not_needed: not_needed, errors: errors }
+        log(:info, "token refresh sweep: refreshed=#{refreshed} not_needed=#{not_needed} " \
+                   "errors=#{errors} held_by_live_session=#{held}")
+        { refreshed: refreshed, not_needed: not_needed, errors: errors, held: held }
       end
     end
   end

--- a/test/models/agent_credential_test.rb
+++ b/test/models/agent_credential_test.rb
@@ -310,6 +310,47 @@ class AgentCredentialTest < ActiveSupport::TestCase
     refute_includes AgentCredential.refresh_due, cred
   end
 
+  # --- without_live_session scope (keeps the sweep off tokens a container holds) ---
+
+  test "without_live_session excludes a credential a live session holds" do
+    cred = create(:agent_credential, user: @user, agent_type: "claude_code",
+                                     config_data: claude_config(expires_at: 5.minutes.from_now))
+    create(:terminal_session, user: @user, company_id: cred.company_id,
+                              agent_type: "claude_code", state: "running")
+
+    refute_includes AgentCredential.without_live_session, cred
+  end
+
+  test "without_live_session ignores sessions that already ended" do
+    cred = create(:agent_credential, user: @user, agent_type: "claude_code",
+                                     config_data: claude_config(expires_at: 5.minutes.from_now))
+    create(:terminal_session, user: @user, company_id: cred.company_id,
+                              agent_type: "claude_code", state: "finished")
+
+    assert_includes AgentCredential.without_live_session, cred
+  end
+
+  # A session on a different agent holds different token material, so it says nothing
+  # about whether this credential is safe to refresh.
+  test "without_live_session only counts sessions on the same agent type" do
+    cred = create(:agent_credential, user: @user, agent_type: "claude_code",
+                                     config_data: claude_config(expires_at: 5.minutes.from_now))
+    create(:terminal_session, user: @user, company_id: cred.company_id,
+                              agent_type: "codex", state: "running")
+
+    assert_includes AgentCredential.without_live_session, cred
+  end
+
+  test "without_live_session only counts sessions belonging to the credential owner" do
+    cred = create(:agent_credential, user: @user, agent_type: "claude_code",
+                                     config_data: claude_config(expires_at: 5.minutes.from_now))
+    other = create(:user, company: @company)
+    create(:terminal_session, user: other, company_id: cred.company_id,
+                              agent_type: "claude_code", state: "running")
+
+    assert_includes AgentCredential.without_live_session, cred
+  end
+
   # --- status / refresh error lifecycle ---
 
   test "mark_refresh_error! increments failure count and records the message" do

--- a/test/models/agent_credential_test.rb
+++ b/test/models/agent_credential_test.rb
@@ -351,6 +351,67 @@ class AgentCredentialTest < ActiveSupport::TestCase
     assert_includes AgentCredential.without_live_session, cred
   end
 
+  # --- refresh_if_expiring! (launch-time top-up) ---
+
+  # A session runs about as long as the token lives, so one started on a token with
+  # minutes left dies halfway through. The sweep only tops up in the last stretch of
+  # a token's life, which is why the launch does its own check.
+  def refreshable_claude_config(expires_at:)
+    { "claudeAiOauth" => { "accessToken" => "old-tok", "refreshToken" => "old-ref",
+                           "expiresAt" => (expires_at.to_f * 1000).to_i } }
+  end
+
+  def stub_token_endpoint
+    stub_request(:post, Agents::ClaudeCodeAdapter::OAUTH_TOKEN_URL)
+      .to_return(status: 200,
+                 body: { access_token: "new-tok", refresh_token: "new-ref", expires_in: 3_600 }.to_json,
+                 headers: { "Content-Type" => "application/json" })
+  end
+
+  test "refresh_if_expiring! leaves a token with plenty of life alone" do
+    cred = create(:agent_credential, user: @user, agent_type: "claude_code",
+                                     config_data: refreshable_claude_config(expires_at: 3.hours.from_now))
+
+    assert_equal :not_needed, cred.refresh_if_expiring!
+  end
+
+  test "refresh_if_expiring! tops up a token that would not outlive the session" do
+    cred = create(:agent_credential, user: @user, agent_type: "claude_code",
+                                     config_data: refreshable_claude_config(expires_at: 20.minutes.from_now))
+    stub_token_endpoint
+
+    result = cred.refresh_if_expiring!
+
+    assert_equal :refreshed, result[:status]
+    assert_equal "new-tok", cred.reload.config_data.dig("claudeAiOauth", "accessToken")
+  end
+
+  # Rotating while another container runs on these tokens invalidates the copy it is
+  # using — one session about to start would take the others down with it.
+  test "refresh_if_expiring! defers to a container already holding the tokens" do
+    cred = create(:agent_credential, user: @user, agent_type: "claude_code",
+                                     config_data: refreshable_claude_config(expires_at: 20.minutes.from_now))
+    create(:terminal_session, user: @user, company_id: cred.company_id,
+                              agent_type: "claude_code", state: "running")
+
+    assert_equal :held, cred.refresh_if_expiring!
+    assert_equal "old-tok", cred.reload.config_data.dig("claudeAiOauth", "accessToken")
+  end
+
+  # The session being launched is the one asking, and its container has not been
+  # handed anything yet — it must not block its own top-up.
+  test "refresh_if_expiring! ignores the session it is launching for" do
+    cred = create(:agent_credential, user: @user, agent_type: "claude_code",
+                                     config_data: refreshable_claude_config(expires_at: 20.minutes.from_now))
+    launching = create(:terminal_session, user: @user, company_id: cred.company_id,
+                                          agent_type: "claude_code", state: "running")
+    stub_token_endpoint
+
+    result = cred.refresh_if_expiring!(excluding_session_id: launching.id)
+
+    assert_equal :refreshed, result[:status]
+  end
+
   # --- status / refresh error lifecycle ---
 
   test "mark_refresh_error! increments failure count and records the message" do

--- a/test/services/agents/claude_code_adapter_test.rb
+++ b/test/services/agents/claude_code_adapter_test.rb
@@ -767,6 +767,28 @@ module Agents
                        "a grant the server rejected must not be retried by the next sweep"
     end
 
+    # A refresh failure is only actionable if the log says which block of which
+    # credential died and how its own expiry compares — that is what separates
+    # "someone rotated this grant out from under us" from "the grant aged out".
+    test "refresh! logs the failing block, credential and expiry on a rejected refresh" do
+      soon = ms_from_now(5 * 60 * 1000)
+      cred = create(:agent_credential, :claude_code, user: @user, config_data: {
+        "designOauth" => {
+          "accessToken" => "stale-d", "refreshToken" => "stale-dr",
+          "expiresAt" => soon, "clientId" => "design-client"
+        }
+      })
+      stub_request(:post, ClaudeCodeAdapter::OAUTH_TOKEN_URL)
+        .to_return(status: 400,
+                   body: { error: "invalid_grant", error_description: "Refresh token expired" }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+      Rails.logger.expects(:warn)
+           .with(regexp_matches(/block=designOauth credential=#{cred.id} expiresAt=.*expires_in_5m/))
+           .at_least_once
+
+      @adapter.refresh!(cred)
+    end
+
     test "refresh! does not clear accessToken on transient 5xx error" do
       soon = ms_from_now(5 * 60 * 1000)
       cred = create(:agent_credential, :claude_code, user: @user, config_data: {

--- a/test/services/container_strategies/agent_session_strategy_test.rb
+++ b/test/services/container_strategies/agent_session_strategy_test.rb
@@ -161,6 +161,24 @@ module ContainerStrategies
       assert_equal "active", @credential.reload.status
     end
 
+    # Deferring to the container that holds the tokens is the right call, but it means
+    # starting on whatever is stored — which the logs have to say, or the resulting
+    # mid-session 401 has nothing to correlate it to.
+    test "before_exec says so when it starts on a token another live session holds" do
+      @credential.update!(config_data: {
+        "claudeAiOauth" => { "accessToken" => "old-tok", "refreshToken" => "old-ref",
+                             "expiresAt" => (20.minutes.from_now.to_f * 1000).to_i }
+      })
+      create(:terminal_session, user: @user, company_id: @credential.company_id,
+                                agent_type: "claude_code", state: "running")
+      SessionContextService.stubs(:assemble_session_context)
+      Rails.logger.expects(:warn).with(regexp_matches(/another live session holds these tokens/)).at_least_once
+
+      run_before_exec(build_strategy)
+
+      assert_equal "old-tok", @credential.reload.config_data.dig("claudeAiOauth", "accessToken")
+    end
+
     test "before_exec rejects a nil credential before assembling context" do
       strategy = AgentSessionStrategy.new(
         user_id: @user.id,

--- a/test/services/container_strategies/agent_session_strategy_test.rb
+++ b/test/services/container_strategies/agent_session_strategy_test.rb
@@ -107,6 +107,60 @@ module ContainerStrategies
       strategy.before_exec(container_id: "container_ref")
     end
 
+    # A session runs about as long as the token lives, so one handed a token with
+    # minutes left dies halfway through on an opaque 401. The sweep only tops up in
+    # the last stretch of a token's life — the launch has to check for itself.
+    test "before_exec tops up a token that would expire mid-session" do
+      @credential.update!(config_data: {
+        "claudeAiOauth" => { "accessToken" => "old-tok", "refreshToken" => "old-ref",
+                             "expiresAt" => (20.minutes.from_now.to_f * 1000).to_i }
+      })
+      stub_request(:post, Agents::ClaudeCodeAdapter::OAUTH_TOKEN_URL)
+        .to_return(status: 200,
+                   body: { access_token: "fresh-tok", refresh_token: "fresh-ref", expires_in: 3_600 }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+      SessionContextService.stubs(:assemble_session_context)
+
+      run_before_exec(build_strategy)
+
+      assert_equal "fresh-tok", @credential.reload.config_data.dig("claudeAiOauth", "accessToken")
+    end
+
+    # Nothing inside the container can recover from a rejected base login, so the
+    # launch stops with the message that names the fix instead of starting a session
+    # doomed to 401 on its first call.
+    test "before_exec refuses to launch when the base login is permanently rejected" do
+      @credential.update!(config_data: {
+        "claudeAiOauth" => { "accessToken" => "old-tok", "refreshToken" => "dead-ref",
+                             "expiresAt" => (20.minutes.from_now.to_f * 1000).to_i }
+      })
+      stub_request(:post, Agents::ClaudeCodeAdapter::OAUTH_TOKEN_URL)
+        .to_return(status: 400,
+                   body: { error: "invalid_grant", error_description: "Refresh token expired" }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+      SessionContextService.expects(:assemble_session_context).never
+
+      error = assert_raises(AgentCredential::PreflightError) { run_before_exec(build_strategy) }
+
+      assert_includes error.message, "expired"
+      assert_equal "error", @credential.reload.status
+    end
+
+    # The token in hand is still valid for a while — a token endpoint having a bad
+    # minute is no reason to refuse the session.
+    test "before_exec starts the session anyway when the top-up fails transiently" do
+      @credential.update!(config_data: {
+        "claudeAiOauth" => { "accessToken" => "old-tok", "refreshToken" => "old-ref",
+                             "expiresAt" => (20.minutes.from_now.to_f * 1000).to_i }
+      })
+      stub_request(:post, Agents::ClaudeCodeAdapter::OAUTH_TOKEN_URL).to_return(status: 500, body: "boom")
+      SessionContextService.expects(:assemble_session_context).once
+
+      run_before_exec(build_strategy)
+
+      assert_equal "active", @credential.reload.status
+    end
+
     test "before_exec rejects a nil credential before assembling context" do
       strategy = AgentSessionStrategy.new(
         user_id: @user.id,
@@ -730,6 +784,19 @@ module ContainerStrategies
         route_token: @session.route_token,
         credential: cred
       )
+    end
+
+    # Drive before_exec with the container plumbing stubbed out — these tests are
+    # about what the launch does with the credential, not about the runtime.
+    def run_before_exec(strategy)
+      container_mock = mock("container")
+      strategy.stubs(:resolve_container).returns(container_mock)
+      runtime_mock = mock("runtime")
+      strategy.stubs(:runtime).returns(runtime_mock)
+      runtime_mock.stubs(:container_identifier).with(container_mock).returns("abc123")
+      strategy.stubs(:run_credential_preflight!)
+
+      strategy.before_exec(container_id: "container_ref")
     end
 
     def build_codex_preflight_strategy(auth_content)

--- a/test/temporal/activities/agent_credentials/refresh_expiring_tokens_activity_test.rb
+++ b/test/temporal/activities/agent_credentials/refresh_expiring_tokens_activity_test.rb
@@ -20,12 +20,17 @@ module Activities
 
       # Point AgentCredential.refreshable.refresh_due(REFRESH_WINDOW) at a fixed
       # collection that responds to find_each (the activity iterates with it).
-      def stub_due(records)
+      # `held` stands for credentials a live container holds: they are due, but the
+      # sweep must leave them alone and only report how many it skipped.
+      def stub_due(records, held: 0)
         records.define_singleton_method(:find_each) { |&blk| each(&blk) }
+        due = mock("due_relation")
+        due.stubs(:count).returns(records.size + held)
+        due.stubs(:without_live_session).returns(records)
         refreshable = mock("refreshable_relation")
         refreshable.stubs(:refresh_due)
           .with(RefreshExpiringTokensActivity::REFRESH_WINDOW)
-          .returns(records)
+          .returns(due)
         ::AgentCredential.stubs(:refreshable).returns(refreshable)
       end
 
@@ -70,7 +75,21 @@ module Activities
 
         result = run_activity(RefreshExpiringTokensActivity)
 
-        assert_equal({ refreshed: 0, not_needed: 0, errors: 0 }, result)
+        assert_equal({ refreshed: 0, not_needed: 0, errors: 0, held: 0 }, result)
+      end
+
+      # Refreshing a token a container also holds replays a grant that container may
+      # already have rotated, so the sweep leaves it alone — and says how many it left.
+      test "leaves credentials a live session holds to that session and counts them" do
+        credential = credential_double(id: 1, agent_type: "claude_code", status: :refreshed)
+        credential.stubs(:refresh_error).returns(nil)
+
+        stub_due([ credential ], held: 2)
+
+        result = run_activity(RefreshExpiringTokensActivity)
+
+        assert_equal 2, result[:held]
+        assert_equal 1, result[:refreshed]
       end
 
       test "marks credential with permanent error on invalid_grant" do


### PR DESCRIPTION
Follow-up to #203. That PR stopped a dead `designOauth` block from condemning the whole Claude credential and stopped the sweep from retrying a rejected grant forever. This one goes after *why the grant dies*, and makes sure a session starts on a token that outlives it.

## What the incident data shows

The token endpoint answers `{"error": "invalid_grant", "error_description": "Refresh token expired"}` — the grant was rotated out or aged out, not revoked. The refresh code itself is correct: it persists rotations, merges per block, and refuses to downgrade a newer stored token.

What is not correct is how many holders one single-use refresh token has. `ClaudeCodeAdapter#config_files` writes both OAuth blocks into `.credentials.json` for **every** session, so each running container holds a copy of the same grant, alongside the copy the sweep holds. In the production window, the affected users had up to five containers running in parallel between the last successful refresh (01:40Z) and the first `invalid_grant` (02:25Z). Whoever renews first rotates the family; everyone else is holding a token the server now rejects.

The base block survives this because it is used constantly and a fresh copy keeps landing back in the DB at session cleanup. The design block is used by nobody in a normal step, so a stale copy just sits there until the sweep reaches for it near the end of its 8 hours.

## Changes

**The sweep no longer refreshes a credential a live container holds.** `AgentCredential.without_live_session` excludes credentials with an active session on the same (user, company, agent_type). Those are refreshed by the CLI in the container, and `AgentSessionStrategy#persist_refreshed_credentials` merges the rotated block back at cleanup. The skip is reported, not silent: the sweep logs and returns `held_by_live_session`.

**A session no longer starts on a token that will die under it.** `before_exec` — the last point before the token is written into the container — refreshes anything with less than an hour of life left (`AgentCredential::SESSION_REFRESH_THRESHOLD`). A rejected base login stops the launch with the message that names the fix; a transient failure does not, since the token in hand is still valid and a bad minute at the token endpoint is no reason to refuse a session.

This is a pre-launch refresh again, which #177 removed as "fragile, blocks session start". What made it fragile is guarded now: the refresh is skipped while another live container holds the same credential (rotating would invalidate the copy it is running on, turning one stale session into several), and the expiry is re-checked under the row lock, so parallel launches of one credential perform a single refresh instead of each replaying an already-rotated grant.

For scale: Claude hands out 8-hour tokens (`expires_in` 28800, measured against production rows — `expires_at` minus the refresh that wrote it is 480 minutes across the board). A one-hour threshold therefore fires only in the final hour of a token's life, so this adds roughly one refresh per credential per 8 hours, not one per launch. The two guards matter for the parallel case rather than the frequency.

**The sweep's window drops from 60 to 15 minutes.** #177 widened it to compensate for removing the pre-launch refresh, but `ClaudeCodeAdapter::REFRESH_MARGIN_MS` still refuses to refresh a block more than 15 minutes from expiry — so the extra 45 minutes only bought a re-read and decrypt of rows nothing would act on, every 5 minutes. The compensation never actually worked; the launch does that job now.

**Refresh failures now say what died.** The warning carried only the HTTP status and body, which is why diagnosing this took a production archaeology session. It now also carries the block name, the credential id, and the block's own expiry — `block=designOauth credential=52 expiresAt=2026-09-05T02:40:00Z expires_in_5m`. No token material is logged.

That last line is also the experiment: an `invalid_grant` on a block still minutes from its own expiry means something else rotated the grant out from under us, while the same error on a long-stale block means the grant simply aged out. Right now both hypotheses fit the data.

## Deliberately not changed

Not injecting `designOauth` into containers that never use it would remove the remaining race, but `DesignSync` is a Claude Code built-in sitting unconditionally in `BUILTIN_TOOLS` — there is no per-step signal for "this one needs design", so gating it is a product decision rather than a bug fix. Left as is until the new logs say whether rotation is actually the mechanism.

## Tests

`docker compose exec -T web make check_all` — green (backend 92.18%, frontend 80.77%).

Covers: the scope excludes a credential held by a running session and ignores finished sessions, sessions on another agent, and sessions belonging to another user; the sweep skips held credentials and reports the count; the launch tops up an expiring token, refuses to launch on a permanently rejected base login, and starts anyway on a transient failure; the launch-time refresh defers to a container already holding the tokens and ignores the session it is launching for; a rejected refresh logs block, credential and expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
