### PR TITLE
Harden the admission gate after the production cutover

### DIFF
--- a/app/models/session_admission_policy.rb
+++ b/app/models/session_admission_policy.rb
@@ -11,7 +11,33 @@ class SessionAdmissionPolicy < ApplicationRecord
   }.freeze
 
   def self.current = find_by(id: 1) || create_or_find_by!(id: 1)
-  def self.enabled? = current.enabled?
+
+  # Answers the gate every session launch asks, and survives the deploy window
+  # where the two cannot be in step.
+  #
+  # The image tag production runs is mutable, so new code starts serving when
+  # the image is PUSHED, not when the deploy job runs — and migrations run just
+  # before that job. A pod rescheduled in between (spot, autoscaling) executes
+  # new code against the old schema for as long as that gap lasts. On
+  # 2026-09-05 that cost five sessions: this gate sits on the container-create
+  # path, so a table it could not read failed the launch outright.
+  #
+  # A missing table is not an ambiguous answer. The queue cannot be on if its
+  # policy does not exist yet, so say so and let the legacy path serve. Anything
+  # else from the database still raises — this narrows to one question, it does
+  # not swallow database errors.
+  def self.enabled?
+    current.enabled?
+  rescue ActiveRecord::StatementInvalid => e
+    raise unless undefined_table?(e)
+
+    Rails.logger.warn("[SessionAdmission] policy table is not present yet; treating admission as disabled")
+    false
+  end
+
+  def self.undefined_table?(error)
+    error.cause.class.name == "PG::UndefinedTable"
+  end
 
   # The size of a scope queue is plain deployment configuration, read live, so a
   # ConfigMap edit takes effect on the next pod with nothing to remember to run.

--- a/app/services/container_runtime/kubernetes_runtime.rb
+++ b/app/services/container_runtime/kubernetes_runtime.rb
@@ -64,7 +64,11 @@ module ContainerRuntime
       raise "Admission must be enabled before removing legacy quotas" unless SessionAdmissionPolicy.enabled?
       raise ArgumentError, "Quota UID required" if uid.blank?
       ns = core_client.get_namespace(namespace)
