### PR TITLE
feat(triggers): reply in the Slack thread when a launch fails before a run exists

### DIFF
--- a/app/jobs/slack/notify_launch_failure_job.rb
+++ b/app/jobs/slack/notify_launch_failure_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Slack
+  # Off the dispatch path: a launch skipped by TriggerEngine#fire_workflow still
+  # deserves a word in the Slack thread that asked for it, but posting to Slack is
+  # a network call and must not sit inside the dispatch lock.
+  class NotifyLaunchFailureJob < ApplicationJob
+    queue_as :default
+
+    def perform(trigger_dispatch_id)
+      dispatch = TriggerDispatch.find_by(id: trigger_dispatch_id)
+      Slack::RunFailureNotifier.notify_launch_skip(dispatch)
+    end
+  end
+end

--- a/app/models/trigger_binding.rb
+++ b/app/models/trigger_binding.rb
@@ -20,10 +20,11 @@ class TriggerBinding < ApplicationRecord
 
   SCHEDULE_EVENT_TYPE = "schedule.fired"
 
-  # notify_on_failure (default true) — when a run this binding started fails,
-  # say so in the Slack thread it came from, with what it failed with. Only
-  # Slack-born runs carry the reply coordinates, so it is a no-op on every other
-  # trigger kind; see Slack::RunFailureNotifier.
+  # notify_on_failure (default true) — when a launch this binding started fails
+  # (the run reaches `failed`, or it is skipped before a run exists), say so in
+  # the Slack thread it came from, with what it failed with. Only Slack-born
+  # events carry the reply coordinates, so it is a no-op on every other trigger
+  # kind; see Slack::RunFailureNotifier.
 
   validates :event_type, presence: true
   validates :cooldown_seconds, numericality: { greater_than_or_equal_to: 0 }

--- a/app/services/slack/run_failure_notifier.rb
+++ b/app/services/slack/run_failure_notifier.rb
@@ -45,17 +45,20 @@ module Slack
 
         dispatch = TriggerDispatch.where(workflow_run_id: run.id).order(:id).last
         return false unless notify?(dispatch)
-        return false unless claim(dispatch)
 
         integration = integration_for(run.project, slack["integration_id"])
         return false if integration.nil?
 
-        Slack::Notifier.post(
-          integration: integration,
-          channel: channel,
-          thread_ts: slack["thread_ts"],
-          text: message_for(run)
-        )
+        return false unless claim(dispatch)
+
+        post_or_release(dispatch) do
+          Slack::Notifier.post(
+            integration: integration,
+            channel: channel,
+            thread_ts: slack["thread_ts"],
+            text: message_for(run)
+          )
+        end
       rescue StandardError => e
         Rails.logger.error("[Slack::RunFailureNotifier] run ##{run&.id}: #{e.message}")
         false
@@ -73,17 +76,20 @@ module Slack
 
         channel = event.data["channel"]
         return false if channel.blank?
-        return false unless claim(dispatch)
 
         integration = integration_for(dispatch.trigger_binding.project, event.data["integration_id"])
         return false if integration.nil?
 
-        Slack::Notifier.post(
-          integration: integration,
-          channel: channel,
-          thread_ts: event.data["thread_ts"] || event.data["ts"],
-          text: launch_skip_message(dispatch)
-        )
+        return false unless claim(dispatch)
+
+        post_or_release(dispatch) do
+          Slack::Notifier.post(
+            integration: integration,
+            channel: channel,
+            thread_ts: event.data["thread_ts"] || event.data["ts"],
+            text: launch_skip_message(dispatch)
+          )
+        end
       rescue StandardError => e
         Rails.logger.error("[Slack::RunFailureNotifier] dispatch ##{dispatch&.id}: #{e.message}")
         false
@@ -102,10 +108,29 @@ module Slack
       # Atomic claim: the UPDATE only touches the row while the column is still
       # NULL, so exactly one caller ever gets through — job retries, a duplicate
       # enqueue, and the reaper + WorkflowService.fail both landing on the same
