### PR TITLE
fix(sessions): name the connection a blocked launch is waiting on

### DIFF
--- a/app/frontend/shared/components/SessionNewForm.test.tsx
+++ b/app/frontend/shared/components/SessionNewForm.test.tsx
@@ -121,7 +121,7 @@ describe('SessionNewForm', () => {
       status: 422,
       json: () =>
         Promise.resolve({
-          error: 'Connect required for 1 OAuth MCP server(s) before launching',
+          error: 'Connect required before launching: Sentry',
           reauth_required: [{ mcp_server_id: 5, name: 'Sentry', connect_url: '/oauth/mcp/5/connect' }],
         }),
     } as Response);

--- a/app/services/oauth/preflight_error.rb
+++ b/app/services/oauth/preflight_error.rb
@@ -10,7 +10,17 @@ module Oauth
 
     def initialize(connections)
       @connections = connections
-      super("Connect required for #{connections.size} OAuth MCP server(s) before launching")
+      super("Connect required before launching: #{self.class.names(connections)}")
+    end
+
+    # The browser gets the whole `connections` list and renders it, but a
+    # workflow-step launch has no browser: the relay stores only this message on
+    # the admission, and that was the operator's entire account of a blocked
+    # run. "1 OAuth MCP server(s)" left them to guess which one — production,
+    # 2026-09-09: nine Verify steps refused over three and a half hours because
+    # one project-shared grant had expired, and nothing said whose.
+    def self.names(connections)
+      connections.map { |c| c[:name].presence || "MCP server ##{c[:mcp_server_id]}" }.join(", ")
     end
   end
 end

--- a/app/services/session_launch_relay.rb
+++ b/app/services/session_launch_relay.rb
@@ -47,6 +47,13 @@ class SessionLaunchRelay
         if admission.claim_token == claim
           admission.update!(launch_state: "pending", claimed_at: nil)
           SessionAdmissionService.cancel!(session)
+          # The refusal has to reach the session too. Only the admission carried
+          # it, and nothing on the board reads that — a step refused at the gate
+          # showed up as a bare "cancelled" with an empty error, so the run's
+          # owner had no way to learn that a connection needed reconnecting.
+          session.reload.update!(
+            error_message: TerminalSession.preferred_error_message(session.error_message, e.message)
+          )
         end
       end
     end

--- a/app/services/session_service.rb
+++ b/app/services/session_service.rb
@@ -268,7 +268,7 @@ class SessionService
         Oauth::TokenService.refresh_if_expiring_soon(cred)
         cred.reload
         if cred.error?
