### PR TITLE
Report a failed run back to the Slack thread that started it

### DIFF
--- a/app/controllers/api/v1/projects/workflows/triggers_controller.rb
+++ b/app/controllers/api/v1/projects/workflows/triggers_controller.rb
@@ -132,7 +132,7 @@ module Api
 
           def trigger_binding_params
             params.require(:trigger).permit(
-              :name, :trigger_mode, :enabled, :cooldown_seconds,
+              :name, :trigger_mode, :enabled, :cooldown_seconds, :notify_on_failure,
               :subject_policy, :subject_column_id, :subject_title_template,
               filter_predicate: {}, schedule_config: %i[cron timezone]
             )
@@ -181,6 +181,7 @@ module Api
               subject_title_template: binding.subject_title_template,
               schedule_config: binding.schedule_config,
               cooldown_seconds: binding.cooldown_seconds,
+              notify_on_failure: binding.notify_on_failure,
               enabled: binding.enabled
             }
           end

--- a/app/frontend/pages/Projects/Workflows/TriggerFormPanel.test.tsx
+++ b/app/frontend/pages/Projects/Workflows/TriggerFormPanel.test.tsx
@@ -211,8 +211,24 @@ describe('Projects/Workflows/TriggerFormPanel', () => {
     expect(bodyOf(fetchSpy, 'POST').trigger).toEqual({
       kind: 'slack',
       filter_predicate: { channel: 'C42', text: { op: 'contains', value: 'deploy' } },
+      notify_on_failure: true,
       subject_policy: 'none',
     });
+  });
+
+  it('reports slack failures back by default and stops when the switch is turned off', async () => {
+    const fetchSpy = installFetch();
+
+    renderPage(<TriggerFormPanel {...baseProps({ defaultKind: 'slack' })} />);
+
+    const notify = screen.getByRole('switch', { name: /report failures back to slack/i });
+    expect(notify).toBeChecked();
+
+    await userEvent.click(notify);
+    await userEvent.click(screen.getByRole('button', { name: 'Add trigger' }));
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    expect(bodyOf(fetchSpy, 'POST').trigger.notify_on_failure).toBe(false);
   });
 
   it('posts an empty slack filter when channel and pattern are left blank', async () => {

--- a/app/frontend/pages/Projects/Workflows/TriggerFormPanel.tsx
+++ b/app/frontend/pages/Projects/Workflows/TriggerFormPanel.tsx
@@ -93,6 +93,7 @@ export function TriggerFormPanel({
   const [enabled, setEnabled] = useState(editing?.enabled ?? true);
 
   const [channel, setChannel] = useState(editSlack?.channel ?? '');
+  const [notifyOnFailure, setNotifyOnFailure] = useState(editing?.notify_on_failure ?? true);
   const [textContains, setTextContains] = useState(editSlack?.value ?? '');
   const [textOp, setTextOp] = useState(editSlack?.op ?? 'contains');
 
@@ -137,6 +138,7 @@ export function TriggerFormPanel({
       if (kind === 'slack') {
         if (channel.trim()) filter.channel = channel.trim();
         if (textContains.trim()) filter.text = { op: textOp, value: textContains.trim() };
+        trigger.notify_on_failure = notifyOnFailure;
       } else if (kind === 'webhook') {
         if (!isEdit) {
           trigger.verification_strategy = verification;
@@ -196,6 +198,7 @@ export function TriggerFormPanel({
     cooldown,
     enabled,
     channel,
+    notifyOnFailure,
     textContains,
     textOp,
     verification,
@@ -621,6 +624,14 @@ export function TriggerFormPanel({
                     }}
                   />
                 </div>
+              </div>
+              <div style={{ marginBottom: 12 }}>
+                <Switch
+                  label="Report failures back to Slack"
+                  description="When a run from this trigger fails, reply in the same thread with the error."
+                  checked={notifyOnFailure}
+                  onChange={(e) => setNotifyOnFailure(e.currentTarget.checked)}
+                />
               </div>
               <div style={{ marginBottom: 12 }}>
                 <label

--- a/app/frontend/pages/Projects/Workflows/types.ts
+++ b/app/frontend/pages/Projects/Workflows/types.ts
@@ -5,6 +5,7 @@ export interface Trigger {
   name?: string | null;
   trigger_mode?: string;
   cooldown_seconds?: number;
+  notify_on_failure?: boolean;
   enabled?: boolean;
   column_name?: string;
   board_column_id?: number;

--- a/app/jobs/slack/notify_run_failure_job.rb
+++ b/app/jobs/slack/notify_run_failure_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Slack
+  # Off the state transition: posting to Slack is a network call, and a failed
+  # run must finish failing whether or not Slack answers.
+  class NotifyRunFailureJob < ApplicationJob
+    queue_as :default
+
+    def perform(workflow_run_id)
+      run = WorkflowRun.find_by(id: workflow_run_id)
+      Slack::RunFailureNotifier.call(run)
+    end
+  end
+end

--- a/app/models/trigger_binding.rb
+++ b/app/models/trigger_binding.rb
@@ -20,6 +20,11 @@ class TriggerBinding < ApplicationRecord
 
   SCHEDULE_EVENT_TYPE = "schedule.fired"
 
+  # notify_on_failure (default true) — when a run this binding started fails,
+  # say so in the Slack thread it came from, with what it failed with. Only
+  # Slack-born runs carry the reply coordinates, so it is a no-op on every other
+  # trigger kind; see Slack::RunFailureNotifier.
+
   validates :event_type, presence: true
   validates :cooldown_seconds, numericality: { greater_than_or_equal_to: 0 }
   validate :workflow_accessible_from_project

--- a/app/services/personal_tools/create_workflow_trigger.rb
+++ b/app/services/personal_tools/create_workflow_trigger.rb
@@ -35,6 +35,8 @@ module PersonalTools
                            description: "auto starts the run immediately; manual only offers it. Defaults to auto."
       param :enabled, type: :boolean, description: "Whether the trigger fires. Defaults to true; column triggers are always on."
       param :cooldown_seconds, type: :integer, description: "Minimum gap between two firings. Defaults to 5 for column triggers, 0 otherwise."
+      param :notify_on_failure, type: :boolean,
+            description: "Post to the triggering Slack thread when a run from this trigger fails, with the error (default true; Slack triggers only)."
       param :subject_policy, type: :string, enum: WorkflowTriggerSupport::SUBJECT_POLICIES,
                              description: "Which board task the run is about: none, existing_task, or create_task " \
                                           "(create_task also needs subject_column_id)."

--- a/app/services/personal_tools/update_workflow_trigger.rb
+++ b/app/services/personal_tools/update_workflow_trigger.rb
@@ -23,6 +23,8 @@ module PersonalTools
                            description: "auto starts the run immediately; manual only offers it."
       param :enabled, type: :boolean, description: "Whether the trigger fires."
       param :cooldown_seconds, type: :integer, description: "Minimum gap between two firings."
+      param :notify_on_failure, type: :boolean,
+            description: "Post to the triggering Slack thread when a run from this trigger fails, with the error (default true; Slack triggers only)."
       param :subject_policy, type: :string, enum: WorkflowTriggerSupport::SUBJECT_POLICIES,
                              description: "Which board task the run is about: none, existing_task, or create_task " \
                                           "(create_task also needs subject_column_id)."

--- a/app/services/personal_tools/workflow_trigger_support.rb
+++ b/app/services/personal_tools/workflow_trigger_support.rb
@@ -15,7 +15,7 @@ module PersonalTools
     VERIFICATION_STRATEGIES = %w[none slack_v0 hmac_sha256 shared_token].freeze
 
     # Mutable fields, mirroring the controller's permit lists.
-    BINDING_FIELDS = %i[name trigger_mode enabled cooldown_seconds
+    BINDING_FIELDS = %i[name trigger_mode enabled cooldown_seconds notify_on_failure
                         subject_policy subject_column_id subject_title_template].freeze
     COLUMN_FIELDS = %i[trigger_mode cooldown_seconds].freeze
     SCHEDULE_KEYS = %w[cron timezone].freeze
@@ -88,6 +88,7 @@ module PersonalTools
         subject_title_template: trigger.subject_title_template,
         schedule_config: trigger.schedule_config,
         cooldown_seconds: trigger.cooldown_seconds,
+        notify_on_failure: trigger.notify_on_failure,
         enabled: trigger.enabled
       }
     end

--- a/app/services/slack/run_failure_notifier.rb
+++ b/app/services/slack/run_failure_notifier.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module Slack
+  # Tells the Slack thread that started a workflow run that the run failed, and
+  # what it failed with.
+  #
+  # A run launched from Slack is fire-and-forget for the person who typed the
+  # mention: they get whatever the agent chose to post back, and nothing at all
+  # when the run dies before the agent could post anything — which is exactly
+  # when a failure most needs saying out loud. This closes that hole, opt-out per
+  # trigger (TriggerBinding#notify_on_failure).
+  #
+  # Best-effort by construction: every path returns false rather than raising, so
+  # a Slack outage can never turn a failed run into a failed state transition.
+  class RunFailureNotifier
+    class << self
+      def call(run)
+        return false if run.nil? || !run.failed?
+
+        slack = run.shared_context.to_h["slack"].to_h
+        channel = slack["channel"]
+        return false if channel.blank?
+        return false unless notify?(run)
+
+        integration = integration_for(run, slack)
+        return false if integration.nil?
+
+        Slack::Notifier.post(
+          integration: integration,
+          channel: channel,
+          thread_ts: slack["thread_ts"],
+          text: message_for(run)
+        )
+      rescue StandardError => e
+        Rails.logger.error("[Slack::RunFailureNotifier] run ##{run&.id}: #{e.message}")
+        false
+      end
+
+      private
+
+      # The binding that started this run, through the dispatch ledger. A run with
+      # Slack context but no binding (a re-run started by hand from a Slack-born
+      # run, which inherits shared_context) is left alone: nobody asked for a
+      # notification on it.
+      def notify?(run)
+        binding = TriggerDispatch.where(workflow_run_id: run.id).order(:id).last&.trigger_binding
+        binding.present? && binding.notify_on_failure?
+      end
+
+      # Reply through the SAME workspace that triggered the run — its install is
+      # named in shared_context — so a company with several connected workspaces
+      # answers in the right one. Mirrors InternalTools::SlackPostMessage
+      # #slack_integration, including its project-first fallback.
+      def integration_for(run, slack)
+        return nil if run.project.nil?
+
+        scope = Integration.active.where(provider: :slack, company_id: run.project.company_id)
+
+        if (id = slack["integration_id"]).present?
+          by_id = scope.find_by(id: id)
+          return by_id if by_id
+        end
+
+        scope.where("project_id = :pid OR project_id IS NULL", pid: run.project_id)
+             .order(Arel.sql("project_id IS NULL"))
+             .first
+      end
+
+      def message_for(run)
+        summary = failure_summary(run)
+        lines = [ ":x: *#{run.workflow&.name || 'Workflow'}* run ##{run.id} failed." ]
+        lines << "> #{summary}" if summary.present?
+        lines << run_url(run)
+        lines.compact.join("\n")
+      end
+
+      # What actually went wrong: the quota case names itself, otherwise the last
+      # failed step's message. Truncated — a container log dump in a Slack thread
+      # helps nobody, and the run page has the whole thing.
+      def failure_summary(run)
+        if run.failure_reason == "quota_exceeded"
+          return "#{run.failed_agent_credential&.agent_type || 'The connected account'} ran out of credits."
+        end
+
+        step = run.step_runs.where(state: "failed").order(:updated_at).last
+        [ step&.step&.name, step&.error_message.to_s.truncate(400).presence ].compact.join(": ").presence ||
+          run.failure_reason.to_s.humanize.presence
+      end
+
+      def run_url(run)
+        return nil if run.project_id.blank?
+
+        "https://#{Settings.domain}/company/projects/#{run.project_id}/workflow_runs/#{run.id}"
+      end
+    end
+  end
+end

--- a/app/state_machines/workflow_run_state_machine.rb
+++ b/app/state_machines/workflow_run_state_machine.rb
@@ -31,7 +31,7 @@ module WorkflowRunStateMachine
       end
 
       event :fail do
-        transitions from: %i[running paused], to: :failed, after: :on_completed
+        transitions from: %i[running paused], to: :failed, after: %i[on_completed announce_failure]
       end
 
       event :cancel do
@@ -52,5 +52,15 @@ module WorkflowRunStateMachine
 
   def on_cancelled
     update_column(:completed_at, Time.current)
+  end
+
+  # On the transition rather than in WorkflowService.fail, because that is not
+  # the only way a run ends up failed — the stale-run sweeper calls `fail!`
+  # straight on the record, and a run reaped as stale is precisely the kind of
+  # failure nobody is watching for.
+  def announce_failure
+    Slack::NotifyRunFailureJob.perform_later(id)
+  rescue StandardError => e
+    Rails.logger.error("[WorkflowRun] Failed to enqueue the Slack failure notice for run ##{id}: #{e.message}")
   end
 end

--- a/db/migrate/20260905213113_add_notify_on_failure_to_trigger_bindings.rb
+++ b/db/migrate/20260905213113_add_notify_on_failure_to_trigger_bindings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotifyOnFailureToTriggerBindings < ActiveRecord::Migration[8.0]
+  def change
+    add_column :trigger_bindings, :notify_on_failure, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1021,6 +1021,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_06_120000) do
     t.string "event_type", null: false
     t.jsonb "filter_predicate", default: {}, null: false
     t.string "name"
+    t.boolean "notify_on_failure", default: true, null: false
     t.bigint "project_id", null: false
     t.jsonb "schedule_config", default: {}, null: false
     t.bigint "subject_column_id"

--- a/test/controllers/api/v1/projects/workflows/triggers_controller_test.rb
+++ b/test/controllers/api/v1/projects/workflows/triggers_controller_test.rb
@@ -44,6 +44,27 @@ module Api
             assert_equal "slack", json["kind"]
           end
 
+          test "a slack trigger reports failures back to Slack unless it is switched off" do
+            post :create, params: {
+              project_id: @project.id, workflow_id: @workflow.id,
+              trigger: { kind: "slack", filter_predicate: { channel: "C1" }, subject_policy: "none" }
+            }
+
+            assert_response :created
+            assert json["notify_on_failure"], "a new slack trigger notifies on failure by default"
+            binding = TriggerBinding.find(json["id"])
+            assert binding.notify_on_failure
+
+            patch :update, params: {
+              project_id: @project.id, workflow_id: @workflow.id, id: binding.id,
+              trigger: { notify_on_failure: false }
+            }
+
+            assert_response :success
+            assert_not json["notify_on_failure"]
+            assert_not binding.reload.notify_on_failure
+          end
+
           test "create webhook trigger provisions an endpoint and returns its url + secret" do
             assert_difference -> { TriggerBinding.count } => 1, -> { WebhookEndpoint.count } => 1 do
               post :create, params: {

--- a/test/models/workflow_run_test.rb
+++ b/test/models/workflow_run_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class WorkflowRunTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   setup do
     @company = create(:company, name: "wrtest-co-#{SecureRandom.hex(4)}")
     @admin = create(:user, :admin, company: @company)
@@ -44,6 +46,22 @@ class WorkflowRunTest < ActiveSupport::TestCase
     run = create(:workflow_run, project: @project, workflow: @workflow, user: @admin)
 
     assert_not run.controllable_by?(nil)
+  end
+
+  test "failing a run queues the Slack failure notice, whoever failed it" do
+    run = create(:workflow_run, project: @project, workflow: @workflow, user: @admin)
+    run.start!
+
+    assert_enqueued_with(job: Slack::NotifyRunFailureJob, args: [ run.id ]) { run.fail! }
+    assert_equal "failed", run.state
+    assert_not_nil run.completed_at
+  end
+
+  test "completing a run queues nothing" do
+    run = create(:workflow_run, project: @project, workflow: @workflow, user: @admin)
+    run.start!
+
+    assert_no_enqueued_jobs(only: Slack::NotifyRunFailureJob) { run.complete! }
   end
 
   test "default state is pending" do

--- a/test/services/slack/run_failure_notifier_test.rb
+++ b/test/services/slack/run_failure_notifier_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Slack
+  class RunFailureNotifierTest < ActiveSupport::TestCase
+    setup do
+      @user = create(:user, :with_company)
+      @company = @user.companies.first
+      @project = create(:project, owner: @user, company: @company)
+      @integration = Integration.create!(
+        provider: :slack, company: @company, project: @project, connected_by: @user,
+        name: "Acme", status: :active
+      )
+      @integration.update!(credentials_data: { "bot_token" => "xoxb-1" })
+      stub_slack_client!
+
+      @workflow = create(:workflow, scope: @project, name: "Weekly Digest")
+      # A trigger binding refuses to attach to a workflow with a step that needs
+      # a human — an unattended launch would be silently skipped at fire time.
+      @step = create(:step, workflow: @workflow, name: "Render Output", position: 1, allow_non_interactive: true)
+      @binding = create(:trigger_binding, project: @project, workflow: @workflow, event_type: "slack.message")
+    end
+
+    def failed_run(shared_context: slack_context, notify: true, binding: @binding)
+      @binding&.update!(notify_on_failure: notify)
+      run = create(:workflow_run, :running, workflow: @workflow, project: @project, user: @user,
+        shared_context: shared_context)
+      if binding
+        event = TriggerEvent.create!(event_type: "slack.message", source: "slack:acme", data: {}, occurred_at: Time.current)
+        TriggerDispatch.create!(trigger_event: event, trigger_binding: binding, workflow_run: run,
+          dedup_key: "d-#{run.id}", status: "started", source: "trigger_binding")
+      end
+      create(:step_run, :failed, workflow_run: run, step: @step, error_message: "container exited with code 1")
+      run.update_column(:state, "failed")
+      run
+    end
+
+    def slack_context
+      { "slack" => { "channel" => "C1", "thread_ts" => "111.222", "integration_id" => @integration.id } }
+    end
+
+    test "replies in the triggering thread with the workflow, the step and its error" do
+      assert Slack::RunFailureNotifier.call(failed_run)
+
+      msg = fake_slack.last_posted_message
+      assert_equal "xoxb-1", msg[:token]
+      assert_equal "C1", msg[:channel]
+      assert_equal "111.222", msg[:thread_ts]
+      assert_match(/Weekly Digest/, msg[:text])
+      assert_match(/Render Output: container exited with code 1/, msg[:text])
+      assert_match(%r{/workflow_runs/}, msg[:text])
+    end
+
+    test "says the account ran out of credits when that is why the run failed" do
+      run = failed_run
+      run.update_columns(failure_reason: "quota_exceeded")
+
+      assert Slack::RunFailureNotifier.call(run)
+      assert_match(/ran out of credits/, fake_slack.last_posted_message[:text])
+    end
+
+    test "stays quiet when the trigger has notifications switched off" do
+      assert_not Slack::RunFailureNotifier.call(failed_run(notify: false))
+      assert_empty fake_slack.posted_messages
+    end
+
+    test "stays quiet for a run that did not come from Slack" do
+      assert_not Slack::RunFailureNotifier.call(failed_run(shared_context: {}))
+      assert_empty fake_slack.posted_messages
+    end
+
+    test "stays quiet for a Slack-context run with no trigger behind it" do
+      assert_not Slack::RunFailureNotifier.call(failed_run(binding: nil))
+      assert_empty fake_slack.posted_messages
+    end
+
+    test "stays quiet for a run that has not failed" do
+      run = create(:workflow_run, :running, workflow: @workflow, project: @project, user: @user,
+        shared_context: slack_context)
+
+      assert_not Slack::RunFailureNotifier.call(run)
+      assert_empty fake_slack.posted_messages
+    end
+
+    test "a Slack outage is swallowed, never raised at the caller" do
+      Slack::Notifier.stubs(:post).raises(StandardError, "slack is down")
+
+      assert_not Slack::RunFailureNotifier.call(failed_run)
+    end
+  end
+end


### PR DESCRIPTION
A run launched by @mentioning the bot is fire-and-forget for whoever typed the mention: they see whatever the agent chose to post back, and **nothing at all** when the run dies before the agent could post anything — which is exactly when the failure most needs saying out loud.

## What changed

- Slack triggers now reply in the **same thread** when a run they started fails, naming the failed step and its error (truncated — the run page has the full thing), or the account that ran out of credits, plus a link to the run.
- `trigger_bindings.notify_on_failure`, default **true**. A switch on the Slack trigger form; the MCP trigger tools (`create_workflow_trigger` / `update_workflow_trigger`) take it too.
- Only Slack-born runs carry the reply coordinates, so the flag is a no-op on every other trigger kind.

## Where the hook lives

On the `fail` **transition**, not in `WorkflowService.fail` — that is not the only way a run ends up failed. The stale-run sweeper calls `fail!` straight on the record, and a run reaped as stale is precisely the kind of failure nobody is watching for.

The post itself runs in `Slack::NotifyRunFailureJob`, so a Slack outage can never turn a failed run into a failed state transition. `RunFailureNotifier` returns `false` on every unhappy path rather than raising.

## Deliberately quiet

- A run with Slack context but no dispatch behind it (a re-run started by hand from a Slack-born run inherits `shared_context`) — nobody asked for a notification on it.
- The reply goes through the **same workspace install** the run came from, mirroring `InternalTools::SlackPostMessage#slack_integration`.

## Checks

`docker compose exec -T web make check_all` — green, including `schema_parity_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
