### PR TITLE
feat(slack): give agents Block Kit and the thread they were called from

### DIFF
--- a/app/services/internal_tools/concerns/slack_context.rb
+++ b/app/services/internal_tools/concerns/slack_context.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module InternalTools
+  module Concerns
+    # SlackContext — shared plumbing for the Slack tools: which workspace install
+    # this call talks to, and the channel/thread the run was started from.
+    #
+    # Every Slack tool is gated on `requires_integration :slack`, so the install
+    # exists in the common case; the guards here cover the run that was launched
+    # by hand, or after the workspace was disconnected mid-run.
+    module SlackContext
+      # What an agent needs to know to write `blocks` without a round-trip through
+      # a Slack `invalid_blocks` error: the block types that work on the message
+      # surface, their size caps, and the two formatting dialects. Shared by every
+      # tool that accepts blocks, so the guidance can never drift between them.
+      BLOCK_KIT_GUIDE = <<~GUIDE.freeze
+        Block Kit array, max 50 blocks. Message-surface types worth using:
+        - {"type":"markdown","text":"..."} — real Markdown: headings, tables, ordered lists,
+          [links](url), fenced code. The easiest path, and usually the right one. 12000 chars
+          across all markdown blocks in the message; every heading level renders one size and
+          images become links.
+        - {"type":"section","text":{"type":"mrkdwn","text":"..."}} — mrkdwn, max 3000 chars.
+          Optional "fields": up to 10 text objects of 2000 chars, laid out in two columns.
+        - {"type":"header","text":{"type":"plain_text","text":"..."}} — max 150 chars, plain_text only.
+        - {"type":"context","elements":[...]} — up to 10 small text/image elements, for footnotes.
+        - {"type":"divider"} — a horizontal rule.
+        - {"type":"image","image_url":"https://...","alt_text":"..."} — png/jpg/gif at a PUBLIC url
+          (max 3000 chars; alt_text max 2000). To show a file you just produced, attach it through
+          `files` instead — a container path is not reachable by Slack.
+        mrkdwn is NOT Markdown: *bold*, _italic_, ~strike~, `code`, ```block```, > quote,
+        <https://url|label>, <@U123>, <#C123>. [label](url) does NOT render in an mrkdwn text
+        object — use a markdown block if you want Markdown syntax.
+        Interactive blocks (actions/input, buttons, selects) are rejected: this deployment runs no
+        Slack interactivity endpoint, so a click would go nowhere.
+        Keep `text` set alongside blocks — it is the notification and fallback line.
+      GUIDE
+
+      # Blocks whose whole point is a click Slack would deliver to an interactivity
+      # request URL this deployment does not expose.
+      INTERACTIVE_BLOCK_TYPES = %w[actions input].freeze
+
+      MAX_BLOCKS = 50
+
+      private
+
+      # Reply coordinates threaded into the run by TriggerEngine#slack_run_context:
+      # channel, ts, thread_ts, team, integration_id, plus the triggering message's
+      # text and author. Empty for a run that did not start from Slack.
+      def slack_context
+        workflow_run&.shared_context.to_h["slack"] || {}
+      end
+
+      # Reply through the SAME workspace that triggered this run (its integration is
+      # carried in shared_context), so with several connected workspaces the message
+      # goes back to the right one. Falls back to any active install for the company
+      # (e.g. a run not started from Slack).
+      def slack_integration
+        return nil if project.nil?
+
+        scope = Integration.active.where(provider: :slack, company_id: project.company_id)
+
+        if (id = slack_context["integration_id"]).present?
+          by_id = scope.find_by(id: id)
+          return by_id if by_id
+        end
+
+        scope.where("project_id = :pid OR project_id IS NULL", pid: project.id)
+          .order(Arel.sql("project_id IS NULL"))
+          .first
+      end
+
+      # The install and channel a call acts on, defaulting the channel to the one
+      # that triggered the run. Returns [integration, channel, error]: on the first
+      # missing half, error is a tool error naming what is absent.
+      def resolve_slack_target(explicit_channel)
+        integration = slack_integration
+        return [ nil, nil, error("Slack is not connected for this project") ] if integration.nil?
+
+        channel = explicit_channel.presence || slack_context["channel"]
+        if channel.blank?
+          return [ integration, nil, error("No channel given, and this run was not triggered from Slack") ]
+        end
+
+        [ integration, channel, nil ]
+      end
+
+      def slack_bot_token(integration)
+        integration.credentials_data["bot_token"]
+      end
+
+      # A Slack call whose failure is the agent's to see and act on — unlike
+      # Slack::Notifier, which swallows errors so a Slack outage can never fail a
+      # run. Returns [response, error]; the Slack error code (channel_not_found,
+      # message_not_found, invalid_blocks, ...) is passed through verbatim, since
+      # that is what tells the agent which retry is worth making.
+      def slack_call
+        [ yield, nil ]
+      rescue Slack::Client::Error => e
+        [ nil, error("Slack rejected the request: #{e.message}") ]
+      end
+
+      # Normalizes the `blocks` param and catches the mistakes worth catching
+      # before they cost a Slack round-trip: a non-array, more than 50 blocks, an
+      # entry that is not a typed block object, or an interactive block nothing in
+      # this deployment could respond to. Returns [blocks, error]; blocks is [] when
+      # none were given, and nil when the entry was rejected.
+      def build_blocks
+        raw = params[:blocks]
+        return [ [], nil ] if raw.blank?
+        return [ nil, error("`blocks` must be an array of Block Kit block objects") ] unless raw.is_a?(Array)
+        return [ nil, error("`blocks` is capped at #{MAX_BLOCKS} blocks per message") ] if raw.size > MAX_BLOCKS
+
+        blocks = raw.map { |b| b.respond_to?(:to_h) ? b.to_h.with_indifferent_access : b }
+        untyped = blocks.each_index.reject { |i| blocks[i].is_a?(Hash) && blocks[i][:type].present? }
+        return [ nil, error("blocks[#{untyped.first}] is not a block object with a `type`") ] if untyped.any?
+
+        interactive = blocks.select { |b| INTERACTIVE_BLOCK_TYPES.include?(b[:type].to_s) }
+        if interactive.any?
+          return [ nil, error("Block type `#{interactive.first[:type]}` needs a Slack interactivity " \
+                              "endpoint this deployment does not run — its clicks would go nowhere. " \
+                              "Post the options as text and ask for a reply instead.") ]
+        end
+
+        [ blocks, nil ]
+      end
+    end
+  end
+end

--- a/app/services/internal_tools/slack_delete_message.rb
+++ b/app/services/internal_tools/slack_delete_message.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module InternalTools
+  # Platform tool: delete a Slack message this workflow posted, addressed by the
+  # `ts` slack_post_message returned. For retracting a message that turned out to
+  # be wrong or is superseded — prefer slack_update_message when the message
+  # should stay and only its content changed, since a delete leaves people who
+  # already read it with no correction.
+  class SlackDeleteMessage < Base
+    include Concerns::SlackContext
+
+    tool do
+      display_name "Slack Delete Message"
+      description "Delete a Slack message this workflow posted, by its `ts` (returned by slack_post_message). Only the bot's own messages can be deleted, and the deletion is permanent. Prefer slack_update_message when the message should stay and only its content is wrong. Omit `channel` to use the channel that triggered the run."
+      tags :messaging, :slack
+      inject_when :workflow_step_session
+      requires_integration :slack
+      destructive
+      input_schema({
+        type: "object",
+        required: %w[ts],
+        properties: {
+          ts: {
+            type: "string",
+            description: "Timestamp of the message to delete, e.g. 1700000000.000100. " \
+                         "Returned by slack_post_message."
+          },
+          channel: {
+            type: "string",
+            description: "Channel ID the message lives in. Defaults to the triggering channel."
+          }
+        }
+      })
+    end
+
+    def execute
+      require_workflow_context!
+
+      integration, channel, target_error = resolve_slack_target(params[:channel])
+      return target_error if target_error
+
+      _response, call_error = slack_call do
+        Slack::Client.delete_message(
+          token: slack_bot_token(integration), channel: channel, ts: params[:ts].to_s
+        )
+      end
+      call_error || success("Deleted #{params[:ts]} from #{channel}")
+    end
+  end
+end

--- a/app/services/internal_tools/slack_post_message.rb
+++ b/app/services/internal_tools/slack_post_message.rb
@@ -1,20 +1,24 @@
 # frozen_string_literal: true
 
 module InternalTools
-  # Platform tool: let a workflow agent send a Slack message. Text and files are
-  # both optional, but at least one is required — text only, files only, or both
-  # arrive as a SINGLE Slack message. Any number of files can be attached, and
-  # each one comes from exactly one source:
+  # Platform tool: let a workflow agent send a Slack message. Text, Block Kit
+  # blocks and files are each optional, but at least one is required. Any number
+  # of files can be attached, and each one comes from exactly one source:
   #   - content:   inline text the agent typed out (needs filename)
   #   - file_path: a path inside the running container — ANY file type, including
   #                binary (png, pdf, xlsx, ...) the agent just produced this step
   #   - asset_id:  a stored project asset's latest version bytes (any type)
-  # Gated on the project having an active Slack integration. Defaults the
-  # channel/thread to the message that triggered the run.
+  # Text + files still arrive as ONE message; blocks + files cannot (Slack has no
+  # way to attach files to a Block Kit message), so Slack::Notifier posts the
+  # message and hangs the files in its thread. Gated on the project having an
+  # active Slack integration. Defaults the channel/thread to the message that
+  # triggered the run.
   class SlackPostMessage < Base
+    include Concerns::SlackContext
+
     tool do
       display_name "Slack Post Message"
-      description "Send a Slack message from this workflow. `text` and `files` are both optional but at least one is required — text only, files only, or both arrive as ONE message. Attach any number of files of any type; each file entry sets EXACTLY ONE source: `content` (inline text, needs `filename`), `file_path` (a path in the running container — any type incl. binary), or `asset_id` (a project asset's bytes). Omit channel/thread to reply in the channel/thread that triggered the run. Requires a Slack integration on the project."
+      description "Send a Slack message from this workflow. `text`, `blocks` and `files` are all optional but at least one is required. `text` is plain/mrkdwn; `blocks` is Block Kit for rich layout; files can be attached in any number, each entry setting EXACTLY ONE source: `content` (inline text, needs `filename`), `file_path` (a path in the running container — any type incl. binary), or `asset_id` (a project asset's bytes). text + files arrive as one message; blocks + files send the message first and hang the files in its thread. Omit channel/thread to reply in the channel/thread that triggered the run. Returns the message `ts`, which slack_update_message and slack_delete_message address it by. Requires a Slack integration on the project."
       tags :messaging, :slack
       inject_when :workflow_step_session
       requires_integration :slack
@@ -24,7 +28,14 @@ module InternalTools
         properties: {
           text: {
             type: "string",
-            description: "Message text. Optional when files are provided."
+            description: "Message text (mrkdwn: *bold*, _italic_, `code`, <https://url|label>). " \
+                         "Optional when blocks or files are provided, but keep it set alongside " \
+                         "`blocks` — it is the notification and fallback line."
+          },
+          blocks: {
+            type: "array",
+            items: { type: "object" },
+            description: Concerns::SlackContext::BLOCK_KIT_GUIDE
           },
           files: {
             type: "array",
@@ -65,6 +76,11 @@ module InternalTools
           thread_ts: {
             type: "string",
             description: "Thread timestamp to reply into. Defaults to the triggering thread."
+          },
+          reply_broadcast: {
+            type: "boolean",
+            description: "Also surface this threaded reply in the channel, for a result everyone " \
+                         "should see. Only meaningful when replying in a thread."
           }
         }
       })
@@ -75,23 +91,37 @@ module InternalTools
 
       files, file_error = build_files
       return file_error if file_error
-      return error("Provide `text` and/or `files`") if params[:text].blank? && files.empty?
 
-      integration = slack_integration
-      return error("Slack is not connected for this project") if integration.nil?
+      blocks, blocks_error = build_blocks
+      return blocks_error if blocks_error
+      return error("Provide `text`, `blocks` and/or `files`") if params[:text].blank? && blocks.empty? && files.empty?
 
-      channel = params[:channel].presence || slack_context["channel"]
-      return error("No channel given, and this run was not triggered from Slack") if channel.blank?
+      integration, channel, target_error = resolve_slack_target(params[:channel])
+      return target_error if target_error
 
-      thread_ts = params[:thread_ts].presence || slack_context["thread_ts"]
-      sent = Slack::Notifier.post(
-        integration: integration, channel: channel,
-        text: params[:text].presence, files: files.presence, thread_ts: thread_ts
-      )
-      sent ? success("Sent to #{channel}") : error("Failed to send to Slack")
+      report(channel, Slack::Notifier.post(
+        integration: integration, channel: channel, text: params[:text].presence,
+        blocks: blocks.presence, files: files.presence,
+        thread_ts: params[:thread_ts].presence || slack_context["thread_ts"],
+        reply_broadcast: (true if params[:reply_broadcast])
+      ))
     end
 
     private
+
+    # A send that half-landed (the Block Kit message posted, the file upload did
+    # not) is reported as a failure that says what DID go out, so the agent retries
+    # the missing half instead of the whole message.
+    def report(channel, result)
+      return error("Failed to send to Slack") if result.nil?
+      return error("Partially sent to #{channel}#{ts_suffix(result)} — #{result.error_message}") unless result.ok?
+
+      success("Sent to #{channel}#{ts_suffix(result)}")
+    end
+
+    def ts_suffix(result)
+      result.ts.present? ? " (ts #{result.ts})" : ""
+    end
 
     # Resolve every files[] entry into the { filename, content, title } shape
     # Slack::Client.upload_files expects. Returns [resolved_array, error]: on the
@@ -152,29 +182,6 @@ module InternalTools
       bytes = version.file.download { |file| file.read }
       filename = f[:filename].presence || asset.name
       [ { filename: filename, content: bytes, title: title }, nil ]
-    end
-
-    def slack_context
-      workflow_run&.shared_context.to_h["slack"] || {}
-    end
-
-    # Reply through the SAME workspace that triggered this run (its integration is
-    # carried in shared_context), so with several connected workspaces the message
-    # goes back to the right one. Falls back to any active install for the company
-    # (e.g. a run not started from Slack).
-    def slack_integration
-      return nil if project.nil?
-
-      scope = Integration.active.where(provider: :slack, company_id: project.company_id)
-
-      if (id = slack_context["integration_id"]).present?
-        by_id = scope.find_by(id: id)
-        return by_id if by_id
-      end
-
-      scope.where("project_id = :pid OR project_id IS NULL", pid: project.id)
-        .order(Arel.sql("project_id IS NULL"))
-        .first
     end
   end
 end

--- a/app/services/internal_tools/slack_read_thread.rb
+++ b/app/services/internal_tools/slack_read_thread.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module InternalTools
+  # Platform tool: read the thread a run was started from (or any other thread in
+  # a channel the bot is in). Without it an agent only ever sees the single
+  # @mention that triggered it, and has no way to pick up the conversation that
+  # led to the ask.
+  #
+  # Needs a history scope for the conversation kind. The app requests
+  # channels:history and groups:history, so public and private channels work;
+  # DM threads (im:history / mpim:history) do not. Slack rate-limits
+  # conversations.replies hard for newer non-Marketplace apps — this is a tool for
+  # reading a thread once, not for polling it.
+  class SlackReadThread < Base
+    include Concerns::SlackContext
+
+    DEFAULT_LIMIT = 50
+    MAX_LIMIT = 200
+
+    tool do
+      display_name "Slack Read Thread"
+      description "Read a Slack thread: the parent message and its replies, oldest first. Call it with no arguments to read the thread this run was triggered from — the usual case, and how you recover the conversation behind the request. Returns JSON: {messages: [{ts, user, bot_id, text, files}], has_more, next_cursor}. Public and private channels only (not DMs). Read a thread once rather than polling it."
+      tags :messaging, :slack
+      inject_when :workflow_step_session
+      requires_integration :slack
+      read_only
+      input_schema({
+        type: "object",
+        required: [],
+        properties: {
+          thread_ts: {
+            type: "string",
+            description: "Timestamp of the thread's parent message. Defaults to the thread that " \
+                         "triggered this run."
+          },
+          channel: {
+            type: "string",
+            description: "Channel ID the thread lives in. Defaults to the triggering channel."
+          },
+          limit: {
+            type: "integer",
+            description: "How many messages to return, #{DEFAULT_LIMIT} by default, #{MAX_LIMIT} at most."
+          },
+          cursor: {
+            type: "string",
+            description: "Pagination cursor — pass the `next_cursor` from a previous call."
+          }
+        }
+      })
+    end
+
+    def execute
+      require_workflow_context!
+
+      integration, channel, target_error = resolve_slack_target(params[:channel])
+      return target_error if target_error
+
+      thread_ts = params[:thread_ts].presence || slack_context["thread_ts"].presence
+      return error("No thread given, and this run was not triggered from a Slack thread") if thread_ts.blank?
+
+      response, call_error = slack_call do
+        Slack::Client.conversation_replies(
+          token: slack_bot_token(integration), channel: channel, ts: thread_ts,
+          limit: limit, cursor: params[:cursor].presence
+        )
+      end
+      call_error || success(render(response))
+    end
+
+    private
+
+    def limit
+      value = params[:limit].presence&.to_i || DEFAULT_LIMIT
+      value.clamp(1, MAX_LIMIT)
+    end
+
+    def render(response)
+      {
+        messages: Array(response["messages"]).map { |m| message_fields(m) },
+        has_more: response["has_more"].present?,
+        next_cursor: response.dig("response_metadata", "next_cursor").presence
+      }.compact.to_json
+    end
+
+    # The fields an agent can act on. `bot_id` is what distinguishes our own
+    # earlier replies in the thread from what a human said.
+    def message_fields(message)
+      {
+        ts: message["ts"],
+        user: message["user"],
+        bot_id: message["bot_id"],
+        text: message["text"],
+        files: Array(message["files"]).filter_map { |f| f["name"] }.presence
+      }.compact
+    end
+  end
+end

--- a/app/services/internal_tools/slack_update_message.rb
+++ b/app/services/internal_tools/slack_update_message.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module InternalTools
+  # Platform tool: edit a Slack message this workflow already posted, addressed by
+  # the `ts` slack_post_message returned. What it buys the agent is the
+  # "working… → result" pattern: one message in the channel that fills in as the
+  # step progresses, instead of a trail of partial updates.
+  #
+  # chat.update REPLACES the message, so whatever is omitted is dropped from it —
+  # a text-only update of a Block Kit message clears its blocks. Files already
+  # shared cannot be edited; they are separate uploads.
+  class SlackUpdateMessage < Base
+    include Concerns::SlackContext
+
+    tool do
+      display_name "Slack Update Message"
+      description "Edit a Slack message this workflow posted, by its `ts` (returned by slack_post_message). Use it for a status message that fills in as the step progresses. The message is REPLACED, not merged: send everything it should end up with — a text-only update of a message that had blocks clears those blocks. Only the bot's own messages can be edited, and already-uploaded files cannot. Omit `channel` to use the channel that triggered the run."
+      tags :messaging, :slack
+      inject_when :workflow_step_session
+      requires_integration :slack
+      idempotent
+      input_schema({
+        type: "object",
+        required: %w[ts],
+        properties: {
+          ts: {
+            type: "string",
+            description: "Timestamp of the message to edit, e.g. 1700000000.000100. " \
+                         "Returned by slack_post_message."
+          },
+          text: {
+            type: "string",
+            description: "New message text (mrkdwn). Required unless `blocks` is given; " \
+                         "keep it set alongside blocks as the notification and fallback line."
+          },
+          blocks: {
+            type: "array",
+            items: { type: "object" },
+            description: Concerns::SlackContext::BLOCK_KIT_GUIDE
+          },
+          channel: {
+            type: "string",
+            description: "Channel ID the message lives in. Defaults to the triggering channel."
+          }
+        }
+      })
+    end
+
+    def execute
+      require_workflow_context!
+
+      blocks, blocks_error = build_blocks
+      return blocks_error if blocks_error
+      return error("Provide `text` and/or `blocks` to replace the message with") if params[:text].blank? && blocks.empty?
+
+      integration, channel, target_error = resolve_slack_target(params[:channel])
+      return target_error if target_error
+
+      _response, call_error = slack_call do
+        Slack::Client.update_message(
+          token: slack_bot_token(integration), channel: channel, ts: params[:ts].to_s,
+          text: params[:text].presence, blocks: blocks.presence
+        )
+      end
+      call_error || success("Updated #{params[:ts]} in #{channel}")
+    end
+  end
+end

--- a/app/services/slack/client.rb
+++ b/app/services/slack/client.rb
@@ -28,11 +28,39 @@ module Slack
       end
 
       # Post a message as the bot. `blocks` (Block Kit) and `thread_ts` (reply in
-      # a thread) are optional. Requires the chat:write scope.
-      def post_message(token:, channel:, text:, thread_ts: nil, blocks: nil)
+      # a thread) are optional; `reply_broadcast` additionally surfaces a threaded
+      # reply in the channel. Requires the chat:write scope. Returns the posted
+      # message's coordinates — `ts` is what chat.update/chat.delete address later.
+      def post_message(token:, channel:, text:, thread_ts: nil, blocks: nil, reply_broadcast: nil)
         post_json("chat.postMessage", token: token, payload: {
-          channel: channel, text: text, thread_ts: thread_ts, blocks: blocks
+          channel: channel, text: text, thread_ts: thread_ts, blocks: blocks,
+          reply_broadcast: reply_broadcast
         }.compact)
+      end
+
+      # Edit a message the bot posted, addressed by its `ts`. Slack replaces the
+      # whole message: fields left nil are dropped from it, so a text-only update
+      # of a Block Kit message clears its blocks. Requires the chat:write scope.
+      def update_message(token:, channel:, ts:, text: nil, blocks: nil)
+        post_json("chat.update", token: token, payload: {
+          channel: channel, ts: ts, text: text, blocks: blocks
+        }.compact)
+      end
+
+      # Delete a message the bot posted. Requires the chat:write scope.
+      def delete_message(token:, channel:, ts:)
+        post("chat.delete", token: token, params: { channel: channel, ts: ts })
+      end
+
+      # Read a thread: the parent message plus its replies, oldest first. `ts` is
+      # the thread parent's timestamp (Slack's own argument name — not thread_ts).
+      # Requires a history scope for the conversation kind (channels:history for
+      # public channels, groups:history for private ones; DM threads would need
+      # im:history / mpim:history, which this app does not request).
+      def conversation_replies(token:, channel:, ts:, limit: nil, cursor: nil)
+        post("conversations.replies", token: token, params: {
+          channel: channel, ts: ts, limit: limit, cursor: cursor
+        })
       end
 
       # Upload one or more files and share them in a SINGLE Slack message. Each

--- a/app/services/slack/notifier.rb
+++ b/app/services/slack/notifier.rb
@@ -5,27 +5,79 @@ module Slack
   # design: a missing/inactive integration or a Slack outage is logged and
   # swallowed, never raised into the workflow that triggered the reply.
   class Notifier
+    # What a send produced. `ts` is the posted message's timestamp — the handle
+    # slack_update_message / slack_delete_message address it by, and the thread
+    # parent for anything the agent wants to hang under it.
+    #
+    # Returned only when SOMETHING reached Slack; `post` answers nil when nothing
+    # did, so callers can keep treating the return value as a plain success flag.
+    # A send that is half-delivered (the Block Kit message landed, the file upload
+    # did not) comes back as a Result carrying `errors` — check `ok?`, not
+    # truthiness, when the difference matters.
+    Result = Struct.new(:channel, :ts, :thread_ts, :errors, :delivered, keyword_init: true) do
+      def ok? = errors.empty?
+
+      def error_message = errors.join("; ")
+    end
+
     class << self
-      # Send one Slack message with optional text and/or file attachments. When
-      # files are present they're uploaded and shared together with `text` as a
-      # single message; otherwise a plain chat.postMessage is sent.
-      def post(integration:, channel:, text: nil, files: nil, thread_ts: nil, blocks: nil)
-        return false if integration.nil? || channel.blank?
-        return false if text.blank? && files.blank?
+      # Send one Slack message with any mix of text, Block Kit blocks and file
+      # attachments. Returns a Result, or nil when nothing was sent at all.
+      def post(integration:, channel:, text: nil, files: nil, thread_ts: nil, blocks: nil, reply_broadcast: nil)
+        return nil if integration.nil? || channel.blank?
+        return nil if text.blank? && files.blank? && blocks.blank?
 
         token = integration.credentials_data["bot_token"]
-        return false if token.blank?
+        return nil if token.blank?
+
+        deliver(token, Result.new(channel: channel, thread_ts: thread_ts, errors: [], delivered: 0),
+          text: text, files: files, blocks: blocks, reply_broadcast: reply_broadcast)
+      end
+
+      private
+
+      # Slack has no way to attach files to a Block Kit message, so blocks + files
+      # go out as TWO requests: the message first, then the files into that
+      # message's own thread, which keeps them together in the channel. Without
+      # blocks nothing changes — text and files still ship as one upload.
+      def deliver(token, result, text:, files:, blocks:, reply_broadcast:)
+        if blocks.present? || files.blank?
+          send_chat(token, result, text: text, blocks: blocks, reply_broadcast: reply_broadcast)
+        end
 
         if files.present?
-          Slack::Client.upload_files(token: token, channel: channel, files: files,
-            initial_comment: text, thread_ts: thread_ts)
-        else
-          Slack::Client.post_message(token: token, channel: channel, text: text, thread_ts: thread_ts, blocks: blocks)
+          # Text already carried by the message above would only be repeated here;
+          # when that message failed to send, the upload becomes its fallback.
+          send_files(token, result, files: files, initial_comment: result.ts ? nil : text)
         end
-        true
+
+        result.delivered.zero? ? nil : result
+      end
+
+      def send_chat(token, result, text:, blocks:, reply_broadcast:)
+        response = Slack::Client.post_message(
+          token: token, channel: result.channel, text: text, thread_ts: result.thread_ts,
+          blocks: blocks, reply_broadcast: reply_broadcast
+        )
+        result.ts = response["ts"]
+        result.delivered += 1
       rescue Slack::Client::Error => e
-        Rails.logger.warn("[Slack::Notifier] post failed: #{e.message}")
-        false
+        record_failure(result, "message", e)
+      end
+
+      def send_files(token, result, files:, initial_comment:)
+        Slack::Client.upload_files(
+          token: token, channel: result.channel, files: files,
+          initial_comment: initial_comment.presence, thread_ts: result.thread_ts || result.ts
+        )
+        result.delivered += 1
+      rescue Slack::Client::Error => e
+        record_failure(result, "files", e)
+      end
+
+      def record_failure(result, what, error)
+        Rails.logger.warn("[Slack::Notifier] #{what} failed: #{error.message}")
+        result.errors << "#{what}: #{error.message}"
       end
     end
   end

--- a/app/services/slack/run_failure_notifier.rb
+++ b/app/services/slack/run_failure_notifier.rb
@@ -30,7 +30,7 @@ module Slack
           channel: channel,
           thread_ts: slack["thread_ts"],
           text: message_for(run)
-        )
+        ).present?
       rescue StandardError => e
         Rails.logger.error("[Slack::RunFailureNotifier] run ##{run&.id}: #{e.message}")
         false

