### PR TITLE
Make the finish_session mandate the last thing a non-interactive agent reads

### DIFF
--- a/app/services/context_builders/critical_rules.rb
+++ b/app/services/context_builders/critical_rules.rb
@@ -44,17 +44,11 @@ module ContextBuilders
 
         ### Session Completion (MANDATORY)
 
-        You MUST call one of these tools when finished:
-        - **finish_session** — when the task is **fully completed** successfully. Optional `note` parameter.
-        - **fail_session** — when the task **cannot be completed**. Required `reason`, optional `note`.
-
-        Call `finish_session` ONLY when ALL deliverables are produced.
-        Call `fail_session` if ANY of these are true:
-        - A required resource is missing (repository, file, API, tool)
-        - You cannot produce the expected deliverables
-        - A critical error prevents completing the task
-
-        **You MUST call one of these tools to end the session — it will not end on its own.**
+        The session ends ONLY when you call `finish_session` (objective fully met) or
+        `fail_session` (objective cannot be met). It will NOT end on its own, and
+        ending your turn without one of those calls leaves it hanging until a sweeper
+        kills it. The full rule — including when partial work must be `fail_session` —
+        is in the `<session-completion>` section at the very end of this context.
       RULES
     end
 

--- a/app/services/context_builders/session_completion.rb
+++ b/app/services/context_builders/session_completion.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module ContextBuilders
+  # The one rule a non-interactive session cannot get away with skipping: it has
+  # to end itself. Nothing else does — the container keeps running, and the
+  # workflow step waiting on it keeps waiting, until the stale-session sweeper
+  # reaps it half an hour later and records the whole run as a failure.
+  #
+  # It lives in its own :footer section — below even the bottom-of-context tool
+  # listings — because agents were still skipping the call when the same mandate
+  # was a subsection buried inside <critical-rules> at the top of a long context.
+  # The short pointer up there stays (primacy); this is the recency half, and it
+  # spells out the cost of skipping rather than only the instruction.
+  class SessionCompletion < Base
+    def applicable?
+      session.mode == "non_interactive"
+    end
+
+    def build
+      [ section(
+        tag: "session-completion",
+        priority: :critical,
+        content: mandate,
+        position_hint: :footer
+      ) ]
+    end
+
+    private
+
+    def mandate
+      <<~RULES.strip
+        ## MANDATORY: how this session ends
+
+        This session does NOT end when you stop writing. It ends ONLY when you call
+        one of these two tools:
+
+        - **`finish_session`** — the objective is FULLY met and every deliverable
+          exists on disk. Optional `note`: a short summary of what you produced.
+        - **`fail_session`** — the objective cannot be met. Required `reason`,
+          optional `note`.
+
+        **Calling one of them is the last thing you do, every time. There is no third
+        option, and no "I'm done" sentence substitutes for the call.**
+
+        If you end your turn without calling either:
+        - the container keeps running and burning budget until a sweeper reaps it,
+        - a workflow step waiting on this session stalls for that entire time,
+        - your work is recorded as a stale failure instead of as the result it was.
+
+        Call `fail_session` — NOT `finish_session` — whenever ANY of these hold:
+        - a required resource is missing (repository, file, credential, API, tool),
+        - you produced only part of the deliverables,
+        - a critical error blocked the task.
+
+        Partial work is a `fail_session` whose `reason` says what is missing. Reporting
+        partial work as success is worse than reporting the failure.
+      RULES
+    end
+  end
+end

--- a/app/services/context_renderer.rb
+++ b/app/services/context_renderer.rb
@@ -5,7 +5,7 @@ class ContextRenderer
   CHARS_PER_TOKEN = 4
 
   PRIORITY_ORDER = { critical: 0, important: 1, info: 2 }.freeze
-  POSITION_ORDER = { top: 0, middle: 1, bottom: 2 }.freeze
+  POSITION_ORDER = { top: 0, middle: 1, bottom: 2, footer: 3 }.freeze
 
   COMPRESSIBLE_TAGS = %w[previous-steps board-context custom-tools available-resources repositories].freeze
 