-      # run all collapse to a single reply.
+      # run all collapse to a single reply. Claimed just before the post and
+      # released again (see #post_or_release) if the post never lands, so a Slack
+      # outage or a config gap leaves the notice retryable rather than eaten.
       def claim(dispatch)
         TriggerDispatch.where(id: dispatch.id, slack_failure_notified_at: nil)
                        .update_all(slack_failure_notified_at: Time.current) == 1
+      end
+
+      # Hold the claim only for a post that actually lands. Slack::Notifier.post
+      # swallows a Slack outage and returns false rather than raising, so a falsy
+      # result has to release the claim too — otherwise a transient failure eats
+      # the notice for good.
+      def post_or_release(dispatch)
+        posted = yield
+        release(dispatch) unless posted
+        posted
+      rescue StandardError
+        release(dispatch)
+        raise
+      end
+
+      def release(dispatch)
+        TriggerDispatch.where(id: dispatch.id).update_all(slack_failure_notified_at: nil)
       end
 
       # Reply through the SAME workspace that triggered the launch — its install is

--- a/app/services/slack/run_failure_notifier.rb
+++ b/app/services/slack/run_failure_notifier.rb
@@ -1,18 +1,40 @@
 # frozen_string_literal: true
 
 module Slack
-  # Tells the Slack thread that started a workflow run that the run failed, and
-  # what it failed with.
+  # Tells the Slack thread that started a workflow that it failed, and what it
+  # failed with.
   #
-  # A run launched from Slack is fire-and-forget for the person who typed the
-  # mention: they get whatever the agent chose to post back, and nothing at all
-  # when the run dies before the agent could post anything — which is exactly
-  # when a failure most needs saying out loud. This closes that hole, opt-out per
-  # trigger (TriggerBinding#notify_on_failure).
+  # Two ways a Slack-triggered workflow can fail silently:
+  #
+  #   * the run reaches `failed` state (step/session error, output validation,
+  #     quota, stale-run reaper, Temporal activity failure) — #call, off the AASM
+  #     `fail` transition;
+  #   * the launch is skipped before a run is ever persisted (e.g. `validate_mode!`
+  #     rejects an interactive step) — #notify_launch_skip, off TriggerEngine's
+  #     dispatch ledger.
+  #
+  # Either way the person who typed the mention gets nothing, which is exactly
+  # when a failure most needs saying out loud. Opt-out per trigger
+  # (TriggerBinding#notify_on_failure).
   #
   # Best-effort by construction: every path returns false rather than raising, so
-  # a Slack outage can never turn a failed run into a failed state transition.
+  # a Slack outage can never turn a failed run into a failed state transition or
+  # break dispatch. Idempotent: the claim on TriggerDispatch#slack_failure_notified_at
+  # means job retries never post the same failure twice.
   class RunFailureNotifier
+    # Reason strings are pulled from raw error text; scrub anything that smells
+    # like a credential before it lands in a channel.
+    SECRET_PATTERNS = [
+      /xox[abprs]-[A-Za-z0-9-]+/,
+      /\bBearer\s+[A-Za-z0-9._\-]+/i,
+      /\bAKIA[0-9A-Z]{16}\b/,
+      /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/,
+      /\b(?:api[_-]?key|token|secret|password|passwd|pwd)\s*[=:]\s*\S+/i,
+      /\b[A-Fa-f0-9]{32,}\b/
+    ].freeze
+
+    REASON_LIMIT = 300
+
     class << self
       def call(run)
         return false if run.nil? || !run.failed?
@@ -20,9 +42,12 @@ module Slack
         slack = run.shared_context.to_h["slack"].to_h
         channel = slack["channel"]
         return false if channel.blank?
-        return false unless notify?(run)
 
