### PR TITLE
fix(layout): stop footer overlapping content on no-padding pages

### DIFF
--- a/app/frontend/layouts/AuthLayout.module.css
+++ b/app/frontend/layouts/AuthLayout.module.css
@@ -36,7 +36,6 @@
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  min-height: 0;
 }
 
 .footer {


### PR DESCRIPTION
## Problem

On the workflow run detail page (and any no-padding page that outgrows the viewport) the "Powered by Aixle" footer laid out on top of the page content instead of below it.

![before](does-not-apply)

`.mainNoPadding` in `AuthLayout.module.css` carried `min-height: 0`. Because `<main>` is a `flex-grow` child of the scrolling `.contentColumn`, that let it shrink *below* its natural content height once the content exceeded the viewport. The footer then positioned against the collapsed `<main>` box while the content — and the sticky live-console panel — kept rendering full-size, overlapping the footer.

PR #133 removed `min-height: 0` from `WorkflowRuns/ShowPage.module.css` `.root`, but the shrink was happening one level up at `<main>`, so the bug persisted.

## Fix

Drop `min-height: 0` from `.mainNoPadding`. The three consumers:

- `Projects/WorkflowRuns/ShowPage` — normal scrolling document; wants `<main>` at full content height. Fixed.
- `Projects/Sessions/ShowPage` and `Company/Sessions/Show` — full-height iframe via `SessionShowContent`, whose `.root` already sets its own `min-height: 0` / `overflow: hidden`. That content root allows itself to shrink to 0, so `<main>`'s auto `min-height` still resolves to the available height — no behavior change, verified the layout still fills.

## Checks

`docker compose exec -T web make check_all` could not complete in this environment — the `web` container's gem cache is broken (`Bundler::GemNotFound`, unrelated to this change) and `tsc` reports pre-existing errors in `AssetsContent.tsx` that are present on `develop`. Ran what applies to a CSS-only change:

- `eslint` (AuthLayout) — pass
- `steiger` (fsd) — pass
- `vitest` `WorkflowRuns` + `layouts` — 24 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGoEtFbxUDGfHvVwZB3FMN