### PR TITLE
feat(slack): let the Slack tools run outside a workflow step

### DIFF
--- a/app/services/internal_tools/concerns/slack_context.rb
+++ b/app/services/internal_tools/concerns/slack_context.rb
@@ -5,9 +5,15 @@ module InternalTools
     # SlackContext — shared plumbing for the Slack tools: which workspace install
     # this call talks to, and the channel/thread the run was started from.
     #
+    # The tools auto-inject into workflow steps only, but nothing here needs a
+    # workflow: the install is resolved from the session's PROJECT, so a plain
+    # agent session that a user attached the tool to works the same way. What it
+    # loses is the trigger context — with no run behind it there is no channel or
+    # thread to default to, and `channel` becomes required.
+    #
     # Every Slack tool is gated on `requires_integration :slack`, so the install
-    # exists in the common case; the guards here cover the run that was launched
-    # by hand, or after the workspace was disconnected mid-run.
+    # exists in the common case; the guards here cover the session launched by
+    # hand, or a workspace disconnected mid-run.
     module SlackContext
       # What an agent needs to know to write `blocks` without a round-trip through
       # a Slack `invalid_blocks` error: the block types that work on the message
@@ -45,7 +51,8 @@ module InternalTools
 
       # Reply coordinates threaded into the run by TriggerEngine#slack_run_context:
       # channel, ts, thread_ts, team, integration_id, plus the triggering message's
-      # text and author. Empty for a run that did not start from Slack.
+      # text and author. Empty for a run that did not start from Slack, and for a
+      # session with no workflow run behind it at all.
       def slack_context
         workflow_run&.shared_context.to_h["slack"] || {}
       end
@@ -73,12 +80,15 @@ module InternalTools
       # that triggered the run. Returns [integration, channel, error]: on the first
       # missing half, error is a tool error naming what is absent.
       def resolve_slack_target(explicit_channel)
+        return [ nil, nil, error("This tool needs a project — the session has none") ] if project.nil?
+
         integration = slack_integration
         return [ nil, nil, error("Slack is not connected for this project") ] if integration.nil?
 
         channel = explicit_channel.presence || slack_context["channel"]
         if channel.blank?
-          return [ integration, nil, error("No channel given, and this run was not triggered from Slack") ]
+          return [ integration, nil, error("No channel given. Only a run started from Slack has one to " \
+                                           "fall back on — pass `channel` explicitly.") ]
         end
 
         [ integration, channel, nil ]

--- a/app/services/internal_tools/slack_delete_message.rb
+++ b/app/services/internal_tools/slack_delete_message.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module InternalTools
-  # Platform tool: delete a Slack message this workflow posted, addressed by the
+  # Platform tool: delete a Slack message the bot posted, addressed by the
   # `ts` slack_post_message returned. For retracting a message that turned out to
   # be wrong or is superseded — prefer slack_update_message when the message
   # should stay and only its content changed, since a delete leaves people who
@@ -11,7 +11,7 @@ module InternalTools
 
     tool do
       display_name "Slack Delete Message"
-      description "Delete a Slack message this workflow posted, by its `ts` (returned by slack_post_message). Only the bot's own messages can be deleted, and the deletion is permanent. Prefer slack_update_message when the message should stay and only its content is wrong. Omit `channel` to use the channel that triggered the run."
+      description "Delete a Slack message the bot posted, by its `ts` (returned by slack_post_message). Only the bot's own messages can be deleted, and the deletion is permanent. Prefer slack_update_message when the message should stay and only its content is wrong. Omit `channel` only when this session was started from Slack; otherwise name it."
       tags :messaging, :slack
       inject_when :workflow_step_session
       requires_integration :slack
@@ -27,15 +27,13 @@ module InternalTools
           },
           channel: {
             type: "string",
-            description: "Channel ID the message lives in. Defaults to the triggering channel."
+            description: "Channel ID the message lives in. Defaults to the triggering channel, when there is one."
           }
         }
       })
     end
 
     def execute
-      require_workflow_context!
-
       integration, channel, target_error = resolve_slack_target(params[:channel])
       return target_error if target_error
 