--- a/app/services/trigger_engine.rb
+++ b/app/services/trigger_engine.rb
@@ -343,6 +343,10 @@ class TriggerEngine
 
       slack = {
         "channel" => event.data["channel"],
+        # Both, and they differ: `ts` is the message that mentioned us, `thread_ts`
+        # the thread it belongs to. Replies default to the thread; `ts` is what an
+        # agent needs to point at that one message inside it.
+        "ts" => event.data["ts"],
         "thread_ts" => event.data["thread_ts"] || event.data["ts"],
         "team" => event.data["team"],
         "integration_id" => event.data["integration_id"],

--- a/test/jobs/webhooks/process_event_job_test.rb
+++ b/test/jobs/webhooks/process_event_job_test.rb
@@ -108,7 +108,7 @@ module Webhooks
         has_entries(
           workflow: @workflow,
           shared_context: has_entries(
-            "slack" => has_entries("channel" => "C1", "thread_ts" => "111.222",
+            "slack" => has_entries("channel" => "C1", "ts" => "111.222", "thread_ts" => "111.222",
                                    "team" => "T1", "integration_id" => integration.id,
                                    "text" => "run report", "user" => "U1")
           )
@@ -122,6 +122,27 @@ module Webhooks
       assert_equal "F1", event.data.dig("files", 0, "id")
       assert_nil event.data.dig("files", 0, "extra") # only whitelisted file fields kept
       assert_equal integration.id, event.data["integration_id"]
+    end
+
+    test "a mention inside a thread carries both the message ts and its thread" do
+      payload = {
+        "type" => "event_callback", "event_id" => "EvThread", "team_id" => "T1",
+        "event" => {
+          "type" => "app_mention", "channel" => "C1", "user" => "U1", "text" => "and this?",
+          "ts" => "222.333", "thread_ts" => "111.222"
+        }
+      }
+      rw = received(payload, key: "EvThread")
+
+      WorkflowService.expects(:start).with(
+        has_entries(
+          shared_context: has_entries(
+            "slack" => has_entries("ts" => "222.333", "thread_ts" => "111.222")
+          )
+        )
+      ).once.returns(build(:workflow_run))
+
+      Webhooks::ProcessEventJob.perform_now(rw.id)
     end
 
     test "ingests Slack attachments into the matching binding's project at fire time" do

--- a/test/services/internal_tools/slack_message_tools_test.rb
+++ b/test/services/internal_tools/slack_message_tools_test.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The Slack tools that act on a message that already exists: editing it, deleting
+# it, and reading the thread it lives in. Posting is covered by
+# InternalTools::SlackPostMessageTest.
+class InternalTools::SlackMessageToolsTest < ActiveSupport::TestCase
+  setup do
+    @company = create(:company)
+    @user = create(:user, company: @company)
+    @project = create(:project, company: @company, owner: @user)
+    @integration = Integration.create!(
+      provider: :slack, company: @company, project: @project, connected_by: @user,
+      name: "Acme", status: :active
+    )
+    @integration.update!(credentials_data: { "bot_token" => "xoxb-1", "team_id" => "T1" })
+
+    workflow = create(:workflow, scope: @project)
+    step = create(:step, workflow: workflow)
+    @workflow_run = create(:workflow_run, workflow: workflow, project: @project, user: @user,
+      shared_context: { "slack" => {
+        "channel" => "C1", "ts" => "111.5", "thread_ts" => "111.2", "integration_id" => @integration.id
+      } })
+    @step_run = create(:step_run, workflow_run: @workflow_run, step: step)
+    @session = create(:terminal_session, :running, :agent_session,
+      user: @user, project: @project, mode: "non_interactive", initial_prompt: "x")
+    @step_run.update!(terminal_session: @session)
+    @session.reload
+
+    stub_slack_client!
+  end
+
+  def update(params) = InternalTools::SlackUpdateMessage.new(params: params, session: @session).execute
+  def delete(params) = InternalTools::SlackDeleteMessage.new(params: params, session: @session).execute
+  def read_thread(params = {}) = InternalTools::SlackReadThread.new(params: params, session: @session).execute
+
+  # --- slack_update_message --------------------------------------------------
+
+  test "update edits the message in the triggering channel by default" do
+    result = update(ts: "111.9", text: "done")
+    assert_equal 0, result[:exit_code]
+
+    edit = fake_slack.last_updated_message
+    assert_equal "xoxb-1", edit[:token]
+    assert_equal "C1", edit[:channel]
+    assert_equal "111.9", edit[:ts]
+    assert_equal "done", edit[:text]
+    assert_nil edit[:blocks]
+  end
+
+  test "update replaces the message with blocks when given" do
+    blocks = [ { "type" => "markdown", "text" => "**done**" } ]
+    assert_equal 0, update(ts: "111.9", text: "done", channel: "C2", blocks: blocks)[:exit_code]
+
+    edit = fake_slack.last_updated_message
+    assert_equal "C2", edit[:channel]
+    assert_equal blocks, edit[:blocks].map(&:to_h)
+  end
+
+  test "update needs something to replace the message with" do
+    result = update(ts: "111.9")
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "Provide `text` and/or `blocks`"
+    assert_empty fake_slack.updated_messages
+  end
+
+  test "update rejects interactive blocks like posting does" do
+    result = update(ts: "111.9", blocks: [ { "type" => "actions", "elements" => [] } ])
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "interactivity endpoint"
+    assert_empty fake_slack.updated_messages
+  end
+
+  test "update surfaces the Slack error code to the agent" do
+    fake_slack.stubs(:update_message).raises(Slack::Client::Error.new("message_not_found"))
+
+    result = update(ts: "111.9", text: "done")
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "message_not_found"
+  end
+
+  test "update errors when Slack is not connected" do
+    @integration.update!(status: :inactive)
+
+    result = update(ts: "111.9", text: "done")
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "Slack is not connected"
+    assert_empty fake_slack.updated_messages
+  end
+
+  # --- slack_delete_message --------------------------------------------------
+
+  test "delete removes the message from the triggering channel by default" do
+    result = delete(ts: "111.9")
+    assert_equal 0, result[:exit_code]
+
+    removed = fake_slack.last_deleted_message
+    assert_equal "xoxb-1", removed[:token]
+    assert_equal "C1", removed[:channel]
+    assert_equal "111.9", removed[:ts]
+  end
+
+  test "delete uses an explicit channel when given" do
+    assert_equal 0, delete(ts: "111.9", channel: "C2")[:exit_code]
+
+    assert_equal "C2", fake_slack.last_deleted_message[:channel]
+  end
+
+  test "delete surfaces the Slack error code to the agent" do
+    fake_slack.stubs(:delete_message).raises(Slack::Client::Error.new("cant_delete_message"))
+
+    result = delete(ts: "111.9")
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "cant_delete_message"
+  end
+
+  test "delete errors when no channel is known" do
+    @workflow_run.update!(shared_context: {})
+
+    result = delete(ts: "111.9")
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "No channel"
+    assert_empty fake_slack.deleted_messages
+  end
+
+  # --- slack_read_thread -----------------------------------------------------
+
+  test "read_thread reads the triggering thread with no arguments" do
+    result = read_thread
+    assert_equal 0, result[:exit_code]
+
+    read = fake_slack.last_replies_read
+    assert_equal "C1", read[:channel]
+    assert_equal "111.2", read[:ts] # the thread, not the message that mentioned us
+    assert_equal 50, read[:limit]
+
+    payload = JSON.parse(result[:stdout])
+    assert_equal 2, payload["messages"].size
+    assert_equal "1700000000.000100", payload.dig("messages", 0, "ts")
+    assert_equal "U00USER000", payload.dig("messages", 0, "user")
+    assert_equal "B00000000", payload.dig("messages", 1, "bot_id")
+    assert_not payload["has_more"]
+    assert_nil payload["next_cursor"]
+  end
+
+  test "read_thread takes an explicit channel, thread and cursor" do
+    assert_equal 0, read_thread(channel: "C2", thread_ts: "222.1", cursor: "page-2")[:exit_code]
+
+    read = fake_slack.last_replies_read
+    assert_equal "C2", read[:channel]
+    assert_equal "222.1", read[:ts]
+    assert_equal "page-2", read[:cursor]
+  end
+
+  test "read_thread clamps the limit to what Slack will serve" do
+    read_thread(limit: 500)
+    assert_equal 200, fake_slack.last_replies_read[:limit]
+
+    read_thread(limit: 0)
+    assert_equal 1, fake_slack.last_replies_read[:limit]
+  end
+
+  test "read_thread reports the cursor when the thread is longer than the page" do
+    result = read_thread(limit: 1)
+
+    payload = JSON.parse(result[:stdout])
+    assert_equal 1, payload["messages"].size
+    assert payload["has_more"]
+    assert_equal "fake-cursor-1", payload["next_cursor"]
+  end
+
+  test "read_thread lists the names of files shared in the thread" do
+    fake_slack.thread_messages = [
+      { "ts" => "1.1", "user" => "U1", "text" => "see this",
+        "files" => [ { "id" => "F1", "name" => "spec.pdf" } ] }
+    ]
+
+    payload = JSON.parse(read_thread[:stdout])
+
+    assert_equal [ "spec.pdf" ], payload.dig("messages", 0, "files")
+  end
+
+  test "read_thread errors when the run did not come from a Slack thread" do
+    @workflow_run.update!(shared_context: { "slack" => { "channel" => "C1" } })
+
+    result = read_thread
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "No thread given"
+    assert_empty fake_slack.replies_reads
+  end
+
+  test "read_thread surfaces the Slack error code to the agent" do
+    fake_slack.stubs(:conversation_replies).raises(Slack::Client::Error.new("thread_not_found"))
+
+    result = read_thread
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "thread_not_found"
+  end
+end

--- a/test/services/internal_tools/slack_post_message_test.rb
+++ b/test/services/internal_tools/slack_post_message_test.rb
@@ -51,10 +51,10 @@ class InternalTools::SlackPostMessageTest < ActiveSupport::TestCase
     assert_equal "999", msg[:thread_ts]
   end
 
-  test "errors when neither text nor files are given" do
+  test "errors when neither text, blocks nor files are given" do
     result = run_tool(text: "")
     assert_equal 1, result[:exit_code]
-    assert_includes result[:stderr], "text` and/or `files"
+    assert_includes result[:stderr], "Provide `text`, `blocks` and/or `files`"
 
     assert_empty fake_slack.posted_messages
     assert_empty fake_slack.uploaded_files
@@ -188,6 +188,101 @@ class InternalTools::SlackPostMessageTest < ActiveSupport::TestCase
     assert_includes result[:stderr], "No channel"
 
     assert_empty fake_slack.posted_messages
+  end
+
+  # --- Block Kit -------------------------------------------------------------
+
+  MARKDOWN_BLOCK = { "type" => "markdown", "text" => "## Report\n\n- one\n- two" }.freeze
+
+  test "sends Block Kit blocks with the text as the fallback line" do
+    assert_equal 0, run_tool(text: "Report ready", blocks: [ MARKDOWN_BLOCK ])[:exit_code]
+
+    msg = fake_slack.last_posted_message
+    assert_equal "Report ready", msg[:text]
+    assert_equal [ MARKDOWN_BLOCK ], msg[:blocks].map(&:to_h)
+    assert_empty fake_slack.uploaded_files
+  end
+
+  test "reports the posted ts so the message can be edited later" do
+    result = run_tool(text: "hi")
+
+    assert_equal 0, result[:exit_code]
+    assert_includes result[:stdout], "ts #{fake_slack.last_posted_message_ts}"
+  end
+
+  test "sends blocks and files as a message plus an upload into the same thread" do
+    result = run_tool(text: "Report ready", blocks: [ MARKDOWN_BLOCK ],
+      files: [ { "filename" => "report.csv", "content" => "a,b" } ])
+    assert_equal 0, result[:exit_code]
+
+    assert_equal 1, fake_slack.posted_messages.size
+    assert_equal 1, fake_slack.uploaded_files.size
+    assert_equal "111.2", fake_slack.last_uploaded_files[:thread_ts]
+    # The text rode on the block message; repeating it above the files would double it.
+    assert_nil fake_slack.last_uploaded_files[:initial_comment]
+  end
+
+  test "hangs the files under the block message when the run has no thread" do
+    @workflow_run.update!(shared_context: { "slack" => { "channel" => "C1", "integration_id" => @integration.id } })
+
+    assert_equal 0, run_tool(blocks: [ MARKDOWN_BLOCK ],
+      files: [ { "filename" => "a.txt", "content" => "x" } ])[:exit_code]
+
+    assert_equal fake_slack.last_posted_message_ts, fake_slack.last_uploaded_files[:thread_ts]
+  end
+
+  test "reports a partial send when the message lands but the upload fails" do
+    fake_slack.stubs(:upload_files).raises(Slack::Client::Error.new("upload_failed"))
+
+    result = run_tool(text: "Report ready", blocks: [ MARKDOWN_BLOCK ],
+      files: [ { "filename" => "a.txt", "content" => "x" } ])
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "Partially sent to C1"
+    assert_includes result[:stderr], "upload_failed"
+    assert_equal 1, fake_slack.posted_messages.size
+  end
+
+  test "broadcasts a threaded reply to the channel when asked" do
+    assert_equal 0, run_tool(text: "done", reply_broadcast: true)[:exit_code]
+
+    assert fake_slack.last_posted_message[:reply_broadcast]
+  end
+
+  test "leaves reply_broadcast unset when it was not asked for" do
+    assert_equal 0, run_tool(text: "done")[:exit_code]
+
+    assert_nil fake_slack.last_posted_message[:reply_broadcast]
+  end
+
+  test "rejects interactive blocks this deployment cannot answer" do
+    result = run_tool(text: "pick one", blocks: [ { "type" => "actions", "elements" => [] } ])
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "interactivity endpoint"
+    assert_empty fake_slack.posted_messages
+  end
+
+  test "rejects more blocks than Slack accepts in one message" do
+    result = run_tool(text: "x", blocks: Array.new(51) { { "type" => "divider" } })
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "capped at 50"
+    assert_empty fake_slack.posted_messages
+  end
+
+  test "rejects blocks that are not typed block objects" do
+    assert_includes run_tool(text: "x", blocks: "not-an-array")[:stderr], "must be an array"
+    assert_includes run_tool(text: "x", blocks: [ { "text" => "no type" } ])[:stderr], "blocks[0]"
+
+    assert_empty fake_slack.posted_messages
+  end
+
+  test "can send blocks with no text at all" do
+    assert_equal 0, run_tool(blocks: [ MARKDOWN_BLOCK ])[:exit_code]
+
+    assert_equal 1, fake_slack.posted_messages.size
+    assert_nil fake_slack.last_posted_message[:text]
   end
 
   test "replies through the workspace that triggered the run (by integration_id)" do

--- a/test/services/slack/client_contract_test.rb
+++ b/test/services/slack/client_contract_test.rb
@@ -91,6 +91,101 @@ module Slack
       assert_match(/channel_not_found/, error.message)
     end
 
+    test "post_message sends blocks and reply_broadcast when given" do
+      blocks = [ { "type" => "markdown", "text" => "**hi**" } ]
+      expected = @fake.post_message(token: BOT_TOKEN, channel: "C1", text: "hi", blocks: blocks)
+      stub = stub_request(:post, "#{API}/chat.postMessage")
+        .with(body: hash_including(
+          "blocks" => blocks, "reply_broadcast" => true, "thread_ts" => "5.5"
+        ))
+        .to_return(json(expected))
+
+      Slack::Client.post_message(token: BOT_TOKEN, channel: "C1", text: "hi", thread_ts: "5.5",
+        blocks: blocks, reply_broadcast: true)
+
+      assert_requested stub
+    end
+
+    # --- chat.update -----------------------------------------------------------
+
+    test "update_message posts JSON and parses into the fake's shape" do
+      blocks = [ { "type" => "section", "text" => { "type" => "mrkdwn", "text" => "done" } } ]
+      expected = @fake.update_message(token: BOT_TOKEN, channel: "C1", ts: "5.5", text: "done", blocks: blocks)
+      stub = stub_request(:post, "#{API}/chat.update")
+        .with(
+          headers: { "Authorization" => "Bearer #{BOT_TOKEN}", "Content-Type" => "application/json; charset=utf-8" },
+          body: hash_including("channel" => "C1", "ts" => "5.5", "text" => "done", "blocks" => blocks)
+        )
+        .to_return(json(expected))
+
+      actual = Slack::Client.update_message(token: BOT_TOKEN, channel: "C1", ts: "5.5",
+        text: "done", blocks: blocks)
+
+      assert_equal expected, actual
+      assert_equal "5.5", actual["ts"]
+      assert_requested stub
+    end
+
+    test "update_message raises Slack::Client::Error on an ok:false body" do
+      stub_request(:post, "#{API}/chat.update").to_return(json(ok: false, error: "message_not_found"))
+
+      error = assert_raises(Slack::Client::Error) do
+        Slack::Client.update_message(token: BOT_TOKEN, channel: "C1", ts: "5.5", text: "x")
+      end
+      assert_match(/message_not_found/, error.message)
+    end
+
+    # --- chat.delete -----------------------------------------------------------
+
+    test "delete_message posts the form and parses into the fake's shape" do
+      expected = @fake.delete_message(token: BOT_TOKEN, channel: "C1", ts: "5.5")
+      stub = stub_request(:post, "#{API}/chat.delete")
+        .with(headers: { "Authorization" => "Bearer #{BOT_TOKEN}" },
+              body: hash_including("channel" => "C1", "ts" => "5.5"))
+        .to_return(json(expected))
+
+      actual = Slack::Client.delete_message(token: BOT_TOKEN, channel: "C1", ts: "5.5")
+
+      assert_equal expected, actual
+      assert_requested stub
+    end
+
+    test "delete_message raises Slack::Client::Error on an ok:false body" do
+      stub_request(:post, "#{API}/chat.delete").to_return(json(ok: false, error: "cant_delete_message"))
+
+      error = assert_raises(Slack::Client::Error) do
+        Slack::Client.delete_message(token: BOT_TOKEN, channel: "C1", ts: "5.5")
+      end
+      assert_match(/cant_delete_message/, error.message)
+    end
+
+    # --- conversations.replies -------------------------------------------------
+
+    test "conversation_replies sends ts (not thread_ts) and parses into the fake's shape" do
+      expected = @fake.conversation_replies(token: BOT_TOKEN, channel: "C1", ts: "1700000000.000100")
+      stub = stub_request(:post, "#{API}/conversations.replies")
+        .with(headers: { "Authorization" => "Bearer #{BOT_TOKEN}" },
+              body: hash_including("channel" => "C1", "ts" => "1700000000.000100", "limit" => "50"))
+        .to_return(json(expected))
+
+      actual = Slack::Client.conversation_replies(token: BOT_TOKEN, channel: "C1",
+        ts: "1700000000.000100", limit: 50)
+
+      assert_equal expected, actual
+      assert_equal 2, actual["messages"].size
+      assert_equal "1700000000.000100", actual.dig("messages", 0, "ts")
+      assert_requested stub
+    end
+
+    test "conversation_replies raises Slack::Client::Error on an ok:false body" do
+      stub_request(:post, "#{API}/conversations.replies").to_return(json(ok: false, error: "thread_not_found"))
+
+      error = assert_raises(Slack::Client::Error) do
+        Slack::Client.conversation_replies(token: BOT_TOKEN, channel: "C1", ts: "1.1")
+      end
+      assert_match(/thread_not_found/, error.message)
+    end
+
     # --- files: getUploadURLExternal -> PUT bytes -> completeUploadExternal ----
 
     test "upload_files runs the external-upload flow and returns completeUpload's shape" do

--- a/test/services/slack/notifier_test.rb
+++ b/test/services/slack/notifier_test.rb
@@ -62,10 +62,87 @@ module Slack
       assert_empty fake_slack.posted_messages
     end
 
-    test "post swallows Slack API errors and returns false" do
+    test "post swallows Slack API errors and returns nothing" do
       fake_slack.stubs(:post_message).raises(Slack::Client::Error.new("channel_not_found"))
 
       assert_not Slack::Notifier.post(integration: @integration, channel: "C1", text: "hi")
+    end
+
+    test "post returns the posted message's coordinates" do
+      result = Slack::Notifier.post(integration: @integration, channel: "C1", text: "hi", thread_ts: "5.5")
+
+      assert result.ok?
+      assert_equal "C1", result.channel
+      assert_equal "5.5", result.thread_ts
+      assert_equal fake_slack.last_posted_message_ts, result.ts
+      assert_empty result.errors
+    end
+
+    test "post sends blocks and reply_broadcast through to the client" do
+      blocks = [ { "type" => "divider" } ]
+
+      assert Slack::Notifier.post(integration: @integration, channel: "C1", text: "hi",
+        blocks: blocks, thread_ts: "5.5", reply_broadcast: true)
+
+      msg = fake_slack.last_posted_message
+      assert_equal blocks, msg[:blocks]
+      assert msg[:reply_broadcast]
+    end
+
+    test "post with blocks AND files sends the message, then the files into its thread" do
+      result = Slack::Notifier.post(integration: @integration, channel: "C1", text: "hi",
+        blocks: [ { "type" => "divider" } ], files: [ { filename: "a.rb", content: "x" } ])
+
+      assert result.ok?
+      assert_equal 1, fake_slack.posted_messages.size
+      assert_equal 1, fake_slack.uploaded_files.size
+      assert_equal result.ts, fake_slack.last_uploaded_files[:thread_ts]
+      assert_nil fake_slack.last_uploaded_files[:initial_comment]
+    end
+
+    test "post with blocks and files keeps an explicit thread for both" do
+      Slack::Notifier.post(integration: @integration, channel: "C1", text: "hi", thread_ts: "5.5",
+        blocks: [ { "type" => "divider" } ], files: [ { filename: "a.rb", content: "x" } ])
+
+      assert_equal "5.5", fake_slack.last_posted_message[:thread_ts]
+      assert_equal "5.5", fake_slack.last_uploaded_files[:thread_ts]
+    end
+
+    test "post reports a half-delivered send instead of swallowing it" do
+      fake_slack.stubs(:upload_files).raises(Slack::Client::Error.new("upload_failed"))
+
+      result = Slack::Notifier.post(integration: @integration, channel: "C1", text: "hi",
+        blocks: [ { "type" => "divider" } ], files: [ { filename: "a.rb", content: "x" } ])
+
+      assert_not result.ok?
+      assert result.ts.present?
+      assert_match(/files: upload_failed/, result.error_message)
+    end
+
+    test "post falls back to carrying the text on the upload when the message fails" do
+      fake_slack.stubs(:post_message).raises(Slack::Client::Error.new("invalid_blocks"))
+
+      result = Slack::Notifier.post(integration: @integration, channel: "C1", text: "hi",
+        blocks: [ { "type" => "divider" } ], files: [ { filename: "a.rb", content: "x" } ])
+
+      assert_not result.ok?
+      assert_nil result.ts
+      assert_equal "hi", fake_slack.last_uploaded_files[:initial_comment]
+    end
+
+    test "post returns nothing when every request fails" do
+      fake_slack.stubs(:post_message).raises(Slack::Client::Error.new("invalid_blocks"))
+      fake_slack.stubs(:upload_files).raises(Slack::Client::Error.new("upload_failed"))
+
+      assert_not Slack::Notifier.post(integration: @integration, channel: "C1", text: "hi",
+        blocks: [ { "type" => "divider" } ], files: [ { filename: "a.rb", content: "x" } ])
+    end
+
+    test "post sends blocks with no text at all" do
+      assert Slack::Notifier.post(integration: @integration, channel: "C1",
+        blocks: [ { "type" => "divider" } ])
+
+      assert_equal 1, fake_slack.posted_messages.size
     end
   end
 end

--- a/test/services/tools/registry_test.rb
+++ b/test/services/tools/registry_test.rb
@@ -47,7 +47,7 @@ class Tools::RegistryTest < ActiveSupport::TestCase
     defs = Tools::Registry.definitions.values
 
     assert_equal 30, defs.count { |d| d.tags.include?(:builder) }
-    assert_equal 19, defs.count { |d| d.inject_rules.include?(:workflow_step_session) }
+    assert_equal 22, defs.count { |d| d.inject_rules.include?(:workflow_step_session) }
     assert_equal 3, defs.count { |d| d.inject_rules.intersect?(%i[container_tools_present non_interactive_session]) }
   end
 end

--- a/test/support/fakes/fake_slack_client.rb
+++ b/test/support/fakes/fake_slack_client.rb
@@ -2,13 +2,15 @@
 
 # In-memory fake for the Slack boundary. A real object implementing
 # Slack::Client's public class-method interface (exchange_code, auth_test,
-# post_message, upload_files, download_file) as INSTANCE methods (R3,
-# docs/testing.md §4). Callers stub Slack::Client onto one of these via
+# post_message, update_message, delete_message, conversation_replies,
+# upload_files, download_file) as INSTANCE methods (R3, docs/testing.md §4).
+# Callers stub Slack::Client onto one of these via
 # SlackTestHelper#stub_slack_client!.
 #
 # Every method records its call so tests can assert what was sent
-# (`oauth_exchanges`, `auth_tests`, `posted_messages`, `uploaded_files`,
-# `downloads`) and returns a realistic canned response whose SHAPE matches what
+# (`oauth_exchanges`, `auth_tests`, `posted_messages`, `updated_messages`,
+# `deleted_messages`, `replies_reads`, `uploaded_files`, `downloads`) and returns
+# a realistic canned response whose SHAPE matches what
 # the real Slack::Client parses out of the Slack Web API — string-keyed hashes
 # for the JSON endpoints, a raw String for download_file. That shape equality is
 # pinned by test/services/slack/client_contract_test.rb (R4): change a canned
@@ -23,18 +25,38 @@ class FakeSlackClient
   DEFAULT_FILE_BODY = "fake slack file bytes"
   WORKSPACE_HOST    = "fake-workspace.slack.com"
 
-  attr_reader :oauth_exchanges, :auth_tests, :posted_messages, :uploaded_files, :downloads
+  # A two-message thread: a human's @mention and the bot's reply to it. Shaped
+  # like conversations.replies returns them, down to `thread_ts` on both and the
+  # parent's reply bookkeeping.
+  DEFAULT_THREAD_PARENT = {
+    "type" => "message", "user" => "U00USER000", "text" => "<@U0BOTFAKE0> ship the report",
+    "ts" => "1700000000.000100", "thread_ts" => "1700000000.000100",
+    "reply_count" => 1, "replies" => [ { "user" => "U0BOTFAKE0", "ts" => "1700000000.000200" } ]
+  }.freeze
+  DEFAULT_THREAD_REPLY = {
+    "type" => "message", "subtype" => "bot_message", "text" => "On it.",
+    "ts" => "1700000000.000200", "thread_ts" => "1700000000.000100", "bot_id" => DEFAULT_BOT_ID
+  }.freeze
+
+  attr_reader :oauth_exchanges, :auth_tests, :posted_messages, :uploaded_files, :downloads,
+              :updated_messages, :deleted_messages, :replies_reads
   # Let a test tailor the shared canned values (e.g. a specific team_id) without
   # reaching into the response builders.
   attr_accessor :team_id, :team_name, :bot_token, :bot_user_id, :scope, :file_body
+  # The thread conversations.replies hands back, so a test can stage a thread
+  # without knowing the wire shape. Each entry is a Slack message hash.
+  attr_accessor :thread_messages
 
   def initialize
-    @oauth_exchanges = []
-    @auth_tests      = []
-    @posted_messages = []
-    @uploaded_files  = []
-    @downloads       = []
-    @seq             = 0
+    @oauth_exchanges  = []
+    @auth_tests       = []
+    @posted_messages  = []
+    @uploaded_files   = []
+    @downloads        = []
+    @updated_messages = []
+    @deleted_messages = []
+    @replies_reads    = []
+    @seq              = 0
 
     @team_id     = DEFAULT_TEAM_ID
     @team_name   = DEFAULT_TEAM_NAME
@@ -42,6 +64,8 @@ class FakeSlackClient
     @bot_user_id = DEFAULT_BOT_USER
     @scope       = DEFAULT_SCOPE
     @file_body   = DEFAULT_FILE_BODY
+
+    @thread_messages = [ DEFAULT_THREAD_PARENT, DEFAULT_THREAD_REPLY ]
   end
 
   # --- Slack::Client public interface (JSON endpoints return string-keyed hashes) ---
@@ -79,13 +103,16 @@ class FakeSlackClient
     }
   end
 
-  # chat.postMessage — { ok, channel, ts, message }. Slack::Notifier only checks
-  # that this does not raise (truthy return), so the exact shape matters only for
-  # the contract pin.
-  def post_message(token:, channel:, text: nil, thread_ts: nil, blocks: nil)
+  # chat.postMessage — { ok, channel, ts, message }. Slack::Notifier reads `ts`
+  # out of this to address the message later and to thread file uploads under it.
+  def post_message(token:, channel:, text: nil, thread_ts: nil, blocks: nil, reply_broadcast: nil)
     ts = next_ts
+    # `ts` is the one value here that is a RESPONSE rather than a request field;
+    # recorded alongside so a test can assert what the caller did with the
+    # timestamp it got back (thread a follow-up under it, report it to the agent).
     @posted_messages << {
-      token: token, channel: channel, text: text, thread_ts: thread_ts, blocks: blocks
+      token: token, channel: channel, text: text, thread_ts: thread_ts, blocks: blocks,
+      reply_broadcast: reply_broadcast, ts: ts
     }
     {
       "ok"      => true,
@@ -128,6 +155,46 @@ class FakeSlackClient
     }
   end
 
+  # chat.update — { ok, channel, ts, text, message }. Slack echoes back the edited
+  # message, so `ts` is the one that was addressed, not a new one.
+  def update_message(token:, channel:, ts:, text: nil, blocks: nil)
+    @updated_messages << {
+      token: token, channel: channel, ts: ts, text: text, blocks: blocks
+    }
+    {
+      "ok"      => true,
+      "channel" => channel,
+      "ts"      => ts,
+      "text"    => text.to_s,
+      "message" => {
+        "type" => "message", "subtype" => "bot_message", "text" => text.to_s,
+        "ts" => ts, "bot_id" => DEFAULT_BOT_ID
+      }.merge(blocks ? { "blocks" => blocks } : {})
+    }
+  end
+
+  # chat.delete — { ok, channel, ts }.
+  def delete_message(token:, channel:, ts:)
+    @deleted_messages << { token: token, channel: channel, ts: ts }
+    { "ok" => true, "channel" => channel, "ts" => ts }
+  end
+
+  # conversations.replies — { ok, messages, has_more, response_metadata }. Returns
+  # `thread_messages` (the parent plus its replies, oldest first), truncated to
+  # `limit` with has_more set when there is more behind it.
+  def conversation_replies(token:, channel:, ts:, limit: nil, cursor: nil)
+    @replies_reads << { token: token, channel: channel, ts: ts, limit: limit, cursor: cursor }
+
+    messages = thread_messages.map(&:dup)
+    page = limit ? messages.first(limit) : messages
+    has_more = page.size < messages.size
+    {
+      "ok"       => true,
+      "messages" => page,
+      "has_more" => has_more
+    }.merge(has_more ? { "response_metadata" => { "next_cursor" => "fake-cursor-1" } } : {})
+  end
+
   # File download — the raw body String (not JSON). Slack::FileIngestor writes it
   # straight into an AssetVersion.
   def download_file(url:, token:, max_bytes: nil)
@@ -143,6 +210,23 @@ class FakeSlackClient
 
   def last_uploaded_files
     uploaded_files.last
+  end
+
+  # The ts the last chat.postMessage handed back.
+  def last_posted_message_ts
+    last_posted_message&.fetch(:ts, nil)
+  end
+
+  def last_updated_message
+    updated_messages.last
+  end
+
+  def last_deleted_message
+    deleted_messages.last
+  end
+
+  def last_replies_read
+    replies_reads.last
   end
 
   def last_download

--- a/test/support/slack_test_helper.rb
+++ b/test/support/slack_test_helper.rb
@@ -13,7 +13,10 @@
 # teardown (registered from #included when the module is mixed into
 # ActiveSupport::TestCase), so it is auto-reset just like a Mocha stub.
 module SlackTestHelper
-  SLACK_CLIENT_METHODS = %i[exchange_code auth_test post_message upload_files download_file].freeze
+  SLACK_CLIENT_METHODS = %i[
+    exchange_code auth_test post_message update_message delete_message
+    conversation_replies upload_files download_file
+  ].freeze
 
   def self.included(base)
     base.teardown { unstub_slack_client! }


### PR DESCRIPTION
## Why

A workflow agent could only send plain mrkdwn back to Slack, and could only ever see the single `@mention` that triggered it. Block Kit was already plumbed through `Slack::Client` and `Slack::Notifier` — but no caller ever passed `blocks`, so the parameter was dead code.

## What changed

### Posting

- `slack_post_message` takes **`blocks`** and **`reply_broadcast`**, and returns the posted message's **`ts`**.
- **blocks + files.** Slack has no way to attach files to a Block Kit message, so `Slack::Notifier` sends two requests: the message first, then the files into *that message's own thread*, keeping them together in the channel. Without blocks nothing changes — text and files still ship as one upload.
- **Half-delivered sends are reported.** `Notifier.post` returns a `Result` (channel, ts, thread_ts, errors) and `nil` only when nothing reached Slack. A message that landed while its upload failed comes back as `Partially sent to C1 (ts …) — files: upload_failed`, so the agent retries the missing half rather than the whole message. Slack's own error codes (`invalid_blocks`, `message_not_found`, …) reach the agent verbatim.

### Threads

| Tool | API | For |
|---|---|---|
| `slack_read_thread` | `conversations.replies` | Read the conversation behind the ask, not just the mention |
| `slack_update_message` | `chat.update` | "working… → result" in one message |
| `slack_delete_message` | `chat.delete` | Retract |

They share `InternalTools::Concerns::SlackContext` for the workspace-install lookup and the channel/thread defaults. `reply_broadcast` covers "reply in the thread, but show it in the channel too".

The triggering message's `ts` now rides in `shared_context` next to `thread_ts` — the two differ when the mention was made inside an existing thread.

### Guidance the agent actually gets

The `blocks` schema carries a Block Kit reference: the block types that work on the message surface with their size caps (50 blocks, section 3000 chars, `fields` 10 × 2000, header 150, context 10, markdown blocks 12000 cumulative), and the trap that mrkdwn is **not** Markdown — `[label](url)` does not render in a section, use a `markdown` block for that. The `markdown` block is presented as the default path, since agents write GitHub-flavoured Markdown by habit and it works there as-is.

## Judgment calls

- **Interactive blocks (`actions`/`input`) are rejected** with an explanation rather than forwarded. This deployment exposes no Slack interactivity request URL (`routes.rb` has only `webhooks/slack#events`), so a button would render and its click would go nowhere. One line in `INTERACTIVE_BLOCK_TYPES` reverses this when an endpoint lands.
- **DM threads cannot be read.** The app requests `channels:history` and `groups:history`, not `im:history` / `mpim:history`. Noted in the tool; scopes left alone.
- `Slack::Notifier.post` changed from `true/false` to `Result`/`nil`. Falsy-on-failure is preserved, so existing call sites keep working; `RunFailureNotifier` pins its boolean explicitly.

## Testing

`docker compose exec -T web make check_all` — green across all nine checks (5081 runs, 0 failures).

New coverage: the two-request blocks+files path and its threading, partial-failure reporting, block validation (interactive, >50, malformed), `reply_broadcast`, all three new tools, and `ts`/`thread_ts` divergence for an in-thread mention. `FakeSlackClient` gained `update_message` / `delete_message` / `conversation_replies`, each pinned by `client_contract_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)