### PR TITLE
Open a finished session's terminal log without a click

### DIFF
--- a/app/frontend/shared/components/SessionShowContent/SessionTerminalReplay.test.tsx
+++ b/app/frontend/shared/components/SessionShowContent/SessionTerminalReplay.test.tsx
@@ -5,7 +5,7 @@ import { renderPage, screen, userEvent, waitFor } from 'test/renderPage';
 
 import { SessionTerminalReplay } from './SessionTerminalReplay';
 
-const expand = () => userEvent.click(screen.getByRole('button', { name: /terminal session log/i }));
+const toggle = () => userEvent.click(screen.getByRole('button', { name: /terminal session log/i }));
 
 // xterm.js is a vendor module (jsdom has no canvas/WebGL), so per docs/testing.md R8
 // the third-party seam may be mocked. We assert the component feeds fetched bytes into
@@ -27,21 +27,30 @@ describe('SessionTerminalReplay', () => {
   beforeEach(() => {
     write.mockClear();
     open.mockClear();
+    dispose.mockClear();
     vi.mocked(Terminal).mockClear();
   });
 
-  it('is collapsed by default and only fetches the log once expanded', async () => {
+  it('is expanded by default and fetches the log without a click', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('hi', { status: 200 }));
 
     renderPage(<SessionTerminalReplay logUrl={LOG_URL} />);
 
-    expect(screen.getByRole('button', { name: /terminal session log/i })).toBeInTheDocument();
-    expect(fetchSpy).not.toHaveBeenCalled();
-    expect(write).not.toHaveBeenCalled();
-
-    await expand();
-
+    expect(screen.getByRole('button', { name: /terminal session log/i })).toHaveAttribute('aria-expanded', 'true');
     await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(LOG_URL, expect.anything()));
+    fetchSpy.mockRestore();
+  });
+
+  it('collapses on click and tears the terminal down', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('hi', { status: 200 }));
+
+    renderPage(<SessionTerminalReplay logUrl={LOG_URL} />);
+    await waitFor(() => expect(write).toHaveBeenCalled());
+
+    await toggle();
+
+    expect(screen.getByRole('button', { name: /terminal session log/i })).toHaveAttribute('aria-expanded', 'false');
+    await waitFor(() => expect(dispose).toHaveBeenCalled());
     fetchSpy.mockRestore();
   });
 
@@ -51,7 +60,6 @@ describe('SessionTerminalReplay', () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
 
     renderPage(<SessionTerminalReplay logUrl={LOG_URL} />);
-    await expand();
 
     await waitFor(() => expect(Terminal).toHaveBeenCalled());
     const opts = vi.mocked(Terminal).mock.calls.at(-1)?.[0];
@@ -64,7 +72,6 @@ describe('SessionTerminalReplay', () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
 
     renderPage(<SessionTerminalReplay logUrl={LOG_URL} />);
-    await expand();
 
     await waitFor(() => expect(write).toHaveBeenCalledWith(body));
     expect(fetchSpy).toHaveBeenCalledWith(LOG_URL, expect.anything());
@@ -75,7 +82,6 @@ describe('SessionTerminalReplay', () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 404 }));
 
     renderPage(<SessionTerminalReplay logUrl={LOG_URL} />);
-    await expand();
 
     expect(await screen.findByText(/no terminal output was captured/i)).toBeInTheDocument();
     expect(write).not.toHaveBeenCalled();
@@ -90,7 +96,6 @@ describe('SessionTerminalReplay', () => {
       .mockResolvedValue(new Response(body, { status: 200, headers: { 'X-Log-Truncated': 'true' } }));
 
     renderPage(<SessionTerminalReplay logUrl={LOG_URL} />);
-    await expand();
 
     expect(await screen.findByText(/log truncated/i)).toBeInTheDocument();
     await waitFor(() => expect(write).toHaveBeenCalled());

--- a/app/frontend/shared/components/SessionShowContent/SessionTerminalReplay.tsx
+++ b/app/frontend/shared/components/SessionShowContent/SessionTerminalReplay.tsx
@@ -11,7 +11,8 @@ import classes from './SessionTerminalReplay.module.css';
  * raw ANSI bytes from `logUrl` (server already caps to the tail) and renders
  * them into xterm.js, preserving the original colors/markup. Static dump (no
  * time-based playback); input-disabled. xterm is lazy-imported so it stays out
- * of the main bundle.
+ * of the main bundle, and the section starts expanded — the log is what a
+ * finished session's page is for.
  */
 
 type Status = 'idle' | 'loading' | 'ready' | 'empty' | 'error';
@@ -66,14 +67,17 @@ function computeLayout(text: string, el: HTMLElement) {
 export function SessionTerminalReplay({ logUrl }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<import('@xterm/xterm').Terminal | null>(null);
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
   const [status, setStatus] = useState<Status>('idle');
   const [truncated, setTruncated] = useState(false);
   const colorScheme = useComputedColorScheme('dark', { getInitialValueInEffect: true });
 
-  // Collapsed by default: only fetch the log and mount xterm once the user
-  // expands the section. colorScheme is intentionally NOT a dependency — a theme
-  // toggle must not re-download or rebuild; the effect below recolors in place.
+  // Expanded by default: a finished session's log is the reason the page is
+  // being opened, so it loads without a click. Collapsing tears the terminal
+  // down (effect cleanup) and re-expanding refetches — cheap, and it keeps
+  // "is the log mounted" owned by this one effect.
+  // colorScheme is intentionally NOT a dependency — a theme toggle must not
+  // re-download or rebuild; the effect below recolors in place.
   useEffect(() => {
     if (!open) return undefined;
 


### PR DESCRIPTION
The terminal replay on a finished session was collapsed by default, so the one thing that page exists to show — what the agent actually did — took a click to appear, every time.

It now mounts expanded and fetches on load. Collapsing still tears the terminal down (effect cleanup), and re-expanding refetches, so "is the log mounted" stays owned by the one effect.

## Checks

`docker compose exec -T web make check_all` — green (rails-test, rubocop, brakeman, system-test, eslint, typescript, fsd, vitest, vite-build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)