--- a/app/services/internal_tools/slack_post_message.rb
+++ b/app/services/internal_tools/slack_post_message.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module InternalTools
-  # Platform tool: let a workflow agent send a Slack message. Text, Block Kit
+  # Platform tool: let an agent send a Slack message. Text, Block Kit
   # blocks and files are each optional, but at least one is required. Any number
   # of files can be attached, and each one comes from exactly one source:
   #   - content:   inline text the agent typed out (needs filename)
@@ -12,13 +12,14 @@ module InternalTools
   # way to attach files to a Block Kit message), so Slack::Notifier posts the
   # message and hangs the files in its thread. Gated on the project having an
   # active Slack integration. Defaults the channel/thread to the message that
-  # triggered the run.
+  # triggered the run; a session with no Slack trigger behind it must name a
+  # channel itself.
   class SlackPostMessage < Base
     include Concerns::SlackContext
 
     tool do
       display_name "Slack Post Message"
-      description "Send a Slack message from this workflow. `text`, `blocks` and `files` are all optional but at least one is required. `text` is plain/mrkdwn; `blocks` is Block Kit for rich layout; files can be attached in any number, each entry setting EXACTLY ONE source: `content` (inline text, needs `filename`), `file_path` (a path in the running container — any type incl. binary), or `asset_id` (a project asset's bytes). text + files arrive as one message; blocks + files send the message first and hang the files in its thread. Omit channel/thread to reply in the channel/thread that triggered the run. Returns the message `ts`, which slack_update_message and slack_delete_message address it by. Requires a Slack integration on the project."
+      description "Send a Slack message. `text`, `blocks` and `files` are all optional but at least one is required. `text` is plain/mrkdwn; `blocks` is Block Kit for rich layout; files can be attached in any number, each entry setting EXACTLY ONE source: `content` (inline text, needs `filename`), `file_path` (a path in the running container — any type incl. binary), or `asset_id` (a project asset's bytes). text + files arrive as one message; blocks + files send the message first and hang the files in its thread. Omit channel/thread to reply in the channel/thread that triggered the run; when nothing Slack-side started this session there is no default, so pass `channel` yourself. Returns the message `ts`, which slack_update_message and slack_delete_message address it by. Requires a Slack integration on the project."
       tags :messaging, :slack
       inject_when :workflow_step_session
       requires_integration :slack
@@ -87,8 +88,6 @@ module InternalTools
     end
 
     def execute
-      require_workflow_context!
-
       files, file_error = build_files
       return file_error if file_error
 

--- a/app/services/internal_tools/slack_read_thread.rb
+++ b/app/services/internal_tools/slack_read_thread.rb
@@ -19,7 +19,7 @@ module InternalTools
 
     tool do
       display_name "Slack Read Thread"
-      description "Read a Slack thread: the parent message and its replies, oldest first. Call it with no arguments to read the thread this run was triggered from — the usual case, and how you recover the conversation behind the request. Returns JSON: {messages: [{ts, user, bot_id, text, files}], has_more, next_cursor}. Public and private channels only (not DMs). Read a thread once rather than polling it."
+      description "Read a Slack thread: the parent message and its replies, oldest first. In a run triggered from Slack, call it with no arguments to read the thread behind the request — the usual case; anywhere else, name `channel` and `thread_ts`. Returns JSON: {messages: [{ts, user, bot_id, text, files}], has_more, next_cursor}. Public and private channels only (not DMs). Read a thread once rather than polling it."
       tags :messaging, :slack
       inject_when :workflow_step_session
       requires_integration :slack