-        integration = integration_for(run, slack)
+        dispatch = TriggerDispatch.where(workflow_run_id: run.id).order(:id).last
+        return false unless notify?(dispatch)
+        return false unless claim(dispatch)
+
+        integration = integration_for(run.project, slack["integration_id"])
         return false if integration.nil?
 
         Slack::Notifier.post(
@@ -36,32 +61,68 @@ module Slack
         false
       end
 
-      private
+      # A launch that was accepted (the mention matched a workflow) but skipped
+      # before a run existed. Reply using the event's own coordinates — there is
+      # no run and no shared_context to read.
+      def notify_launch_skip(dispatch)
+        return false if dispatch.nil? || dispatch.status != "skipped"
+        return false unless notify?(dispatch)
 
-      # The binding that started this run, through the dispatch ledger. A run with
-      # Slack context but no binding (a re-run started by hand from a Slack-born
-      # run, which inherits shared_context) is left alone: nobody asked for a
-      # notification on it.
-      def notify?(run)
-        binding = TriggerDispatch.where(workflow_run_id: run.id).order(:id).last&.trigger_binding
-        binding.present? && binding.notify_on_failure?
+        event = dispatch.trigger_event
+        return false unless event&.event_type.to_s.start_with?("slack.")
+
+        channel = event.data["channel"]
+        return false if channel.blank?
+        return false unless claim(dispatch)
+
+        integration = integration_for(dispatch.trigger_binding.project, event.data["integration_id"])
+        return false if integration.nil?
+
+        Slack::Notifier.post(
+          integration: integration,
+          channel: channel,
+          thread_ts: event.data["thread_ts"] || event.data["ts"],
+          text: launch_skip_message(dispatch)
+        )
+      rescue StandardError => e
+        Rails.logger.error("[Slack::RunFailureNotifier] dispatch ##{dispatch&.id}: #{e.message}")
+        false
       end
 
-      # Reply through the SAME workspace that triggered the run — its install is
-      # named in shared_context — so a company with several connected workspaces
-      # answers in the right one. Mirrors InternalTools::SlackPostMessage
+      private
+
+      # The binding that started this launch has to exist and still want the
+      # notification. A run with Slack context but no binding (a re-run started by
+      # hand from a Slack-born run, which inherits shared_context) is left alone:
+      # nobody asked for a notification on it.
+      def notify?(dispatch)
+        dispatch&.trigger_binding&.notify_on_failure?
+      end
+
+      # Atomic claim: the UPDATE only touches the row while the column is still
+      # NULL, so exactly one caller ever gets through — job retries, a duplicate
+      # enqueue, and the reaper + WorkflowService.fail both landing on the same
+      # run all collapse to a single reply.
+      def claim(dispatch)
+        TriggerDispatch.where(id: dispatch.id, slack_failure_notified_at: nil)
+                       .update_all(slack_failure_notified_at: Time.current) == 1
+      end
+
+      # Reply through the SAME workspace that triggered the launch — its install is
+      # named in the Slack context / event — so a company with several connected
+      # workspaces answers in the right one. Mirrors InternalTools::SlackPostMessage
       # #slack_integration, including its project-first fallback.
-      def integration_for(run, slack)
-        return nil if run.project.nil?
+      def integration_for(project, integration_id)
+        return nil if project.nil?
 
-        scope = Integration.active.where(provider: :slack, company_id: run.project.company_id)
+        scope = Integration.active.where(provider: :slack, company_id: project.company_id)
 
-        if (id = slack["integration_id"]).present?
-          by_id = scope.find_by(id: id)
+        if integration_id.present?
+          by_id = scope.find_by(id: integration_id)
           return by_id if by_id
         end
 
-        scope.where("project_id = :pid OR project_id IS NULL", pid: run.project_id)
+        scope.where("project_id = :pid OR project_id IS NULL", pid: project.id)
              .order(Arel.sql("project_id IS NULL"))
              .first
       end
@@ -74,17 +135,31 @@ module Slack
         lines.compact.join("\n")
       end
 
-      # What actually went wrong: the quota case names itself, otherwise the last
-      # failed step's message. Truncated — a container log dump in a Slack thread
-      # helps nobody, and the run page has the whole thing.
+      def launch_skip_message(dispatch)
+        name = dispatch.trigger_binding.workflow&.name || "Workflow"
+        reason = redact(dispatch.detail.to_h["reason"]).truncate(REASON_LIMIT).presence || "Workflow failed."
+        ":x: *#{name}* failed to start.\n> #{reason}"
+      end
+
+      # What actually went wrong: the known failure_reason values name themselves,
+      # otherwise the last failed step's message. Truncated and scrubbed — a
+      # container log dump in a Slack thread helps nobody, and the run page has
+      # the whole thing.
       def failure_summary(run)
-        if run.failure_reason == "quota_exceeded"
+        case run.failure_reason
+        when "quota_exceeded"
           return "#{run.failed_agent_credential&.agent_type || 'The connected account'} ran out of credits."
+        when "stale_run"
+          return "The run timed out and was cleaned up as stale."
         end
 
         step = run.step_runs.where(state: "failed").order(:updated_at).last
-        [ step&.step&.name, step&.error_message.to_s.truncate(400).presence ].compact.join(": ").presence ||
+        [ step&.step&.name, redact(step&.error_message).truncate(REASON_LIMIT).presence ].compact.join(": ").presence ||
           run.failure_reason.to_s.humanize.presence
+      end
+
+      def redact(text)
+        SECRET_PATTERNS.reduce(text.to_s) { |acc, re| acc.gsub(re, "[redacted]") }
       end
 
       def run_url(run)

--- a/app/services/trigger_engine.rb
+++ b/app/services/trigger_engine.rb
@@ -205,6 +205,7 @@ class TriggerEngine
             status: started ? "started" : "skipped",
             detail: started ? {} : { "reason" => skip_reason(result) }
           )