@@ -14,11 +14,15 @@ class ContextRenderer
 
     sections = compress(sections) if over_budget?(sections)
 
-    sorted = sections.sort_by do |s|
-      [ POSITION_ORDER[s.position_hint], PRIORITY_ORDER[s.priority] ]
+    # sort_by is not stable, so equal (position, priority) pairs would otherwise
+    # render in an arbitrary order between runs — and the last critical section
+    # is exactly the one whose placement matters (see ContextBuilders::
+    # SessionCompletion). The index tiebreak keeps builder order.
+    sorted = sections.each_with_index.sort_by do |s, i|
+      [ POSITION_ORDER[s.position_hint], PRIORITY_ORDER[s.priority], i ]
     end
 
-    sorted.map { |s| render_section(s) }.join("\n\n")
+    sorted.map { |s, _i| render_section(s) }.join("\n\n")
   end
 
   def self.render_section(section)

--- a/app/services/context_section.rb
+++ b/app/services/context_section.rb
@@ -2,7 +2,9 @@
 
 class ContextSection
   PRIORITIES = %i[critical important info].freeze
-  POSITIONS  = %i[top middle bottom].freeze
+  # :footer is below even the bottom-of-context reference listings (shell tools,
+  # MCP servers) — reserved for the one rule that has to be the last thing read.
+  POSITIONS  = %i[top middle bottom footer].freeze
 
   attr_reader :tag, :priority, :content, :position_hint, :builder_name
 

--- a/app/services/session_context_constructor.rb
+++ b/app/services/session_context_constructor.rb
@@ -13,7 +13,10 @@ class SessionContextConstructor
     ContextBuilders::Resources,
     ContextBuilders::ConfigItems,
     ContextBuilders::BmadMethod,
-    ContextBuilders::OutputRules
+    ContextBuilders::OutputRules,
+    # Last on purpose: ties in the renderer's sort are broken by this order, so
+    # the completion mandate is the final thing the agent reads.
+    ContextBuilders::SessionCompletion
   ].freeze
 
   def self.build(session)

--- a/test/services/context_builders/critical_rules_test.rb
+++ b/test/services/context_builders/critical_rules_test.rb
@@ -50,6 +50,19 @@ class ContextBuilders::CriticalRulesTest < ActiveSupport::TestCase
     assert_not_includes sections.first.content, "NEVER ask questions"
   end
 
+  test "non_interactive rules point at the session-completion section instead of restating it" do
+    session = create(:terminal_session, :agent_session,
+      user: @user, project: @project, mode: "non_interactive", initial_prompt: "do work")
+
+    content = ContextBuilders::CriticalRules.new(session).build.first.content
+
+    assert_includes content, "`finish_session`"
+    assert_includes content, "`<session-completion>`"
+    # The detail (what counts as partial work, what it costs to skip the call)
+    # belongs to ContextBuilders::SessionCompletion, rendered last.
+    assert_not_includes content, "Partial work"
+  end
+
   test "non_interactive rules include key backward-compatible phrases" do
     session = create(:terminal_session, :agent_session,
       user: @user, project: @project, mode: "non_interactive", initial_prompt: "do work")