@@ -35,7 +35,7 @@ module InternalTools
           },
           channel: {
             type: "string",
-            description: "Channel ID the thread lives in. Defaults to the triggering channel."
+            description: "Channel ID the thread lives in. Defaults to the triggering channel, when there is one."
           },
           limit: {
             type: "integer",
@@ -50,8 +50,6 @@ module InternalTools
     end
 
     def execute
-      require_workflow_context!
-
       integration, channel, target_error = resolve_slack_target(params[:channel])
       return target_error if target_error
 

--- a/app/services/internal_tools/slack_update_message.rb
+++ b/app/services/internal_tools/slack_update_message.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module InternalTools
-  # Platform tool: edit a Slack message this workflow already posted, addressed by
+  # Platform tool: edit a Slack message the bot already posted, addressed by
   # the `ts` slack_post_message returned. What it buys the agent is the
   # "working… → result" pattern: one message in the channel that fills in as the
   # step progresses, instead of a trail of partial updates.
@@ -14,7 +14,7 @@ module InternalTools
 
     tool do
       display_name "Slack Update Message"
-      description "Edit a Slack message this workflow posted, by its `ts` (returned by slack_post_message). Use it for a status message that fills in as the step progresses. The message is REPLACED, not merged: send everything it should end up with — a text-only update of a message that had blocks clears those blocks. Only the bot's own messages can be edited, and already-uploaded files cannot. Omit `channel` to use the channel that triggered the run."
+      description "Edit a Slack message the bot posted, by its `ts` (returned by slack_post_message). Use it for a status message that fills in as the step progresses. The message is REPLACED, not merged: send everything it should end up with — a text-only update of a message that had blocks clears those blocks. Only the bot's own messages can be edited, and already-uploaded files cannot. Omit `channel` only when this session was started from Slack; otherwise name it."
       tags :messaging, :slack
       inject_when :workflow_step_session
       requires_integration :slack
@@ -40,15 +40,13 @@ module InternalTools
           },
           channel: {
             type: "string",
-            description: "Channel ID the message lives in. Defaults to the triggering channel."
+            description: "Channel ID the message lives in. Defaults to the triggering channel, when there is one."
           }
         }
       })
     end
 
     def execute
-      require_workflow_context!
-
       blocks, blocks_error = build_blocks
       return blocks_error if blocks_error
       return error("Provide `text` and/or `blocks` to replace the message with") if params[:text].blank? && blocks.empty?

--- a/test/services/internal_tools/slack_message_tools_test.rb
+++ b/test/services/internal_tools/slack_message_tools_test.rb
@@ -205,4 +205,45 @@ class InternalTools::SlackMessageToolsTest < ActiveSupport::TestCase
     assert_equal 1, result[:exit_code]
     assert_includes result[:stderr], "thread_not_found"
   end
+
+  # --- outside a workflow run ------------------------------------------------
+  #
+  # Attached by hand to a plain agent session, these work off the session's
+  # project; only the trigger-derived channel/thread defaults are missing.
+
+  test "update and delete work in a plain agent session with an explicit channel" do
+    assert_equal 0, InternalTools::SlackUpdateMessage.new(
+      params: { ts: "111.9", text: "done", channel: "C7" }, session: plain_session
+    ).execute[:exit_code]
+    assert_equal "C7", fake_slack.last_updated_message[:channel]
+
+    assert_equal 0, InternalTools::SlackDeleteMessage.new(
+      params: { ts: "111.9", channel: "C7" }, session: plain_session
+    ).execute[:exit_code]
+    assert_equal "C7", fake_slack.last_deleted_message[:channel]
+  end
+
+  test "read_thread in a plain agent session needs both coordinates named" do
+    no_channel = InternalTools::SlackReadThread.new(params: { thread_ts: "1.1" }, session: plain_session).execute
+    assert_equal 1, no_channel[:exit_code]
+    assert_includes no_channel[:stderr], "pass `channel` explicitly"
+
+    no_thread = InternalTools::SlackReadThread.new(params: { channel: "C7" }, session: plain_session).execute
+    assert_equal 1, no_thread[:exit_code]
+    assert_includes no_thread[:stderr], "No thread given"
+
+    assert_empty fake_slack.replies_reads
+
+    ok = InternalTools::SlackReadThread.new(
+      params: { channel: "C7", thread_ts: "1.1" }, session: plain_session
+    ).execute
+    assert_equal 0, ok[:exit_code]
+    assert_equal "C7", fake_slack.last_replies_read[:channel]
+  end
+
+  # An agent session in the same project, with no step_run and so no workflow run.
+  def plain_session
+    @plain_session ||= create(:terminal_session, :running, :agent_session,
+      user: @user, project: @project, mode: "non_interactive", initial_prompt: "x")
+  end
 end

--- a/test/services/internal_tools/slack_post_message_test.rb
+++ b/test/services/internal_tools/slack_post_message_test.rb
@@ -301,4 +301,49 @@ class InternalTools::SlackPostMessageTest < ActiveSupport::TestCase
     assert_equal "C9", msg[:channel]
     assert_equal "9.9", msg[:thread_ts]
   end