+          notify_launch_failure(dispatch, event) unless started
         end
       end
       result
@@ -274,6 +275,19 @@ class TriggerEngine
     def skip_reason(result)
       msgs = result.try(:errors)&.full_messages
       msgs.presence&.join("; ") || "workflow did not start"
+    end
+
+    # Best-effort: tell the originating Slack thread the launch was skipped. Only
+    # Slack-born events carry reply coordinates; enqueue failure never breaks the
+    # dispatch that triggered it.
+    def notify_launch_failure(dispatch, event)
+      return unless event.event_type.to_s.start_with?("slack.")
+
+      Slack::NotifyLaunchFailureJob.perform_later(dispatch.id)
+    rescue StandardError => e
+      Rails.logger.error(
+        "[TriggerEngine] Failed to enqueue the Slack launch-failure notice for dispatch ##{dispatch.id}: #{e.message}"
+      )
     end
 
     # Resolve the board task a binding's run should be about, per subject_policy.

--- a/db/migrate/20260909120000_add_slack_failure_notified_at_to_trigger_dispatches.rb
+++ b/db/migrate/20260909120000_add_slack_failure_notified_at_to_trigger_dispatches.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSlackFailureNotifiedAtToTriggerDispatches < ActiveRecord::Migration[8.0]
+  def change
+    add_column :trigger_dispatches, :slack_failure_notified_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_06_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_09_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -1041,6 +1041,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_06_120000) do
     t.datetime "created_at", null: false
     t.string "dedup_key", null: false
     t.jsonb "detail", default: {}, null: false
+    t.datetime "slack_failure_notified_at"
     t.string "source"
     t.string "status", default: "matched", null: false
     t.bigint "trigger_binding_id"

--- a/test/jobs/slack/notify_launch_failure_job_test.rb
+++ b/test/jobs/slack/notify_launch_failure_job_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Slack
+  class NotifyLaunchFailureJobTest < ActiveSupport::TestCase
+    test "hands the dispatch to the notifier" do
+      dispatch = create(:trigger_event).then do |event|
+        TriggerDispatch.create!(trigger_event: event, dedup_key: "d-#{event.id}", status: "skipped")
+      end
+
+      Slack::RunFailureNotifier.expects(:notify_launch_skip).with(dispatch).once
+
+      Slack::NotifyLaunchFailureJob.new.perform(dispatch.id)
+    end
+
+    test "is a no-op when the dispatch is gone" do
+      Slack::RunFailureNotifier.expects(:notify_launch_skip).with(nil).once
+
+      Slack::NotifyLaunchFailureJob.new.perform(-1)
+    end
+  end
+end

--- a/test/services/slack/run_failure_notifier_test.rb
+++ b/test/services/slack/run_failure_notifier_test.rb
@@ -115,6 +115,19 @@ module Slack
       assert_equal 1, fake_slack.posted_messages.size
     end
 
