### PR TITLE
fix(workflows): stop the generic cancellation text erasing the real reason

### DIFF
--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -39,8 +39,13 @@ class StepRun < ApplicationRecord
     update!(state: :skipped, completed_at: Time.current, skip_reason: reason)
   end
 
-  def mark_cancelled!
-    update!(state: :cancelled, completed_at: Time.current)
+  # `reason` is what the session died of, when something diagnosed it — a spend
+  # limit, a lost node. A cancelled step with an empty error_message reads as "someone
+  # clicked cancel", which is exactly the wrong thing to tell a user whose account is
+  # out of credit.
+  def mark_cancelled!(reason = nil)
+    update!(state: :cancelled, completed_at: Time.current,
+            error_message: reason.presence || error_message)
   end
 
   def create_sub_step_runs!

--- a/app/models/terminal_session.rb
+++ b/app/models/terminal_session.rb
@@ -7,6 +7,27 @@ class TerminalSession < ApplicationRecord
 
   WORKFLOW_TIMEOUT = 86_400 # 24 hours
 
+  # What the cancellation path reports for every reason a session can be cancelled
+  # for — including the ones something already diagnosed precisely: a spend limit read
+  # off the terminal by ScanQuotaErrorsActivity, a node that took the pod with it,
+  # caught by ScanDeadContainersActivity.
+  #
+  # Both write the real reason here first and both were then overwritten by this
+  # string, because cleanup runs last. That is not only a cosmetic loss: the quota
+  # detector in CompleteStepActivity reads `error_message`, so a clobbered session
+  # never got `error_category: :quota_exceeded` either, and the run surfaced as a bare
+  # "cancelled" with nothing to act on. (2026-09-05: eleven runs, all of them a spend
+  # limit nobody could see.)
+  GENERIC_ERROR_MESSAGES = [ "Workflow cancelled" ].freeze
+
+  # A specific reason always outranks a generic one, whichever arrives last.
+  def self.preferred_error_message(existing, incoming)
+    return existing if incoming.blank?
+    return existing if existing.present? && GENERIC_ERROR_MESSAGES.include?(incoming)
+
+    incoming
+  end
+
   # `bmm` ships inside the npm package; every other module is cloned from GitHub
   # at install time, and each one costs an api.github.com tag lookup against a
   # per-IP hourly budget shared by the whole cluster (see BmadMethodInjector).

--- a/app/services/container_strategies/base_strategy.rb
+++ b/app/services/container_strategies/base_strategy.rb
@@ -114,7 +114,7 @@ module ContainerStrategies
       session.reload
 
       if error
-        session.update(error_message: error)
+        session.update(error_message: TerminalSession.preferred_error_message(session.error_message, error))
         session.fail! if session.may_fail?
       else
         # `complete_finish!` is idempotent: when the user initiated finalization,

--- a/app/services/workflow_service.rb
+++ b/app/services/workflow_service.rb
@@ -183,11 +183,28 @@ class WorkflowService
 
     def cancel_active_step_runs(run)
       run.step_runs.where(state: %w[pending running waiting_input]).find_each do |sr|
-        SessionService.cancel(session: sr.terminal_session) if sr.terminal_session
-        sr.mark_cancelled!
+        session = sr.terminal_session
+        SessionService.cancel(session: session) if session
+        # Read after the cancel: the session is where a diagnosed reason lives, and
+        # cleanup may have just written one.
+        sr.mark_cancelled!(diagnosed_reason(session))
       rescue StandardError => e
         Rails.logger.warn("[WorkflowService] Failed to cancel step_run ##{sr.id}: #{e.message}")
       end
+    end
+
+    # Only a reason worth showing: the generic cancellation text says nothing the
+    # step's own `cancelled` state does not already say.
+    def diagnosed_reason(session)
+      return nil unless session
+
+      message = session.reload.error_message
+      return nil if message.blank? || TerminalSession::GENERIC_ERROR_MESSAGES.include?(message)
+
+      message
+    rescue StandardError => e
+      Rails.logger.warn("[WorkflowService] Failed to read cancellation reason: #{e.message}")
+      nil
     end
 
     def broadcast_task_updated(run)

--- a/app/temporal/activities/container/admitted_phase_activity.rb
+++ b/app/temporal/activities/container/admitted_phase_activity.rb
@@ -150,7 +150,8 @@ module Activities
           session.reload
           final_state = session.cancelled? ? "cancelled" : (state[:error] || session.failed? ? "failed" : "finished")
           session.update!(state: final_state, finished_at: session.finished_at || Time.current,
-            container_id: nil, error_message: state[:error] || session.error_message)
+            container_id: nil,
+            error_message: TerminalSession.preferred_error_message(session.error_message, state[:error]))
         end
       end
     end

--- a/test/models/step_run_test.rb
+++ b/test/models/step_run_test.rb
@@ -3,6 +3,25 @@
 require "test_helper"
 
 class StepRunTest < ActiveSupport::TestCase
+  # A cancelled step with no message reads as "someone clicked cancel" — wrong to show
+  # a user whose account simply ran out of credit.
+  test "mark_cancelled! records the reason it was given" do
+    step_run = create(:step_run)
+
+    step_run.mark_cancelled!("You've hit your individual spend limit")
+
+    assert_equal "cancelled", step_run.reload.state
+    assert_equal "You've hit your individual spend limit", step_run.error_message
+  end
+
+  test "mark_cancelled! without a reason leaves any earlier message alone" do
+    step_run = create(:step_run, error_message: "Earlier detail")
+
+    step_run.mark_cancelled!
+
+    assert_equal "cancelled", step_run.reload.state
+    assert_equal "Earlier detail", step_run.error_message
+  end
   setup do
     @company = create(:company)
     @user = create(:user, :admin, company: @company)