+
+  # --- outside a workflow run ------------------------------------------------
+  #
+  # The tool auto-injects into workflow steps only, but a user can attach it to a
+  # plain agent session from the picker. The install is resolved from the PROJECT,
+  # so that works — what the session lacks is the trigger, hence no default channel.
+
+  test "posts from a plain agent session when the channel is named" do
+    result = InternalTools::SlackPostMessage.new(
+      params: { text: "hi", channel: "C7" }, session: plain_session
+    ).execute
+    assert_equal 0, result[:exit_code]
+
+    msg = fake_slack.last_posted_message
+    assert_equal "xoxb-1", msg[:token]
+    assert_equal "C7", msg[:channel]
+    assert_nil msg[:thread_ts]
+  end
+
+  test "asks a plain agent session to name a channel, since it has no trigger to borrow one from" do
+    result = InternalTools::SlackPostMessage.new(params: { text: "hi" }, session: plain_session).execute
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "pass `channel` explicitly"
+    assert_empty fake_slack.posted_messages
+  end
+
+  test "errors when the session has no project to resolve an install from" do
+    projectless = create(:terminal_session, :running, :agent_session, user: @user, project: nil,
+      mode: "non_interactive", initial_prompt: "x")
+
+    result = InternalTools::SlackPostMessage.new(
+      params: { text: "hi", channel: "C7" }, session: projectless
+    ).execute
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "needs a project"
+    assert_empty fake_slack.posted_messages
+  end
+
+  # An agent session in the same project, with no step_run and so no workflow run.
+  def plain_session
+    @plain_session ||= create(:terminal_session, :running, :agent_session,
+      user: @user, project: @project, mode: "non_interactive", initial_prompt: "x")
+  end
 end


### PR DESCRIPTION
## Why

All four Slack tools opened with `require_workflow_context!`, which raises unless the session carries a `step_run`. Meanwhile they are `user_attachable` (the DSL default), and `Definition#to_row_attributes` projects `requires_integration: "slack"` + `user_attachable: true` onto their shadow rows — which is exactly what `Tool.visible_for_project` filters on.

So a user could attach `slack_post_message` to a plain agent session from the picker, watch it show up in the tool list, and get `This tool requires a workflow context (no step_run on session)` on every single call. Visible, attachable, dead.

## What changed

Nothing in these tools actually needs a workflow:

| Needs | Plain agent session |
|---|---|
| `project` (to resolve the install) | **Yes** — `slack_integration` only reads `project.company_id` |
| `container_id` (for `file_path` attachments) | **Yes** |
| `slack_context` (trigger channel/thread) | No — but it already degrades to `{}` via `workflow_run&.shared_context` |

The workflow was only ever supplying the *defaults*. So the guard is replaced by a single project check inside `resolve_slack_target`, covering all four tools at their one shared entry point, and `channel` simply becomes required outside a Slack-triggered run — which the error message now says in as many words instead of the old "this run was not triggered from Slack".

Tool descriptions and class comments were rewritten accordingly ("this workflow posted" becomes "the bot posted", and each `channel` param notes that the default only exists when there is a trigger).

## What deliberately did NOT change

`inject_when :workflow_step_session` stays on all four. These still auto-inject **only** inside a workflow step; anywhere else somebody has to attach them on purpose. That keeps the blast radius where it was: a workflow run answers in the channel it was called from, while a hand-attached tool can post anywhere the bot is invited — which is now a deliberate act by whoever attached it, not something the platform does on its own.

## Testing

Per the repo owner's instruction for this change, the suite runs on CI rather than locally. What was run locally: `rubocop` and `brakeman` (green), plus the targeted Slack tool tests earlier in the main checkout (97 runs, 0 failures).

A local `check_all` in the isolated worktree fails on `Couldn't find the node_modules state file` — yarn wants `.yarn/install-state.gz`, which a `node_modules` symlink does not provide — taking `vite-build` down and, with it, `rails-test` (tests consume built assets) and every frontend check. Environmental, not from this diff; CI is the judge.

New coverage: posting from a plain agent session with an explicit channel, the "name a channel yourself" error when there is no trigger to borrow one from, the projectless-session error, update/delete in a plain session, and read_thread needing both coordinates named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
