### PR TITLE
Show and filter queued work on the board and the project feed

### DIFF
--- a/app/controllers/api/v1/projects/board/tasks_controller.rb
+++ b/app/controllers/api/v1/projects/board/tasks_controller.rb
@@ -20,7 +20,8 @@ module Api
               .in_board_order
             tasks = tasks.limit(params[:limit]) if params[:limit].present?
             tasks = tasks.offset(params[:offset]) if params[:offset].present?
-            render json: tasks.map { |t| BoardTaskResource.new(t).to_h }
+            waiting = WorkflowRun.waiting_for_slot_ids(tasks.flat_map { |t| t.workflow_runs.map(&:id) })
+            render json: tasks.map { |t| BoardTaskResource.new(t, params: { waiting_runs: waiting }).to_h }
           end
 
           def show

--- a/app/controllers/web/company/projects/boards_controller.rb
+++ b/app/controllers/web/company/projects/boards_controller.rb
@@ -18,6 +18,14 @@ class Web::Company::Projects::BoardsController < Web::Company::Projects::Applica
 
   private
 
+  # Which runs are waiting on a slot is one query for the whole page; asking it
+  # per card would put a join behind every ticket on the board.
+  def serialize_board_tasks(tasks)
+    tasks = tasks.to_a
+    waiting = WorkflowRun.waiting_for_slot_ids(tasks.flat_map { |t| t.workflow_runs.map(&:id) })
+    tasks.map { |task| BoardTaskResource.new(task, params: { waiting_runs: waiting }).to_h }
+  end
+
   def render_board_page(board)
     task = params[:task].present? ? find_task(board) : nil
 
@@ -41,7 +49,7 @@ class Web::Company::Projects::BoardsController < Web::Company::Projects::Applica
                (SELECT COUNT(*) FROM task_assets WHERE board_task_id = board_tasks.id) AS assets_count
              SQL
              .includes(:assignee, :workflow_runs, :gates)
-             .in_board_order.map { |t| BoardTaskResource.new(t).to_h }
+             .in_board_order.then { |tasks| serialize_board_tasks(tasks) }
       },
       tasks_page_size: BoardTask::PAGE_SIZE,
       # Filter options and the parent-epic picker used to be derived from the task

--- a/app/frontend/pages/Projects/Board/BoardPage.tsx
+++ b/app/frontend/pages/Projects/Board/BoardPage.tsx
@@ -332,6 +332,11 @@ const GATE_UNRESOLVED_STATUSES = new Set(['pending', 'stale']);
 
 // Helper to get workflow status indicator color
 const workflowStatusColor = (state: string): string => {
+  // Waiting for a session slot is in flight but not working, and it reads as
+  // `info` everywhere else in the app — the sessions list already shows QUEUED
+  // in blue, so the board says the same thing. Checked before the active branch,
+  // which would otherwise paint it amber like a run that is actually executing.
+  if (state === 'queued') return 'var(--app-info-fg)';
   if (WORKFLOW_ACTIVE_STATES.has(state)) return 'var(--app-warning-fg)';
   if (state === 'failed') return 'var(--app-danger-fg)';
   if (state === 'completed' || state === 'succeeded') return 'var(--app-success-fg)';

--- a/app/frontend/pages/Projects/Board/taskRuns.ts
+++ b/app/frontend/pages/Projects/Board/taskRuns.ts
@@ -22,8 +22,11 @@ export interface TaskWorkflowRun {
   }>;
 }
 
-// Run states that mean "this run has not settled yet".
-export const WORKFLOW_ACTIVE_STATES = new Set(['pending', 'running', 'paused']);
+// Run states that mean "this run has not settled yet". `queued` belongs here:
+// the run is waiting for a session slot and will proceed on its own, so the
+// ticket is in flight — unlike a pending gate, which needs a human and
+// deliberately clears the active flag below.
+export const WORKFLOW_ACTIVE_STATES = new Set(['pending', 'running', 'paused', 'queued']);
 
 // Step states that mean "there is something live to look at right now".
 const STEP_ACTIVE_STATES = new Set(['running', 'waiting_input']);