--- a/test/models/terminal_session_test.rb
+++ b/test/models/terminal_session_test.rb
@@ -3,6 +3,26 @@
 require "test_helper"
 
 class TerminalSessionTest < ActiveSupport::TestCase
+  # --- preferred_error_message (a diagnosed reason outranks the generic one) ---
+
+  test "preferred_error_message keeps a diagnosed reason when the generic one arrives after it" do
+    assert_equal "You've hit your individual spend limit",
+                 TerminalSession.preferred_error_message("You've hit your individual spend limit", "Workflow cancelled")
+  end
+
+  test "preferred_error_message takes the generic reason when nothing more specific is known" do
+    assert_equal "Workflow cancelled", TerminalSession.preferred_error_message(nil, "Workflow cancelled")
+    assert_equal "Workflow cancelled", TerminalSession.preferred_error_message("", "Workflow cancelled")
+  end
+
+  test "preferred_error_message lets one specific reason replace another" do
+    assert_equal "Agent container vanished",
+                 TerminalSession.preferred_error_message("Some earlier failure", "Agent container vanished")
+  end
+
+  test "preferred_error_message keeps what it has when nothing new arrives" do
+    assert_equal "Agent container vanished", TerminalSession.preferred_error_message("Agent container vanished", nil)
+  end
   setup do
     @company = create(:company)
     @user = create(:user, :admin, company: @company)

--- a/test/services/workflow_service_test.rb
+++ b/test/services/workflow_service_test.rb
@@ -91,6 +91,39 @@ class WorkflowServiceTest < ActiveSupport::TestCase
     assert_equal "cancelled", run.state
   end
 
+  # The cancellation itself is not the news — the reason is. A session killed by a
+  # spend limit or a lost node has one, and the step is where a user sees it.
+  test "cancel carries the session's diagnosed reason onto the step run" do
+    TemporalWorkflowRegistry.stubs(:start_workflow_execution)
+    TemporalService.stubs(:send_signal)
+    run = WorkflowService.start(workflow: @workflow, project: @project, user: @user)
+    run.start! if run.may_start?
+    step_run = run.step_runs.first
+    session = create(:terminal_session, user: @user, project: @project,
+                                        error_message: "You've hit your individual spend limit")
+    step_run.update!(terminal_session: session, state: "running")
+    SessionService.stubs(:cancel)
+
+    WorkflowService.cancel(run: run)
+
+    assert_equal "You've hit your individual spend limit", step_run.reload.error_message
+  end
+
+  test "cancel leaves the step run unexplained when the generic reason is all there is" do
+    TemporalWorkflowRegistry.stubs(:start_workflow_execution)
+    TemporalService.stubs(:send_signal)
+    run = WorkflowService.start(workflow: @workflow, project: @project, user: @user)
+    run.start! if run.may_start?
+    step_run = run.step_runs.first
+    session = create(:terminal_session, user: @user, project: @project, error_message: "Workflow cancelled")
+    step_run.update!(terminal_session: session, state: "running")
+    SessionService.stubs(:cancel)
+
+    WorkflowService.cancel(run: run)
+
+    assert_predicate step_run.reload.error_message.to_s, :empty?
+  end
+
   test "cancel records a workflow_cancelled activity on the task's board" do
     TemporalWorkflowRegistry.stubs(:start_workflow_execution)
     TemporalService.stubs(:send_signal)


### PR DESCRIPTION
## What this fixes

On 2026-09-05 eleven production runs ended `cancelled`, with `failure_reason: nil`, `step_run.error_message: ""`, and every session saying the same thing:

```
error_message = "Workflow cancelled"
```

They were not cancelled by anyone. All eleven hit the same wall:

```
⎿  You've hit your individual spend limit · run /usage-credits to ask your…
```

`ScanQuotaErrorsActivity` read that off the live terminal and wrote it onto each session — correctly. Cleanup then overwrote it, because cancellation runs last and reports one generic string for every reason a session can be cancelled for.

Establishing that took Temporal history plus a Loki query, for a fact the system had already discovered and then thrown away.

## Why it is not only cosmetic

`CompleteStepActivity` detects quota exhaustion by reading `session.error_message`. A clobbered session therefore also lost:

- `error_category: :quota_exceeded` on the step run,
- `WorkflowRun#mark_quota_failed!` and the credential attribution that goes with it.

The same erasure hits `ScanDeadContainersActivity`, whose "Agent container vanished: its node most likely died or the pod was evicted" met the same fate — that is how the node-eviction incident in [aixle-infra#34](https://github.com/palad-ai/aixle-infra/pull/34) presented, too.

## The change

**A specific reason outranks a generic one, whichever arrives last.** `TerminalSession.preferred_error_message(existing, incoming)` encodes it, applied at both writers that were clobbering: `BaseStrategy#after_cleanup` and `AdmittedPhaseActivity#finalize_session`.

**The cancellation fan-out carries a diagnosed reason onto the step run.** `WorkflowService#cancel_active_step_runs` reads the session after cancelling (cleanup may have just written the reason) and passes it to `StepRun#mark_cancelled!`, which now takes one. A *generic* reason is still dropped on purpose — a cancelled step with no message already says everything "Workflow cancelled" would.

## What it does not do

It does not change which sessions get cancelled, or turn a cancellation into a failure. `fail_session` still routes an admitted session through cancel, because that is what releases the reservation. This is about what the system remembers, not what it does.

## Tests

`docker compose exec -T web make check_all` — green (backend 91.81%, frontend 80.76%).

Covers: a diagnosed reason survives a later generic one; a generic reason is still used when nothing better is known; one specific reason may replace another; `mark_cancelled!` records a reason and leaves an earlier message alone without one; the fan-out carries a diagnosed reason to the step run and drops a generic one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