-          raise Oauth::PreflightError, [ { mcp_server_id: server.id, reason: :credential_error,
+          raise Oauth::PreflightError, [ { mcp_server_id: server.id, name: server.name, reason: :credential_error,
                                            connect_url: "/oauth/mcp/#{server.id}/connect" } ]
         end
       end
@@ -379,14 +379,14 @@ class SessionService
         next if cred.nil?
 
         if cred.error?
-          raise Oauth::PreflightError, [ { mcp_server_id: server.id, reason: :credential_error,
+          raise Oauth::PreflightError, [ { mcp_server_id: server.id, name: server.name, reason: :credential_error,
                                            connect_url: "/oauth/mcp/#{server.id}/connect" } ]
         end
 
         Oauth::TokenService.refresh_if_expiring_soon(cred)
         cred.reload
         if cred.error?
-          raise Oauth::PreflightError, [ { mcp_server_id: server.id, reason: :credential_error,
+          raise Oauth::PreflightError, [ { mcp_server_id: server.id, name: server.name, reason: :credential_error,
                                            connect_url: "/oauth/mcp/#{server.id}/connect" } ]
         end
       end

--- a/test/services/oauth/preflight_error_test.rb
+++ b/test/services/oauth/preflight_error_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The browser renders the whole `connections` list, but a workflow-step launch
+# has no browser: this message is the only account of the refusal that reaches
+# the admission, the session and whoever is reading the run.
+class Oauth::PreflightErrorTest < ActiveSupport::TestCase
+  test "the message names the server that needs connecting" do
+    error = Oauth::PreflightError.new([ { mcp_server_id: 51, name: "Sentry", connect_url: "/oauth/mcp/51/connect" } ])
+
+    assert_equal "Connect required before launching: Sentry", error.message
+  end
+
+  test "several servers are all named" do
+    error = Oauth::PreflightError.new([
+      { mcp_server_id: 51, name: "Sentry" }, { mcp_server_id: 48, name: "Railway MCP" }
+    ])
+
+    assert_equal "Connect required before launching: Sentry, Railway MCP", error.message
+  end
+
+  test "a server with no name falls back to something an operator can look up" do
+    error = Oauth::PreflightError.new([ { mcp_server_id: 51 } ])
+
+    assert_equal "Connect required before launching: MCP server #51", error.message
+  end
+end

--- a/test/services/session_launch_relay_test.rb
+++ b/test/services/session_launch_relay_test.rb
@@ -52,6 +52,27 @@ class SessionLaunchRelayTest < ActiveSupport::TestCase
     assert_nothing_raised { SessionService.revalidate_admission!(@session.reload) }
   end
 
+  # Production, 2026-09-09: nine "Verify the story on real staging" steps were
+  # refused over three and a half hours because one project-shared Sentry grant
+  # had expired. Every one of them ended as a bare `cancelled` with an empty
+  # error, and the only trace of the reason lived on the admission, which no
+  # screen reads.
+  test "a connection the launch was refused over is named on the session" do
+    project = create(:project, company: @user.companies.first, owner: @user)
+    server = create(:mcp_server, :custom, scope: project, transport: :sse,
+                    auth_type: :oauth, credential_scope: :per_user, name: "Sentry")
+    SessionService.stubs(:revalidate_admission!)
+                  .raises(Oauth::PreflightError.new([ { mcp_server_id: server.id, name: server.name,
+                                                        connect_url: "/oauth/mcp/#{server.id}/connect" } ]))
+    TemporalService.expects(:start_workflow).never
+
+    SessionLaunchRelay.dispatch(@admission)
+
+    assert_equal "cancelled", @session.reload.state
+    assert_equal "Connect required before launching: Sentry", @session.error_message
+    assert_equal "Connect required before launching: Sentry", @admission.reload.last_error
+  end
+
   test "failed preflight releases a reservation when no start was attempted" do
     SessionService.stubs(:revalidate_admission!).raises(SessionAdmissionService::Stopped, "Access revoked")
     TemporalService.expects(:start_workflow).never

--- a/test/services/session_service_test.rb
+++ b/test/services/session_service_test.rb
@@ -98,6 +98,9 @@ class SessionServiceTest < ActiveSupport::TestCase
 
     assert_equal 0, @user.terminal_sessions.count, "must not create a session with a broken credential"
     assert_equal "/oauth/mcp/#{server.id}/connect", error.connections.first[:connect_url]
+    # A credential that broke on refresh names its server like any other refusal;
+    # this raise site used to omit the name and leave the message anonymous.
+    assert_equal "Connect required before launching: #{server.name}", error.message
   end
 
   test "create_and_start blocks launch when a credential is already in error status before start" do


### PR DESCRIPTION
## What happened

Production, 2026-09-09. Nine "Verify the story on real staging" steps in project 27 were refused before they ever launched, over three and a half hours:

```
13:58 → 17:21   9 × Verify   cancelled, started_at empty, error_message empty
17:25–17:26     GET /oauth/mcp/51/connect → mcp.sentry.dev/oauth/authorize → /oauth/callback
17:26 → 17:28   6 × Verify   ready, all started
```

The cause was one project-shared Sentry OAuth grant that had expired. Nothing on the board said so. The only record was on the admission:

> Connect required for 1 OAuth MCP server(s) before launching

Which server? The message did not say, and the step is wired to three (Playwright, Railway MCP, Sentry).

## Why the message was anonymous

The interactive path is fine: `Api::V1::TerminalSessionsController#create` renders the whole `connections` list and `SessionNewForm` draws a "Connect Sentry" button per entry. A workflow step has no browser — `SessionLaunchRelay` stores `e.message` on the admission and nothing else, and `SessionAdmissionService.cancel!` leaves the session's own `error_message` blank. So for every non-interactive launch, that one sentence was the entire account of the refusal, and it named a count instead of a server.

## What changed

- `Oauth::PreflightError` names them: `Connect required before launching: Sentry`, `…: Sentry, Railway MCP`, and `…: MCP server #51` when an entry carries no name.
- The three raise sites in `SessionService` that built a `credential_error` entry without `name:` now carry it — those are the "credential broke on refresh" paths, exactly the ones that fire without a browser.
- `SessionLaunchRelay` records the refusal on the session as well as the admission, so a step refused at the gate stops being a bare `cancelled` with nothing to act on.

## Tests

- `test/services/oauth/preflight_error_test.rb` (new): one server, several servers, and the unnamed fallback.
- `session_launch_relay_test.rb`: a refused launch leaves `Connect required before launching: Sentry` on both the session and the admission — the production shape.
- `session_service_test.rb`: the refresh-failure raise site asserts the named message.
- `SessionNewForm.test.tsx` fixture updated to the new string; the per-server Connect CTA is unchanged.

`rubocop` clean on the touched files; the affected backend suites and `SessionNewForm` pass locally. Full suite is CI's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