-      labels = ns.metadata.labels.to_h
+      # Kubeclient hands labels back as a RecursiveOpenStruct, so #to_h keys are
+      # symbols — and a label name like "aixle.com/scope" read with a string key
+      # is silently nil, which made every check below refuse. The dry run caught
+      # it before it mattered; the lookup is normalised here so it cannot recur.
+      labels = ns.metadata.labels.to_h.transform_keys(&:to_s)
       unless labels["aixle.com/runtime-origin"] == runtime_namespace &&
           %w[project user].include?(labels["aixle.com/scope"]) &&
           namespace.match?(/\A#{Regexp.escape(runtime_namespace)}-(project|user)-\d+\z/)

--- a/app/services/session_admission_service.rb
+++ b/app/services/session_admission_service.rb
@@ -34,6 +34,11 @@ class SessionAdmissionService
     # Returns the admission, or nil when admission is disabled and the caller
     # should take the legacy launch path.
     def enqueue!(session)
+      # Asked before the writer lock so that a schema that is not there yet
+      # answers "no queue" instead of failing the launch. The authoritative
+      # re-check still happens under the lock below.
+      return nil unless SessionAdmissionPolicy.enabled?
+
       transaction do |policy|
         next session.session_admission if session.session_admission
         next nil unless policy.enabled?

--- a/app/temporal/activities/session/cleanup_stale_activity.rb
+++ b/app/temporal/activities/session/cleanup_stale_activity.rb
@@ -15,16 +15,24 @@
 module Activities
   module Session
     class CleanupStaleActivity < Base
+      # A session that never started is the one shape nothing used to reap: the
+      # sweeper only ever asked about running, ready and finishing, so a launch
+      # lost between the database commit and Temporal sat in `not_started`
+      # forever. Forty-seven of them had accumulated in production by
+      # 2026-09-05, the oldest since March, none with an error to explain it.
+      NOT_STARTED_STALE_THRESHOLD = 30.minutes
       RUNNING_STALE_THRESHOLD = 30.minutes
       READY_STALE_THRESHOLD = 25.hours
       FINISHING_STALE_THRESHOLD = 10.minutes
 
       def run(_input = nil)
+        cleaned_not_started = cleanup_stale(:not_started, NOT_STARTED_STALE_THRESHOLD)
         cleaned_running = cleanup_stale(:running, RUNNING_STALE_THRESHOLD)
         cleaned_ready = cleanup_stale(:ready, READY_STALE_THRESHOLD)
         cleaned_finishing = cleanup_stale(:finishing, FINISHING_STALE_THRESHOLD)
 
         {
+          cleaned_not_started: cleaned_not_started,
           cleaned_running: cleaned_running,
           cleaned_ready: cleaned_ready,
           cleaned_finishing: cleaned_finishing
@@ -73,6 +81,8 @@ module Activities
         scope = TerminalSession.where(state: state.to_s)
 
         case state
+        when :not_started
+          scope.where(created_at: ...threshold.ago)
         when :running
           scope.where(started_at: ...threshold.ago).or(
             TerminalSession

--- a/test/services/container_runtime/kubernetes_runtime_test.rb
+++ b/test/services/container_runtime/kubernetes_runtime_test.rb
@@ -13,6 +13,63 @@ module ContainerRuntime
       @runtime = KubernetesRuntime.new
     end
 
+    # Kubeclient really does hand labels back symbol-keyed. Building a genuine
+    # Kubeclient::Resource here is the point: a Hash stand-in would read fine
+    # with string keys and hide exactly the bug these guard clauses had.
+    def managed_namespace(scope: "project", origin: "aixle-prod")
+      Kubeclient::Resource.new(
+        metadata: {
+          name: "aixle-prod-project-27",
+          labels: { "aixle.com/runtime-origin" => origin, "aixle.com/scope" => scope }
+        }
+      )
+    end
+
+    def quota_resource(uid:)
+      Kubeclient::Resource.new(metadata: { name: "aixle-resource-quota", namespace: "aixle-prod-project-27", uid: uid })
+    end
+
+    test "remove_managed_session_quota accepts a namespace Kubeclient labelled" do
+      SessionAdmissionPolicy.stubs(:enabled?).returns(true)
+      core = mock("core_client")
+      core.expects(:get_namespace).with("aixle-prod-project-27").returns(managed_namespace)
+      core.expects(:get_resource_quota).returns(quota_resource(uid: "uid-1"))
+      core.expects(:delete_entity).never
+      @runtime.stubs(:core_client).returns(core)
+      @runtime.stubs(:runtime_namespace).returns("aixle-prod")
+
+      quota = @runtime.remove_managed_session_quota(namespace: "aixle-prod-project-27", uid: "uid-1", dry_run: true)
+
+      assert_equal "uid-1", quota.metadata.uid
+    end
+
+    test "remove_managed_session_quota refuses a namespace outside the managed scope" do
+      SessionAdmissionPolicy.stubs(:enabled?).returns(true)
+      core = mock("core_client")
+      core.expects(:get_namespace).returns(managed_namespace(scope: "something-else"))
+      core.expects(:delete_entity).never
+      @runtime.stubs(:core_client).returns(core)
+      @runtime.stubs(:runtime_namespace).returns("aixle-prod")
+
+      assert_raises(RuntimeError) do
+        @runtime.remove_managed_session_quota(namespace: "aixle-prod-project-27", uid: "uid-1")
+      end
+    end
+
+    test "remove_managed_session_quota refuses when the quota has been replaced since the audit" do
+      SessionAdmissionPolicy.stubs(:enabled?).returns(true)
+      core = mock("core_client")
+      core.expects(:get_namespace).returns(managed_namespace)
+      core.expects(:get_resource_quota).returns(quota_resource(uid: "uid-new"))
+      core.expects(:delete_entity).never
+      @runtime.stubs(:core_client).returns(core)
+      @runtime.stubs(:runtime_namespace).returns("aixle-prod")
+
+      assert_raises(RuntimeError) do
+        @runtime.remove_managed_session_quota(namespace: "aixle-prod-project-27", uid: "uid-reviewed")
+      end
+    end
+
     test "pull_image raises when image blank" do
       assert_raises(ArgumentError) { @runtime.pull_image("") }
       assert_raises(ArgumentError) { @runtime.pull_image(nil) }

--- a/test/services/session_admission_recovery_test.rb
+++ b/test/services/session_admission_recovery_test.rb
@@ -89,6 +89,28 @@ class SessionAdmissionRecoveryTest < ActiveSupport::TestCase
     assert_nil admission.reload.released_at, "cleanup, not the reaper, is what frees capacity"
   end
 
+  test "a session that never started is reaped instead of orphaned forever" do
+    lost = create(:terminal_session, user: @user, state: "not_started", started_at: nil,
+                  created_at: 2.hours.ago, temporal_workflow_id: nil)
+    fresh = create(:terminal_session, user: @user, state: "not_started", started_at: nil)
+
+    Activities::Session::CleanupStaleActivity.new.run
+
+    assert_equal "failed", lost.reload.state,
+      "a launch lost between the commit and Temporal used to sit here forever"
+    assert_equal "not_started", fresh.reload.state, "a launch still in flight is not stale"
+  end
+
+  test "a queued session is never mistaken for one that failed to start" do
+    session = create(:terminal_session, user: @user)
+    SessionAdmissionService.enqueue!(session)
+    session.update_column(:created_at, 2.hours.ago)
+
+    Activities::Session::CleanupStaleActivity.new.run
+
+    assert_equal "queued", session.reload.state, "waiting for a slot is not staleness"
+  end
+
   test "a run whose step is still queued is not stale" do
     run = create(:workflow_run, :running, started_at: 6.hours.ago)
     step_run = create(:step_run, :running, workflow_run: run)


### PR DESCRIPTION
## Summary

Three things the production cutover surfaced. All were found by running the change against a real cluster, not by reading it.

## 1. New code can serve before its schema arrives

Production runs `aixle-app-web:main` with `imagePullPolicy: Always`. The tag is mutable, so **new code starts serving when the image is pushed, not when the deploy job runs** — and `DB Migrate` runs just before `Deploy`. On 2026-09-05 that gap was 24 minutes:

```
Build Web      18:49:22   <- image pushed
Backend Checks 19:04 -> 19:13:50
DB Migrate     19:13:52
Deploy         19:14:15
errors         19:10:02 -> 19:13:35   <- inside the gap
```

A worker pod rescheduled in that window (spot, autoscaling — they move constantly) ran new code against the old schema. Five sessions died with `PG::UndefinedTable: relation "session_admission_policies" does not exist`, because the admission gate sits on the container-create path.

A missing policy table is not an ambiguous answer — the queue cannot be on if its policy does not exist — so the gate now says no and the legacy path serves. Narrowed to that one question; every other database error still raises.

This also protects the follow-up that drops `namespace_resource_quotas`, where the same window runs in reverse.

## 2. The legacy-quota removal could never have run

`remove_managed_session_quota` refused all 62 objects with "Namespace is not a managed session scope" no matter how correctly they were labelled:

```
KEYS [Symbol] -> [:"aixle.com/runtime-origin", ...]
STRING_LOOKUP nil
SYMBOL_LOOKUP "aixle-prod"
```

Kubeclient returns labels as a `RecursiveOpenStruct`, so `#to_h` gives symbol keys and every guard clause read them with string keys. The dry run is what caught it, which is what the dry run is for.

There was **no test at all** for that method. There are three now, built on a real `Kubeclient::Resource` — a plain Hash stand-in reads fine with string keys and hides exactly this. Verified that they fail without the fix, with the same message production gave.

## 3. Sessions that never started were never reaped

The stale sweeper asked about `running`, `ready` and `finishing` — never `not_started`. A launch lost between the database commit and Temporal therefore sat untouched forever. Production had **47** of them, the oldest since March, 45 from a single day, none carrying an error to explain itself:

```
WF_ID_NIL 47   STARTED_AT_NIL 47   WITH_ERROR 0
```

That is the failure the queue's durable launch intent exists to prevent, but the legacy path still needs a floor. The scope needed its own branch too — these sessions have no `started_at`, so the shared branch would have matched nothing. Queued sessions stay exempt: waiting for a slot is not staleness.

## Type of change

- [x] Bug fix
- [ ] Breaking change

## How was this tested?

`docker compose exec -T web make check_all` — green in full.

Six tests added. The quota-guard ones were checked against the un-fixed code and reproduce the production error exactly.

## Checklist

- [x] I read CONTRIBUTING.md.
- [x] All commits are signed off for the DCO.
- [x] `make check_all` passes locally.
- [x] Added/updated tests.
- [x] Commits use descriptive messages.
