### PR TITLE
Show and filter queued work on the board and the project feed

### DIFF
--- a/app/frontend/pages/Projects/Sessions/SessionsRunsPage.tsx
+++ b/app/frontend/pages/Projects/Sessions/SessionsRunsPage.tsx
@@ -75,6 +75,7 @@ const AGENT_OPTIONS = [
 
 // One vocabulary over two state machines — see SessionsRunsFeed::STATUS_FILTERS.
 const STATUS_OPTIONS = [
+  { value: 'queued', label: 'Queued' },
   { value: 'running', label: 'Running' },
   { value: 'completed', label: 'Completed' },
   { value: 'failed', label: 'Failed' },

--- a/app/services/sessions_runs_feed.rb
+++ b/app/services/sessions_runs_feed.rb
@@ -20,12 +20,18 @@ class SessionsRunsFeed
   # One status vocabulary over two state machines. A session is "finished" where
   # a run is "completed"; asking a user to know that is asking them to know our
   # schema.
+  # A run whose step is waiting for a session slot is itself `running` — queueing
+  # is a property of the child, not of the run — so this side cannot be a state
+  # list like the others. QUEUED_STEP asks the question the state cannot.
+  QUEUED_STEP = :queued_step
+
   STATUS_FILTERS = {
+    "queued" => { sessions: %w[queued], runs: QUEUED_STEP },
     "running" => { sessions: %w[running ready finishing], runs: %w[running] },
     "completed" => { sessions: %w[finished], runs: %w[completed] },
     "failed" => { sessions: %w[failed], runs: %w[failed] },
     "cancelled" => { sessions: %w[cancelled], runs: %w[cancelled] },
-    "pending" => { sessions: %w[not_started queued], runs: %w[pending paused] }
+    "pending" => { sessions: %w[not_started], runs: %w[pending paused] }
   }.freeze
 
   TYPES = %w[all run solo].freeze
@@ -135,7 +141,10 @@ class SessionsRunsFeed
   def filtered_runs
     scope = WorkflowRun.where(project: project)
     scope = scope.where(user_id: filters[:user_id]) if filters[:user_id].present?
-    if (states = status_states(:runs))
+    states = status_states(:runs)
+    if states == QUEUED_STEP
+      scope = scope.where(id: runs_with_queued_step)
+    elsif states
       scope = states.empty? ? scope.none : scope.where(state: states)
     end
     if filters[:agent_type].present?
@@ -146,6 +155,12 @@ class SessionsRunsFeed
       scope = scope.joins(:workflow).where("workflows.name ILIKE :q", q: "%#{sanitize_like(filters[:search])}%")
     end
     scope
+  end
+
+  def runs_with_queued_step
+    WorkflowRun.joins(step_runs: :terminal_session)
+               .where(terminal_sessions: { state: "queued" })
+               .select(:id)
   end
 
   # nil means "no status filter"; [] means "this side of the union matches

--- a/test/services/sessions_runs_feed_test.rb
+++ b/test/services/sessions_runs_feed_test.rb
@@ -68,13 +68,48 @@ class SessionsRunsFeedTest < ActiveSupport::TestCase
     assert_equal [ finished.id, completed_run.id ].sort, ids.sort
   end
 
-  test "cancelled matches runs only, since sessions have no such state" do
+  test "cancelled matches a cancelled session and a cancelled run alike" do
     standalone(state: "finished")
+    session = standalone(state: "cancelled")
     cancelled = create(:workflow_run, :cancelled, workflow: @workflow, project: @project, user: @user)
 
     entries = feed(filters: { status: "cancelled" }).page(page: 1, limit: 10).entries
 
-    assert_equal [ [ "run", cancelled.id ] ], entries.map { |e| [ e.kind, e.record.id ] }
+    assert_equal [ [ "run", cancelled.id ], [ "session", session.id ] ].sort,
+      entries.map { |e| [ e.kind, e.record.id ] }.sort
+  end
+
+  # Queueing is what an operator watches during a capacity squeeze, so it needs
+  # to be answerable on the page where a project's work actually lives.
+  test "queued finds a waiting standalone session" do
+    waiting = standalone(state: "queued")
+    standalone(state: "ready")
+
+    entries = feed(filters: { status: "queued" }).page(page: 1, limit: 10).entries
+
+    assert_equal [ [ "session", waiting.id ] ], entries.map { |e| [ e.kind, e.record.id ] }
+  end
+
+  test "queued finds a run whose step is waiting, though the run itself is running" do
+    run = create(:workflow_run, :running, workflow: @workflow, project: @project, user: @user)
+    step_run = create(:step_run, :running, workflow_run: run)
+    step_run.update!(terminal_session: create(:terminal_session, project: @project, user: @user,
+                                              session_type: "workflow_step", state: "queued"))
+    create(:workflow_run, :running, workflow: @workflow, project: @project, user: @user)
+
+    entries = feed(filters: { status: "queued" }).page(page: 1, limit: 10).entries
+
+    assert_equal [ [ "run", run.id ] ], entries.map { |e| [ e.kind, e.record.id ] },
+      "a run is 'running' while its step waits, so state alone cannot answer this"
+  end
+
+  test "pending no longer doubles as queued" do
+    standalone(state: "queued")
+    not_started = standalone(state: "not_started")
+
+    entries = feed(filters: { status: "pending" }).page(page: 1, limit: 10).entries
+
+    assert_equal [ [ "session", not_started.id ] ], entries.map { |e| [ e.kind, e.record.id ] }
   end
 
   test "search matches a session's prompt and a run's workflow name" do


### PR DESCRIPTION
## Summary

The company-wide sessions list got a **Queued** filter with the admission queue. The project's own Sessions & Runs list did not — queued sessions were folded into **Pending** alongside `not_started`.

That is backwards: the project feed is where a project's work actually lives, so it is the first place someone looks during a capacity squeeze, and it was the one place that could not answer "what is waiting?".

## Runs need a different question than sessions

A run whose step is waiting for a slot is itself `running` — queueing is a property of the child, not of the run. So the runs side of this filter cannot be a state list like the others:

```ruby
QUEUED_STEP = :queued_step

STATUS_FILTERS = {
  "queued" => { sessions: %w[queued], runs: QUEUED_STEP },
  ...
}
```

`filtered_runs` answers it with a join on step sessions instead. The run row still reads **Running**, which is true; expanding it shows which step is waiting, using the nested session states the resource already carries.

**Pending drops `queued`** rather than keeping it in both, so the two filters do not overlap and disagree about the same row.

## The board could not say it either

The filter was half the problem. A run whose step is waiting for capacity is itself `running`, so the board card painted it amber and the tooltip read `Status: running` — the ticket claimed work was happening while nothing was. Same on the runs feed row.

That is resolved on the server, so every consumer agrees rather than each re-deriving it: board cards, task detail, the runs feed, and the MCP task listing.

```ruby
# "waiting" is a queued step session and nothing else in flight — a run with one
# step executing and another queued is still working, not parked
states.include?("queued") && (states & %w[running ready finishing]).empty?
```

It costs **one query for a whole page**, passed into the resource, rather than a join behind every ticket. The board's N+1 guard moves 8 → 9 for exactly that query, with the reason written next to it.

**Blue, not amber.** `queued` already reads as `info` everywhere else — `StatusBadge` maps it that way and the sessions list has shown blue QUEUED chips since the queue landed — so the board now says the same thing as the rest of the app. It still counts as in flight: the ticket will proceed on its own, unlike a pending gate, which deliberately clears the active flag because nothing moves without a human.

## Type of change

- [x] Bug fix / small feature
- [ ] Breaking change

## How was this tested?

`docker compose exec -T web make check_all` — green in full (rails-test, rubocop, brakeman, system-test, eslint, typescript, fsd, vitest, vite-build).

Four tests added to `SessionsRunsFeedTest`: a waiting standalone session, a run whose step waits while the run is running, and that Pending no longer doubles as Queued.

Also corrects a test whose name outlived it — `"cancelled matches runs only, since sessions have no such state"` asserted something that stopped being true when sessions gained a `cancelled` state.

## Checklist

- [x] I read CONTRIBUTING.md.
- [x] All commits are signed off for the DCO.
- [x] `make check_all` passes locally.
- [x] Added/updated tests.
- [x] Commits use descriptive messages.