+    test "a Slack outage releases the claim so a later call can still post" do
+      run = failed_run
+      dispatch = TriggerDispatch.where(workflow_run_id: run.id).order(:id).last
+
+      Slack::Notifier.stubs(:post).returns(false).then.returns(true)
+
+      assert_not Slack::RunFailureNotifier.call(run)
+      assert_nil dispatch.reload.slack_failure_notified_at
+
+      assert Slack::RunFailureNotifier.call(run)
+      assert_not_nil dispatch.reload.slack_failure_notified_at
+    end
+
     # == launch-skip entry point ==
 
     def skipped_dispatch(reason: "step 'Approve' needs a human", notify: true)

--- a/test/services/slack/run_failure_notifier_test.rb
+++ b/test/services/slack/run_failure_notifier_test.rb
@@ -88,5 +88,76 @@ module Slack
 
       assert_not Slack::RunFailureNotifier.call(failed_run)
     end
+
+    test "says the run timed out when it was reaped as stale" do
+      run = failed_run
+      run.update_columns(failure_reason: "stale_run")
+
+      assert Slack::RunFailureNotifier.call(run)
+      assert_match(/timed out and was cleaned up as stale/, fake_slack.last_posted_message[:text])
+    end
+
+    test "scrubs credentials out of the failure reason" do
+      run = failed_run
+      run.step_runs.last.update!(error_message: "auth failed with token=xoxb-999-secret-abc")
+
+      assert Slack::RunFailureNotifier.call(run)
+      text = fake_slack.last_posted_message[:text]
+      assert_no_match(/xoxb-999-secret-abc/, text)
+      assert_match(/\[redacted\]/, text)
+    end
+
+    test "a second call does not post the failure twice in the thread" do
+      run = failed_run
+
+      assert Slack::RunFailureNotifier.call(run)
+      assert_not Slack::RunFailureNotifier.call(run)
+      assert_equal 1, fake_slack.posted_messages.size
+    end
+
+    # == launch-skip entry point ==
+
+    def skipped_dispatch(reason: "step 'Approve' needs a human", notify: true)
+      @binding.update!(notify_on_failure: notify)
+      event = TriggerEvent.create!(
+        event_type: "slack.message", source: "slack:acme", occurred_at: Time.current,
+        data: { "channel" => "C1", "ts" => "111.222", "integration_id" => @integration.id }
+      )
+      TriggerDispatch.create!(
+        trigger_event: event, trigger_binding: @binding, dedup_key: "d-skip-#{event.id}",
+        status: "skipped", source: "trigger_binding", detail: { "reason" => reason }
+      )
+    end
+
+    test "notify_launch_skip replies in the thread with the workflow and the skip reason" do
+      assert Slack::RunFailureNotifier.notify_launch_skip(skipped_dispatch)
+
+      msg = fake_slack.last_posted_message
+      assert_equal "C1", msg[:channel]
+      assert_equal "111.222", msg[:thread_ts]
+      assert_match(/Weekly Digest/, msg[:text])
+      assert_match(/needs a human/, msg[:text])
+    end
+
+    test "notify_launch_skip is idempotent" do
+      dispatch = skipped_dispatch
+
+      assert Slack::RunFailureNotifier.notify_launch_skip(dispatch)
+      assert_not Slack::RunFailureNotifier.notify_launch_skip(dispatch)
+      assert_equal 1, fake_slack.posted_messages.size
+    end
+
+    test "notify_launch_skip stays quiet when the trigger has notifications off" do
+      assert_not Slack::RunFailureNotifier.notify_launch_skip(skipped_dispatch(notify: false))
+      assert_empty fake_slack.posted_messages
+    end
+
+    test "notify_launch_skip stays quiet for a dispatch that actually started" do
+      dispatch = skipped_dispatch
+      dispatch.update!(status: "started")
+
+      assert_not Slack::RunFailureNotifier.notify_launch_skip(dispatch)
+      assert_empty fake_slack.posted_messages
+    end
   end
 end