--- a/test/services/context_builders/session_completion_test.rb
+++ b/test/services/context_builders/session_completion_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ContextBuilders::SessionCompletionTest < ActiveSupport::TestCase
+  setup do
+    @company = create(:company)
+    @user = create(:user, :admin, company: @company, preferred_agent_language: nil)
+    @project = create(:project, company: @company, owner: @user)
+  end
+
+  test "non_interactive session gets a critical bottom section naming both tools" do
+    session = create(:terminal_session, :agent_session,
+      user: @user, project: @project, mode: "non_interactive", initial_prompt: "do work")
+
+    sections = ContextBuilders::SessionCompletion.new(session).build
+
+    assert_equal 1, sections.length
+    section = sections.first
+    assert_equal "session-completion", section.tag
+    assert_equal :critical, section.priority
+    assert_equal :footer, section.position_hint
+    assert_equal "session_completion", section.builder_name
+    assert_includes section.content, "`finish_session`"
+    assert_includes section.content, "`fail_session`"
+  end
+
+  test "the mandate spells out what skipping the call costs" do
+    session = create(:terminal_session, :agent_session,
+      user: @user, project: @project, mode: "non_interactive", initial_prompt: "do work")
+
+    content = ContextBuilders::SessionCompletion.new(session).build.first.content
+
+    assert_includes content, "does NOT end when you stop writing"
+    assert_includes content, "sweeper"
+    assert_includes content, "Partial work is a `fail_session`"
+  end
+
+  test "interactive session is not applicable" do
+    session = create(:terminal_session, :agent_session,
+      user: @user, project: @project, mode: "interactive")
+
+    assert_not ContextBuilders::SessionCompletion.new(session).applicable?
+  end
+
+  test "constructor renders the mandate as the last section of a non_interactive context" do
+    session = create(:terminal_session, :agent_session,
+      user: @user, project: @project, mode: "non_interactive", initial_prompt: "do work")
+
+    rendered = SessionContextConstructor.build(session)
+
+    assert_includes rendered, "<session-completion priority=\"critical\">"
+    assert_equal "</session-completion>", rendered.lines.map(&:strip).reject(&:empty?).last
+  end
+
+  test "interactive context carries no session-completion section" do
+    session = create(:terminal_session, :agent_session,
+      user: @user, project: @project, mode: "interactive")
+
+    result = SessionContextConstructor.build_result(session)
+
+    assert_not_includes result.sections.map(&:tag), "session-completion"
+    assert_includes result.skipped_builders, "session_completion"
+  end
+end

--- a/test/services/context_renderer_test.rb
+++ b/test/services/context_renderer_test.rb
@@ -29,6 +29,24 @@ class ContextRendererTest < ActiveSupport::TestCase
     assert_includes output, "</beta>"
   end
 
+  test "footer sections render below every bottom section, whatever its priority" do
+    bottom_info = ContextSection.new(tag: "bi", priority: :info, content: "a", position_hint: :bottom)
+    footer = ContextSection.new(tag: "ft", priority: :critical, content: "b", position_hint: :footer)
+
+    output = ContextRenderer.render([ footer, bottom_info ])
+
+    assert_operator output.index("<bi "), :<, output.index("<ft ")
+  end
+
+  test "sections tied on position and priority keep their input order" do
+    first = ContextSection.new(tag: "first", priority: :critical, content: "a", position_hint: :bottom)
+    last = ContextSection.new(tag: "last", priority: :critical, content: "b", position_hint: :bottom)
+
+    output = ContextRenderer.render([ first, last ])
+
+    assert_operator output.index("<first "), :<, output.index("<last ")
+  end
+
   test "sections are sorted by position_hint first, then priority" do
     bottom_critical = ContextSection.new(tag: "bc", priority: :critical, content: "c", position_hint: :bottom)
     top_info = ContextSection.new(tag: "ti", priority: :info, content: "c", position_hint: :top)


### PR DESCRIPTION
Non-interactive agents keep skipping the call that ends their session.

The mandate was already in the context — as a subsection buried inside `<critical-rules>` at the very top, ahead of thousands of tokens of workspace, board, tool and skill context. What actually rendered *last* were the reference listings: shell tools and MCP servers.

## What changed

- **New `ContextBuilders::SessionCompletion`** (non-interactive only) owns the mandate as its own `<session-completion>` section.
- **New `:footer` position** on `ContextSection`, sorting below even the bottom-of-context listings — so the mandate is the last thing in the prompt.
- **The wording states the cost**, not just the instruction: the container keeps burning budget until the sweeper reaps it, the workflow step waiting on the session stalls for that whole time, and the work lands as a stale failure instead of as the result it was. Partial work is spelled out as a `fail_session`.
- **The top block is now a short pointer** to that section (primacy kept, detail moved).
- **The renderer's sort is now stable.** `sort_by` is not, so two sections with the same `(position, priority)` rendered in an arbitrary order — exactly the property this change depends on. Ties now break by builder order.

`OutputRules` keeps its one-line reminder: three mentions of the same rule is deliberate here, not drift.

## Checks

`docker compose exec -T web make check_all` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