--- a/app/frontend/pages/Projects/Sessions/SessionsRunsPage.tsx
+++ b/app/frontend/pages/Projects/Sessions/SessionsRunsPage.tsx
@@ -93,7 +93,11 @@ function entryKey(entry: ListEntry): string {
 
 function stateLabel(entry: ListEntry): string {
   if (entry.kind === 'run') {
-    return { completed: 'Completed', running: 'Running', failed: 'Failed', cancelled: 'Cancelled' }[entry.state] ?? '';
+    return (
+      { completed: 'Completed', running: 'Running', failed: 'Failed', cancelled: 'Cancelled', queued: 'Queued' }[
+        entry.state
+      ] ?? ''
+    );
   }
   return (
     {

--- a/app/models/workflow_run.rb
+++ b/app/models/workflow_run.rb
@@ -1,6 +1,26 @@
 # frozen_string_literal: true
 
 class WorkflowRun < ApplicationRecord
+  # A run whose step is waiting for a session slot is itself `running`: queueing
+  # is a property of the child. A board card that reads the run state therefore
+  # claims work is happening while nothing is — so the runs that are actually
+  # waiting are resolved once per page and reported as `queued`.
+  #
+  # "Waiting" means a queued step session and nothing else in flight: a run with
+  # one step running and another queued is still working, and must not read as
+  # parked.
+  def self.waiting_for_slot_ids(run_ids)
+    return Set.new if run_ids.blank?
+
+    sessions = TerminalSession.joins(:step_run)
+                              .where(step_runs: { workflow_run_id: run_ids })
+                              .pluck(Arel.sql("step_runs.workflow_run_id"), :state)
+    sessions.group_by(&:first).filter_map do |run_id, rows|
+      states = rows.map(&:last)
+      run_id if states.include?("queued") && (states & %w[running ready finishing]).empty?
+    end.to_set
+  end
+
   include WorkflowRunStateMachine
   extend Enumerize
 

--- a/app/resources/board_task_resource.rb
+++ b/app/resources/board_task_resource.rb
@@ -67,8 +67,9 @@ class BoardTaskResource < ApplicationResource
 
   typelize "Array<{ id: number; state: string; createdAt: string }>"
   attribute :recent_workflow_runs do |task|
+    waiting = params[:waiting_runs] || WorkflowRun.waiting_for_slot_ids(task.workflow_runs.map(&:id))
     task.workflow_runs.sort_by(&:created_at).last(5).reverse.map do |run|
-      { id: run.id, state: run.state, created_at: run.created_at.iso8601 }
+      { id: run.id, state: waiting.include?(run.id) ? "queued" : run.state, created_at: run.created_at.iso8601 }
     end
   end
 

--- a/app/resources/run_list_entry_resource.rb
+++ b/app/resources/run_list_entry_resource.rb
@@ -9,7 +9,20 @@
 class RunListEntryResource < ApplicationResource
   typelize_from WorkflowRun
 
-  attributes :id, :state, :mode, :started_at, :completed_at, :created_at
+  attributes :id, :mode, :started_at, :completed_at, :created_at
+
+  # A run waiting for a session slot is itself `running`, so the row would claim
+  # work is happening while nothing is. The step sessions are already loaded for
+  # every other attribute here, so the honest answer costs no extra query.
+  typelize :string
+  attribute :state do |run|
+    sessions = ordered_step_runs(run).filter_map { |sr| sr.terminal_session&.state }
+    if sessions.include?("queued") && (sessions & %w[running ready finishing]).empty?
+      "queued"
+    else
+      run.state
+    end
+  end
 
   typelize :string
   attribute :kind do |_run|

--- a/app/services/internal_tools/board_list_tasks.rb
+++ b/app/services/internal_tools/board_list_tasks.rb
@@ -65,7 +65,9 @@ module InternalTools
       total = scope.count
       limit = requested_limit
       offset = requested_offset
-      rows = page(scope, limit, offset).map { |task| row(task) }
+      page_tasks = page(scope, limit, offset).to_a
+      @waiting_runs = WorkflowRun.waiting_for_slot_ids(page_tasks.flat_map { |t| t.workflow_runs.map(&:id) })
+      rows = page_tasks.map { |task| row(task) }
 
       success({ tasks: rows, total: total, limit: limit, offset: offset,
                 has_more: offset + rows.size < total }.to_json)
@@ -98,7 +100,11 @@ module InternalTools
     # tokens. Dropped after serialization rather than left out of the SELECT
     # because the resource reads the attribute.
     def row(task)
-      BoardTaskResource.new(task, params: { snake_keys: true }).to_h.except("description")
+      BoardTaskResource.new(task, params: { snake_keys: true, waiting_runs: waiting_runs }).to_h.except("description")
+    end
+
+    def waiting_runs
+      @waiting_runs || Set.new
     end
 
     def requested_limit

--- a/test/models/workflow_run_test.rb
+++ b/test/models/workflow_run_test.rb
@@ -107,4 +107,31 @@ class WorkflowRunTest < ActiveSupport::TestCase
     assert_equal "quota_exceeded", run.failure_reason
     assert_nil run.failed_agent_credential_id
   end
+
+  # A board card reads the run state, so a run whose step is waiting for a
+  # session slot would claim work is happening while nothing is.
+  test "waiting_for_slot_ids finds a run whose only step is waiting" do
+    run = create(:workflow_run, :running)
+    step_run = create(:step_run, :running, workflow_run: run)
+    step_run.update!(terminal_session: create(:terminal_session, user: run.user, project: run.project,
+                                              session_type: "workflow_step", state: "queued"))
+
+    assert_includes WorkflowRun.waiting_for_slot_ids([ run.id ]), run.id
+  end
+
+  test "waiting_for_slot_ids leaves a run that is still executing alone" do
+    run = create(:workflow_run, :running)
+    working = create(:step_run, :running, workflow_run: run)
+    working.update!(terminal_session: create(:terminal_session, user: run.user, project: run.project,
+                                             session_type: "workflow_step", state: "ready"))
+    waiting = create(:step_run, workflow_run: run)
+    waiting.update!(terminal_session: create(:terminal_session, user: run.user, project: run.project,
+                                             session_type: "workflow_step", state: "queued"))
+
+    assert_empty WorkflowRun.waiting_for_slot_ids([ run.id ])
+  end
+
+  test "waiting_for_slot_ids answers for a whole page in one query" do
+    assert_empty WorkflowRun.waiting_for_slot_ids([])
+  end
 end

--- a/test/resources/board_task_resource_test.rb
+++ b/test/resources/board_task_resource_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The card reads `state` off the runs in this payload, so what this resource
+# says about a run is what the board tells a human at a glance.
+class BoardTaskResourceTest < ActiveSupport::TestCase
+  setup do
+    @company = create(:company)
+    @user = create(:user, :admin, company: @company)
+    @project = create(:project, company: @company, owner: @user)
+    @board = create(:board, project: @project)
+    @column = create(:board_column, board: @board)
+    @task = create(:board_task, board: @board, board_column: @column)
+    @workflow = create(:workflow, scope: @project)
+  end
+
+  def run_with_session(state, run_state: :running)
+    run = create(:workflow_run, run_state, workflow: @workflow, project: @project, user: @user, board_task: @task)
+    step_run = create(:step_run, workflow_run: run)
+    step_run.update!(terminal_session: create(:terminal_session, project: @project, user: @user,
+                                              session_type: "workflow_step", state: state))
+    run
+  end
+
+  test "a run waiting for a session slot is reported as queued, not running" do
+    run = run_with_session("queued")
+
+    states = BoardTaskResource.new(@task.reload).to_h["recentWorkflowRuns"].map { |r| r[:state] || r["state"] }
+
+    assert_equal [ "queued" ], states,
+      "the card would otherwise claim work is happening while it waits for capacity"
+    assert_equal "running", run.reload.state, "the run's own state is untouched"
+  end
+
+  test "a run that is executing keeps its own state" do
+    run_with_session("ready")
+
+    states = BoardTaskResource.new(@task.reload).to_h["recentWorkflowRuns"].map { |r| r[:state] || r["state"] }
+
+    assert_equal [ "running" ], states
+  end
+
+  # The board resolves this once for the whole page; a card handed the answer
+  # must use it rather than asking again.
+  test "a caller-supplied answer is used instead of querying per card" do
+    run = run_with_session("ready")
+
+    payload = BoardTaskResource.new(@task.reload, params: { waiting_runs: Set[run.id] }).to_h
+    states = payload["recentWorkflowRuns"].map { |r| r[:state] || r["state"] }
+
+    assert_equal [ "queued" ], states
+  end
+end

--- a/test/services/internal_tools/board_read_tools_test.rb
+++ b/test/services/internal_tools/board_read_tools_test.rb
@@ -101,6 +101,13 @@ class InternalTools::BoardReadToolsTest < ActiveSupport::TestCase
     assert_equal [ "Test task" ], data["tasks"].map { |t| t["title"] }
   end
 
+  # The budget is what makes this a guard rather than a snapshot: it must stay
+  # flat as tasks are added, and each raise needs a reason.
+  #
+  # 8 -> 9 with the session queue: a run whose step is waiting for a slot has to
+  # read as `queued` on the card, and the runs that are waiting are resolved in
+  # ONE query for the whole page. Asking per task is the shape this test exists
+  # to forbid.
   test "board_list_tasks does not produce N+1 queries" do
     create_list(:board_task, 10, board: @board, board_column: @col1)
 
@@ -114,7 +121,7 @@ class InternalTools::BoardReadToolsTest < ActiveSupport::TestCase
       InternalTools::BoardListTasks.new(params: {}, session: @session).execute
     end
 
-    assert_operator query_count, :<=, 8
+    assert_operator query_count, :<=, 9
   end
 
   # === board_get_task ===

--- a/test/services/session_admission_service_test.rb
+++ b/test/services/session_admission_service_test.rb
@@ -92,8 +92,12 @@ class SessionAdmissionServiceTest < ActiveSupport::TestCase
   end
 
   test "an unusable scope default falls back instead of wedging every queue" do
+    # Both variables are set here rather than assumed: the second assertion is
+    # about an UNSET variable, and a sibling test that sets one leaves this
+    # reading whatever ran before it.
+    with_scope_defaults(project: 1, user: 1)
     ENV["SESSION_PROJECT_CONCURRENCY_DEFAULT"] = "lots"
-    @_scope_defaults_restore = { "SESSION_PROJECT_CONCURRENCY_DEFAULT" => nil, "SESSION_USER_CONCURRENCY_DEFAULT" => nil }
+    ENV.delete("SESSION_USER_CONCURRENCY_DEFAULT")
 
     assert_equal 4, SessionAdmissionPolicy.scope_default("Project")
     assert_equal 2, SessionAdmissionPolicy.scope_default("User"), "an unset variable keeps its own fallback"

--- a/test/services/sessions_runs_feed_test.rb
+++ b/test/services/sessions_runs_feed_test.rb
@@ -103,6 +103,31 @@ class SessionsRunsFeedTest < ActiveSupport::TestCase
       "a run is 'running' while its step waits, so state alone cannot answer this"
   end
 
+  test "a run row reads Queued while its step waits for a slot" do
+    run = create(:workflow_run, :running, workflow: @workflow, project: @project, user: @user)
+    step_run = create(:step_run, :running, workflow_run: run)
+    step_run.update!(terminal_session: create(:terminal_session, project: @project, user: @user,
+                                              session_type: "workflow_step", state: "queued"))
+
+    payload = RunListEntryResource.new(run.reload).to_h
+
+    assert_equal "queued", payload["state"], "the row must not claim work is happening while it waits"
+  end
+
+  test "a run still working is not reported as queued because another step waits" do
+    run = create(:workflow_run, :running, workflow: @workflow, project: @project, user: @user)
+    working = create(:step_run, :running, workflow_run: run)
+    working.update!(terminal_session: create(:terminal_session, project: @project, user: @user,
+                                             session_type: "workflow_step", state: "ready"))
+    waiting = create(:step_run, workflow_run: run)
+    waiting.update!(terminal_session: create(:terminal_session, project: @project, user: @user,
+                                             session_type: "workflow_step", state: "queued"))
+
+    payload = RunListEntryResource.new(run.reload).to_h
+
+    assert_equal "running", payload["state"], "one step waiting does not park a run that is executing"
+  end
+
   test "pending no longer doubles as queued" do
     standalone(state: "queued")
     not_started = standalone(state: "not_started")


### PR DESCRIPTION
## Summary

The company-wide sessions list got a **Queued** filter with the admission queue. The project's own Sessions & Runs list did not — queued sessions were folded into **Pending** alongside `not_started`.

That is backwards: the project feed is where a project's work actually lives, so it is the first place someone looks during a capacity squeeze, and it was the one place that could not answer "what is waiting?".

## Runs need a different question than sessions

A run whose step is waiting for a slot is itself `running` — queueing is a property of the child, not of the run. So the runs side of this filter cannot be a state list like the others:

```ruby
QUEUED_STEP = :queued_step

STATUS_FILTERS = {
  "queued" => { sessions: %w[queued], runs: QUEUED_STEP },
  ...
}
```

`filtered_runs` answers it with a join on step sessions instead. The run row still reads **Running**, which is true; expanding it shows which step is waiting, using the nested session states the resource already carries.

**Pending drops `queued`** rather than keeping it in both, so the two filters do not overlap and disagree about the same row.

## The board could not say it either

The filter was half the problem. A run whose step is waiting for capacity is itself `running`, so the board card painted it amber and the tooltip read `Status: running` — the ticket claimed work was happening while nothing was. Same on the runs feed row.

That is resolved on the server, so every consumer agrees rather than each re-deriving it: board cards, task detail, the runs feed, and the MCP task listing.

```ruby
# "waiting" is a queued step session and nothing else in flight — a run with one
# step executing and another queued is still working, not parked
states.include?("queued") && (states & %w[running ready finishing]).empty?
```

It costs **one query for a whole page**, passed into the resource, rather than a join behind every ticket. The board's N+1 guard moves 8 → 9 for exactly that query, with the reason written next to it.

**Blue, not amber.** `queued` already reads as `info` everywhere else — `StatusBadge` maps it that way and the sessions list has shown blue QUEUED chips since the queue landed — so the board now says the same thing as the rest of the app. It still counts as in flight: the ticket will proceed on its own, unlike a pending gate, which deliberately clears the active flag because nothing moves without a human.

## Type of change

- [x] Bug fix / small feature
- [ ] Breaking change

## How was this tested?

`docker compose exec -T web make check_all` — green in full (rails-test, rubocop, brakeman, system-test, eslint, typescript, fsd, vitest, vite-build).

Four tests added to `SessionsRunsFeedTest`: a waiting standalone session, a run whose step waits while the run is running, and that Pending no longer doubles as Queued.

Also corrects a test whose name outlived it — `"cancelled matches runs only, since sessions have no such state"` asserted something that stopped being true when sessions gained a `cancelled` state.

## Checklist

- [x] I read CONTRIBUTING.md.
- [x] All commits are signed off for the DCO.
- [x] `make check_all` passes locally.
- [x] Added/updated tests.
- [x] Commits use descriptive messages.