--- a/test/services/trigger_engine_test.rb
+++ b/test/services/trigger_engine_test.rb
@@ -208,6 +208,41 @@ class TriggerEngineTest < ActiveSupport::TestCase
     assert_equal "Triage: fix login", task.title
   end
 
+  # == Slack launch-failure notice ==
+
+  test "a skipped launch from Slack enqueues the launch-failure notice" do
+    binding = create(:trigger_binding, project: @project, workflow: @workflow, created_by: @user,
+      event_type: "slack.message", subject_policy: :none)
+    event = create(:trigger_event, event_type: "slack.message", project: @project,
+      data: { "channel" => "C1", "ts" => "111.222" })
+
+    unstarted = build(:workflow_run)
+    unstarted.errors.add(:base, "step 'Approve' needs a human")
+    WorkflowService.expects(:start).once.returns(unstarted)
+    Slack::NotifyLaunchFailureJob.expects(:perform_later).once
+
+    TriggerEngine.fire_for_binding(binding: binding, event: event)
+
+    dispatch = TriggerDispatch.order(:id).last
+    assert_equal "skipped", dispatch.status
+    assert_equal "step 'Approve' needs a human", dispatch.detail["reason"]
+  end
+
+  test "a skipped launch that did not come from Slack enqueues nothing" do
+    event = create(:trigger_event, event_type: TriggerEngine::COLUMN_EVENT_TYPE, project: @project)
+    TriggerDispatch.create!(
+      trigger_event: event, source: "column_workflow_binding",
+      dedup_key: "event:#{event.id}:column_workflow_binding", status: "matched"
+    )
+    WorkflowService.expects(:start).once.returns(build(:workflow_run))
+    Slack::NotifyLaunchFailureJob.expects(:perform_later).never
+
+    TriggerEngine.fire_workflow(
+      workflow: @workflow, project: @project, task: nil, actor: @user,
+      event: event, source: "column_workflow_binding"
+    )
+  end
+
   test "subject_policy existing_task uses the event's task" do
     board = create(:board, project: @project)
     column = create(:board_column, board: board)


### PR DESCRIPTION
Closes #586.

## Problem

A workflow started from Slack (`@mention` / ChatOps) can fail — a step errors, quota runs out, the stale-run reaper kills it, or the launch is rejected before a run even exists (e.g. `validate_mode!` refuses an interactive step) — and the Slack channel stays completely silent. The person who triggered it has no signal that anything went wrong or why.

PR #212 already handled one half: runs that reach `failed` state get a threaded reply. This PR covers the rest.

## Fix

- **Launch-time failures.** `TriggerEngine#fire_workflow` now enqueues `Slack::NotifyLaunchFailureJob` when it skips a Slack-triggered launch. New `Slack::RunFailureNotifier.notify_launch_skip(dispatch)` replies using the `TriggerEvent`'s own `channel` / `thread_ts` / `integration_id` (there is no `WorkflowRun` to read). Copy: `*<Workflow>* failed to start.` + the reason from `TriggerDispatch.detail`.
- **Idempotent.** New `trigger_dispatches.slack_failure_notified_at` column. Both paths do an atomic claim (`UPDATE … WHERE slack_failure_notified_at IS NULL`) before posting, so job retries / a duplicate enqueue / the reaper and `WorkflowService.fail` both hitting the same run collapse to a single reply. The claim is **released** if the post never lands (`Slack::Notifier.post` swallows an outage and returns false), so a transient Slack failure leaves the notice retryable rather than eaten.
- **`stale_run` reason** now reads "The run timed out and was cleaned up as stale." instead of the bare `humanize`.
- **Secret redaction.** Reason text (step `error_message`, launch-skip detail) is scrubbed of Slack tokens, bearer tokens, `AKIA…` keys, JWTs and `key=/token=/password=` pairs, then truncated to 300 chars.

Gated by the existing per-binding `TriggerBinding#notify_on_failure` opt-out. Best-effort throughout: never raises into Temporal, never changes run state. Non-Slack launches are untouched.

## Testing

`docker compose exec -T web make check_all` — green (all 9 checks OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ahV4WdjhvqrTdczGNPNQG