### PR TITLE
fix(triggers): restore webhook create success view with example cURL

### DIFF
--- a/app/frontend/pages/Projects/Workflows/TriggerFormPanel.test.tsx
+++ b/app/frontend/pages/Projects/Workflows/TriggerFormPanel.test.tsx
@@ -312,6 +312,93 @@ describe('Projects/Workflows/TriggerFormPanel', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Webhook create — success view with the ready-to-run cURL example (issue #624)
+  // -------------------------------------------------------------------------
+  it('stays open on a success view showing the URL, secret, and no-auth cURL after a webhook is created', async () => {
+    installFetch(() =>
+      json({ webhook_url: 'https://example.test/hooks/abc', webhook_secret: '', verification_strategy: 'none' }),
+    );
+    const onSaved = vi.fn();
+
+    renderPage(<TriggerFormPanel {...baseProps({ defaultKind: 'webhook', onSaved })} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Add trigger' }));
+
+    expect(await screen.findByText('Webhook trigger created')).toBeInTheDocument();
+    expect(screen.getByText('https://example.test/hooks/abc')).toBeInTheDocument();
+    expect(screen.getByText('Request URL')).toBeInTheDocument();
+    expect(screen.queryByText('Secret')).not.toBeInTheDocument();
+    expect(screen.getByText(/Example request \(no auth\)/)).toBeInTheDocument();
+    expect(screen.getByText(/curl -X POST 'https:\/\/example\.test\/hooks\/abc'/)).toBeInTheDocument();
+    expect(onSaved).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(onSaved).toHaveBeenCalled();
+  });
+
+  it('shows the shared-token cURL and the secret when the webhook uses shared_token verification', async () => {
+    installFetch(() =>
+      json({
+        webhook_url: 'https://example.test/hooks/xyz',
+        webhook_secret: 'sek_123',
+        verification_strategy: 'shared_token',
+      }),
+    );
+
+    renderPage(<TriggerFormPanel {...baseProps({ defaultKind: 'webhook' })} />);
+    await pickOption('None', 'Shared token');
+    await userEvent.click(screen.getByRole('button', { name: 'Add trigger' }));
+
+    expect(await screen.findByText('Webhook trigger created')).toBeInTheDocument();
+    expect(screen.getByText('sek_123')).toBeInTheDocument();
+    expect(screen.getByText(/Example request \(shared token\)/)).toBeInTheDocument();
+    expect(screen.getByText(/X-Webhook-Token: sek_123/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy curl' })).toBeInTheDocument();
+  });
+
+  it('shows the HMAC SHA-256 cURL for an hmac_sha256 webhook', async () => {
+    installFetch(() =>
+      json({
+        webhook_url: 'https://example.test/hooks/hm',
+        webhook_secret: 'topsecret',
+        verification_strategy: 'hmac_sha256',
+      }),
+    );
+
+    renderPage(<TriggerFormPanel {...baseProps({ defaultKind: 'webhook' })} />);
+    await pickOption('None', 'HMAC SHA-256');
+    await userEvent.click(screen.getByRole('button', { name: 'Add trigger' }));
+
+    expect(await screen.findByText(/Example request \(HMAC SHA-256\)/)).toBeInTheDocument();
+    expect(screen.getByText(/X-Hub-Signature-256: sha256=\$SIG/)).toBeInTheDocument();
+    expect(screen.getByText(/openssl dgst -sha256 -hmac 'topsecret'/)).toBeInTheDocument();
+  });
+
+  it('refreshes the list (onSaved, not onClose) when the webhook success view is dismissed via the ✕', async () => {
+    installFetch(() => json({ webhook_url: 'https://example.test/hooks/abc', webhook_secret: '' }));
+    const onSaved = vi.fn();
+    const onClose = vi.fn();
+
+    renderPage(<TriggerFormPanel {...baseProps({ defaultKind: 'webhook', onSaved, onClose })} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Add trigger' }));
+    expect(await screen.findByText('Webhook trigger created')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onSaved).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not show the success view for a non-webhook trigger — it closes via onSaved', async () => {
+    installFetch(() => json({ webhook_url: 'https://example.test/should-be-ignored' }));
+    const onSaved = vi.fn();
+
+    renderPage(<TriggerFormPanel {...baseProps({ defaultKind: 'slack', onSaved })} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Add trigger' }));
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    expect(screen.queryByText('Webhook trigger created')).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
   // Edit mode — kind locked, seeded from the trigger
   // -------------------------------------------------------------------------
   it('locks the kind and patches a column trigger with the kind query param', async () => {

--- a/app/frontend/pages/Projects/Workflows/TriggerFormPanel.tsx
+++ b/app/frontend/pages/Projects/Workflows/TriggerFormPanel.tsx
@@ -1,5 +1,5 @@
-import { NumberInput, PasswordInput, Select, Switch, TextInput } from '@mantine/core';
-import { IconLock, IconX } from '@tabler/icons-react';
+import { Button, CopyButton, NumberInput, PasswordInput, Select, Switch, TextInput } from '@mantine/core';
+import { IconCheck, IconCopy, IconLock, IconX } from '@tabler/icons-react';
 import cronstrue from 'cronstrue';
 import { useCallback, useState } from 'react';
 
@@ -54,6 +54,33 @@ function slackFilterFromPredicate(pred: Record<string, unknown>): { channel: str
   return { channel, op: 'contains', value: '' };
 }
 
+// Builds a ready-to-run curl command for the created webhook, adapting the auth
+// headers to the chosen verification strategy. Ported from WorkflowTriggersDrawer.
+function buildWebhookCurl(url: string, secret: string | undefined, verification: string): string {
+  const s = secret || '<secret>';
+  if (verification === 'hmac_sha256') {
+    return [
+      `BODY='{"hello":"world"}'`,
+      `SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac '${s}' | sed 's/^.* //')`,
+      `curl -X POST '${url}' \\`,
+      `  -H 'Content-Type: application/json' \\`,
+      `  -H "X-Hub-Signature-256: sha256=$SIG" \\`,
+      `  -d "$BODY"`,
+    ].join('\n');
+  }
+  if (verification === 'shared_token') {
+    return [
+      `curl -X POST '${url}' \\`,
+      `  -H 'Content-Type: application/json' \\`,
+      `  -H 'X-Webhook-Token: ${s}' \\`,
+      `  -d '{"hello":"world"}'`,
+    ].join('\n');
+  }
+  return [`curl -X POST '${url}' \\`, `  -H 'Content-Type: application/json' \\`, `  -d '{"hello":"world"}'`].join(
+    '\n',
+  );
+}
+
 function webhookFilterFromPredicate(pred: Record<string, unknown>): { field: string; op: string; value: string } {
   const field = Object.keys(pred)[0];
   if (!field) return { field: '', op: 'eq', value: '' };
@@ -82,6 +109,9 @@ export function TriggerFormPanel({
   const [kind, setKind] = useState<Kind>((editing?.kind as Kind) ?? (defaultKind as Kind));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Set after a webhook is created: keeps the panel open on a success view showing
+  // the request URL, secret, and a ready-to-run example cURL.
+  const [created, setCreated] = useState<{ url: string; secret: string; verification: string } | null>(null);
 
   const [columnId, setColumnId] = useState<string | null>(
     editing?.board_column_id?.toString() ??
@@ -185,6 +215,17 @@ export function TriggerFormPanel({
         setError((data.errors ?? ['Failed to save trigger']).join(', '));
         return;
       }
+      if (!isEdit && kind === 'webhook') {
+        const data = await res.json().catch(() => ({}));
+        if (data.webhook_url) {
+          setCreated({
+            url: data.webhook_url,
+            secret: data.webhook_secret ?? '',
+            verification: data.verification_strategy ?? verification,
+          });
+          return;
+        }
+      }
       onSaved();
     } finally {
       setSaving(false);
@@ -216,6 +257,10 @@ export function TriggerFormPanel({
     onSaved,
   ]);
 
+  // Once a webhook has been created the trigger already exists on the server, so
+  // dismissing the panel any which way (scrim, ✕, Done) must still refresh the list.
+  const dismiss = created ? onSaved : onClose;
+
   const kindOptions = [
     { value: 'column', label: 'Task enters column' },
     { value: 'schedule', label: 'On schedule' },
@@ -233,7 +278,7 @@ export function TriggerFormPanel({
           background: 'rgba(0,0,0,0.45)',
           zIndex: 90,
         }}
-        onClick={onClose}
+        onClick={dismiss}
       />
 
       {/* Panel */}
@@ -268,7 +313,7 @@ export function TriggerFormPanel({
             {isEdit ? 'Edit trigger' : 'Add trigger'}
           </div>
           <button
-            onClick={onClose}
+            onClick={dismiss}
             title="Close"
             style={{
               background: 'none',
@@ -293,306 +338,32 @@ export function TriggerFormPanel({
           </button>
         </div>
 
-        {/* Body */}
-        <div style={{ flex: 1, overflowY: 'auto', padding: 24 }}>
-          {/* Trigger type */}
-          <div style={{ marginBottom: 16 }}>
-            <label style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', display: 'block', marginBottom: 5 }}>
-              Trigger type
-            </label>
-            {isEdit ? (
-              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                <span style={{ fontSize: 13, color: 'var(--text-1)' }}>
-                  {kindOptions.find((o) => o.value === kind)?.label ?? kind}
-                </span>
-                <IconLock size={12} style={{ color: 'var(--text-3)' }} />
-                <span style={{ fontSize: 12, color: 'var(--text-3)' }}>Type is locked when editing</span>
-              </div>
-            ) : (
-              <Select
-                data={kindOptions}
-                value={kind}
-                onChange={(v) => setKind((v as Kind) ?? 'column')}
-                allowDeselect={false}
-                styles={{
-                  input: {
-                    background: 'var(--bg-card)',
-                    border: '1px solid var(--border)',
-                    borderRadius: 5,
-                    fontSize: 13,
-                  },
-                }}
-              />
-            )}
-          </div>
-
-          {/* Column fields */}
-          {kind === 'column' && (
-            <>
-              <div style={{ marginBottom: 12 }}>
+        {created ? (
+          <WebhookCreatedView created={created} onDone={onSaved} />
+        ) : (
+          <>
+            {/* Body */}
+            <div style={{ flex: 1, overflowY: 'auto', padding: 24 }}>
+              {/* Trigger type */}
+              <div style={{ marginBottom: 16 }}>
                 <label
                   style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', display: 'block', marginBottom: 5 }}
                 >
-                  Column
+                  Trigger type
                 </label>
-                <Select
-                  data={columnBindingData}
-                  value={columnId}
-                  onChange={setColumnId}
-                  placeholder="Pick a column"
-                  searchable
-                  disabled={isEdit}
-                  styles={{
-                    input: {
-                      background: 'var(--bg-card)',
-                      border: '1px solid var(--border)',
-                      borderRadius: 5,
-                      fontSize: 13,
-                    },
-                  }}
-                />
-              </div>
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginTop: 16 }}>
-                <div>
-                  <label
-                    style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', display: 'block', marginBottom: 6 }}
-                  >
-                    Mode
-                  </label>
-                  <div
-                    style={{
-                      display: 'inline-flex',
-                      background: 'var(--bg-raised)',
-                      border: '1px solid var(--border)',
-                      borderRadius: 8,
-                      padding: 3,
-                      gap: 2,
-                    }}
-                  >
-                    {['auto', 'manual'].map((m) => (
-                      <button
-                        key={m}
-                        onClick={() => setMode(m)}
-                        style={{
-                          padding: '6px 20px',
-                          fontSize: 12,
-                          fontWeight: 500,
-                          color: mode === m ? 'var(--text-1)' : 'var(--text-2)',
-                          background: mode === m ? 'var(--bg-card)' : 'transparent',
-                          borderRadius: 4,
-                          border: 'none',
-                          cursor: 'pointer',
-                          transition: 'all 0.12s',
-                          fontFamily: 'inherit',
-                          textTransform: 'capitalize',
-                        }}
-                      >
-                        {m.charAt(0).toUpperCase() + m.slice(1)}
-                      </button>
-                    ))}
+                {isEdit ? (
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <span style={{ fontSize: 13, color: 'var(--text-1)' }}>
+                      {kindOptions.find((o) => o.value === kind)?.label ?? kind}
+                    </span>
+                    <IconLock size={12} style={{ color: 'var(--text-3)' }} />
+                    <span style={{ fontSize: 12, color: 'var(--text-3)' }}>Type is locked when editing</span>
                   </div>
-                </div>
-                <div>
-                  <label
-                    style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', display: 'block', marginBottom: 5 }}
-                  >
-                    Cooldown (s)
-                  </label>
-                  <NumberInput
-                    value={cooldown}
-                    onChange={setCooldown}
-                    min={0}
-                    styles={{
-                      input: {
-                        background: 'var(--bg-card)',
-                        border: '1px solid var(--border)',
-                        borderRadius: 5,
-                        fontSize: 13,
-                      },
-                    }}
-                  />
-                </div>
-              </div>
-            </>
-          )}
-
-          {/* Schedule fields */}
-          {kind === 'schedule' && (
-            <>
-              <div style={{ marginBottom: 12 }}>
-                <label
-                  style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', display: 'block', marginBottom: 5 }}
-                >
-                  Cron
-                </label>
-                <div style={{ fontSize: 12, color: 'var(--text-2)', marginBottom: 6, lineHeight: 1.5 }}>
-                  minute · hour · day-of-month · month · day-of-week
-                </div>
-                <TextInput
-                  placeholder="0 9 * * 1-5"
-                  value={cron}
-                  onChange={(e) => setCron(e.currentTarget.value)}
-                  error={cron.trim() && !cronDesc.ok ? 'Invalid cron' : undefined}
-                  styles={{
-                    input: {
-                      background: 'var(--bg-card)',
-                      border: '1px solid var(--border)',
-                      borderRadius: 5,
-                      fontSize: 13,
-                    },
-                  }}
-                />
-                <div
-                  style={{
-                    fontSize: 12,
-                    color: cronDesc.ok ? 'var(--mantine-color-green-6)' : 'var(--text-3)',
-                    marginTop: 6,
-                  }}
-                >
-                  {cronDesc.ok ? `Runs: ${cronDesc.text}` : cronDesc.text}
-                </div>
-              </div>
-              <div style={{ marginBottom: 12 }}>
-                <label
-                  style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', display: 'block', marginBottom: 5 }}
-                >
-                  Timezone
-                </label>
-                <Select
-                  data={TIMEZONE_OPTIONS}
-                  value={timezone}
-                  onChange={(v) => setTimezone(v ?? 'UTC')}
-                  searchable
-                  nothingFoundMessage="No timezone"
-                  styles={{
-                    input: {
-                      background: 'var(--bg-card)',
-                      border: '1px solid var(--border)',
-                      borderRadius: 5,
-                      fontSize: 13,
-                    },
-                  }}
-                />
-              </div>
-              <div style={{ marginBottom: 12 }}>
-                <label
-                  style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', display: 'block', marginBottom: 5 }}
-                >
-                  Subject (what the run is about)
-                </label>
-                <Select
-                  data={sessionOptions}
-                  value={subjectPolicy}
-                  onChange={(v) => setSubjectPolicy(v ?? 'none')}
-                  allowDeselect={false}
-                  styles={{
-                    input: {
-                      background: 'var(--bg-card)',
-                      border: '1px solid var(--border)',
-                      borderRadius: 5,
-                      fontSize: 13,
-                    },
-                  }}
-                />
-              </div>
-              {subjectPolicy !== 'none' && (
-                <>
-                  <div style={{ marginBottom: 12 }}>
-                    <label
-                      style={{
-                        fontSize: 13,
-                        fontWeight: 500,
-                        color: 'var(--text-1)',
-                        display: 'block',
-                        marginBottom: 5,
-                      }}
-                    >
-                      Task column
-                    </label>
-                    <Select
-                      data={columnData}
-                      value={subjectColumnId}
-                      onChange={setSubjectColumnId}
-                      styles={{
-                        input: {
-                          background: 'var(--bg-card)',
-                          border: '1px solid var(--border)',
-                          borderRadius: 5,
-                          fontSize: 13,
-                        },
-                      }}
-                    />
-                  </div>
-                  <div style={{ marginBottom: 12 }}>
-                    <label
-                      style={{
-                        fontSize: 13,
-                        fontWeight: 500,
-                        color: 'var(--text-1)',
-                        display: 'block',
-                        marginBottom: 5,
-                      }}
-                    >
-                      Task title template
-                    </label>
-                    <TextInput
-                      placeholder="webhook.received — {{date}}"
-                      value={subjectTitleTemplate}
-                      onChange={(e) => setSubjectTitleTemplate(e.currentTarget.value)}
-                      styles={{
-                        input: {
-                          background: 'var(--bg-card)',
-                          border: '1px solid var(--border)',
-                          borderRadius: 5,
-                          fontSize: 13,
-                        },
-                      }}
-                    />
-                  </div>
-                </>
-              )}
-            </>
-          )}
-
-          {/* Slack fields */}
-          {kind === 'slack' && (
-            <>
-              <div style={{ marginBottom: 12 }}>
-                <label
-                  style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', display: 'block', marginBottom: 5 }}
-                >
-                  Channel id
-                </label>
-                <TextInput
-                  placeholder="C0123ABC (blank = any)"
-                  value={channel}
-                  onChange={(e) => setChannel(e.currentTarget.value)}
-                  styles={{
-                    input: {
-                      background: 'var(--bg-card)',
-                      border: '1px solid var(--border)',
-                      borderRadius: 5,
-                      fontSize: 13,
-                    },
-                  }}
-                />
-              </div>
-              <div style={{ display: 'grid', gridTemplateColumns: '150px 1fr', gap: 12, marginBottom: 12 }}>
-                <div>
-                  <label
-                    style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', display: 'block', marginBottom: 5 }}
-                  >
-                    Text match
-                  </label>
+                ) : (
                   <Select
-                    data={[
-                      { value: 'contains', label: 'contains' },
-                      { value: 'eq', label: 'equals' },
-                      { value: 'regex', label: 'regex' },
-                      { value: 'starts_with', label: 'starts with' },
-                    ]}
-                    value={textOp}
-                    onChange={(v) => setTextOp(v ?? 'contains')}
+                    data={kindOptions}
+                    value={kind}
+                    onChange={(v) => setKind((v as Kind) ?? 'column')}
                     allowDeselect={false}
                     styles={{
                       input: {
@@ -603,58 +374,11 @@ export function TriggerFormPanel({
                       },
                     }}
                   />
-                </div>
-                <div>
-                  <label
-                    style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', display: 'block', marginBottom: 5 }}
-                  >
-                    Pattern
-                  </label>
-                  <TextInput
-                    placeholder="ship it (optional)"
-                    value={textContains}
-                    onChange={(e) => setTextContains(e.currentTarget.value)}
-                    styles={{
-                      input: {
-                        background: 'var(--bg-card)',
-                        border: '1px solid var(--border)',
-                        borderRadius: 5,
-                        fontSize: 13,
-                      },
-                    }}
-                  />
-                </div>
+                )}
               </div>
-              <div style={{ marginBottom: 12 }}>
-                <Switch
-                  label="Report failures back to Slack"
-                  description="When a run from this trigger fails, reply in the same thread with the error."
-                  checked={notifyOnFailure}
-                  onChange={(e) => setNotifyOnFailure(e.currentTarget.checked)}
-                />
-              </div>
-              <div style={{ marginBottom: 12 }}>
-                <label
-                  style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', display: 'block', marginBottom: 5 }}
-                >
-                  Subject (what the run is about)
-                </label>
-                <Select
-                  data={sessionOptions}
-                  value={subjectPolicy}
-                  onChange={(v) => setSubjectPolicy(v ?? 'none')}
-                  allowDeselect={false}
-                  styles={{
-                    input: {
-                      background: 'var(--bg-card)',
-                      border: '1px solid var(--border)',
-                      borderRadius: 5,
-                      fontSize: 13,
-                    },
-                  }}
-                />
-              </div>
-              {subjectPolicy !== 'none' && (
+
+              {/* Column fields */}
+              {kind === 'column' && (
                 <>
                   <div style={{ marginBottom: 12 }}>
                     <label
@@ -666,12 +390,161 @@ export function TriggerFormPanel({
                         marginBottom: 5,
                       }}
                     >
-                      Task column
+                      Column
                     </label>
                     <Select
-                      data={columnData}
-                      value={subjectColumnId}
-                      onChange={setSubjectColumnId}
+                      data={columnBindingData}
+                      value={columnId}
+                      onChange={setColumnId}
+                      placeholder="Pick a column"
+                      searchable
+                      disabled={isEdit}
+                      styles={{
+                        input: {
+                          background: 'var(--bg-card)',
+                          border: '1px solid var(--border)',
+                          borderRadius: 5,
+                          fontSize: 13,
+                        },
+                      }}
+                    />
+                  </div>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginTop: 16 }}>
+                    <div>
+                      <label
+                        style={{
+                          fontSize: 13,
+                          fontWeight: 500,
+                          color: 'var(--text-1)',
+                          display: 'block',
+                          marginBottom: 6,
+                        }}
+                      >
+                        Mode
+                      </label>
+                      <div
+                        style={{
+                          display: 'inline-flex',
+                          background: 'var(--bg-raised)',
+                          border: '1px solid var(--border)',
+                          borderRadius: 8,
+                          padding: 3,
+                          gap: 2,
+                        }}
+                      >
+                        {['auto', 'manual'].map((m) => (
+                          <button
+                            key={m}
+                            onClick={() => setMode(m)}
+                            style={{
+                              padding: '6px 20px',
+                              fontSize: 12,
+                              fontWeight: 500,
+                              color: mode === m ? 'var(--text-1)' : 'var(--text-2)',
+                              background: mode === m ? 'var(--bg-card)' : 'transparent',
+                              borderRadius: 4,
+                              border: 'none',
+                              cursor: 'pointer',
+                              transition: 'all 0.12s',
+                              fontFamily: 'inherit',
+                              textTransform: 'capitalize',
+                            }}
+                          >
+                            {m.charAt(0).toUpperCase() + m.slice(1)}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    <div>
+                      <label
+                        style={{
+                          fontSize: 13,
+                          fontWeight: 500,
+                          color: 'var(--text-1)',
+                          display: 'block',
+                          marginBottom: 5,
+                        }}
+                      >
+                        Cooldown (s)
+                      </label>
+                      <NumberInput
+                        value={cooldown}
+                        onChange={setCooldown}
+                        min={0}
+                        styles={{
+                          input: {
+                            background: 'var(--bg-card)',
+                            border: '1px solid var(--border)',
+                            borderRadius: 5,
+                            fontSize: 13,
+                          },
+                        }}
+                      />
+                    </div>
+                  </div>
+                </>
+              )}
+
+              {/* Schedule fields */}
+              {kind === 'schedule' && (
+                <>
+                  <div style={{ marginBottom: 12 }}>
+                    <label
+                      style={{
+                        fontSize: 13,
+                        fontWeight: 500,
+                        color: 'var(--text-1)',
+                        display: 'block',
+                        marginBottom: 5,
+                      }}
+                    >
+                      Cron
+                    </label>
+                    <div style={{ fontSize: 12, color: 'var(--text-2)', marginBottom: 6, lineHeight: 1.5 }}>
+                      minute · hour · day-of-month · month · day-of-week
+                    </div>
+                    <TextInput
+                      placeholder="0 9 * * 1-5"
+                      value={cron}
+                      onChange={(e) => setCron(e.currentTarget.value)}
+                      error={cron.trim() && !cronDesc.ok ? 'Invalid cron' : undefined}
+                      styles={{
+                        input: {
+                          background: 'var(--bg-card)',
+                          border: '1px solid var(--border)',
+                          borderRadius: 5,
+                          fontSize: 13,
+                        },
+                      }}
+                    />
+                    <div
+                      style={{
+                        fontSize: 12,
+                        color: cronDesc.ok ? 'var(--mantine-color-green-6)' : 'var(--text-3)',
+                        marginTop: 6,
+                      }}
+                    >
+                      {cronDesc.ok ? `Runs: ${cronDesc.text}` : cronDesc.text}
+                    </div>
+                  </div>
+                  <div style={{ marginBottom: 12 }}>
+                    <label
+                      style={{
+                        fontSize: 13,
+                        fontWeight: 500,
+                        color: 'var(--text-1)',
+                        display: 'block',
+                        marginBottom: 5,
+                      }}
+                    >
+                      Timezone
+                    </label>
+                    <Select
+                      data={TIMEZONE_OPTIONS}
+                      value={timezone}
+                      onChange={(v) => setTimezone(v ?? 'UTC')}
+                      searchable
+                      nothingFoundMessage="No timezone"
                       styles={{
                         input: {
                           background: 'var(--bg-card)',
@@ -692,52 +565,12 @@ export function TriggerFormPanel({
                         marginBottom: 5,
                       }}
                     >
-                      Task title template
-                    </label>
-                    <TextInput
-                      placeholder="slack.message — {{date}}"
-                      value={subjectTitleTemplate}
-                      onChange={(e) => setSubjectTitleTemplate(e.currentTarget.value)}
-                      styles={{
-                        input: {
-                          background: 'var(--bg-card)',
-                          border: '1px solid var(--border)',
-                          borderRadius: 5,
-                          fontSize: 13,
-                        },
-                      }}
-                    />
-                  </div>
-                </>
-              )}
-            </>
-          )}
-
-          {/* Webhook fields */}
-          {kind === 'webhook' && (
-            <>
-              {!isEdit && (
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 12 }}>
-                  <div>
-                    <label
-                      style={{
-                        fontSize: 13,
-                        fontWeight: 500,
-                        color: 'var(--text-1)',
-                        display: 'block',
-                        marginBottom: 5,
-                      }}
-                    >
-                      Verification
+                      Subject (what the run is about)
                     </label>
                     <Select
-                      data={[
-                        { value: 'none', label: 'None' },
-                        { value: 'hmac_sha256', label: 'HMAC SHA-256' },
-                        { value: 'shared_token', label: 'Shared token' },
-                      ]}
-                      value={verification}
-                      onChange={(v) => setVerification(v ?? 'none')}
+                      data={sessionOptions}
+                      value={subjectPolicy}
+                      onChange={(v) => setSubjectPolicy(v ?? 'none')}
                       allowDeselect={false}
                       styles={{
                         input: {
@@ -749,122 +582,67 @@ export function TriggerFormPanel({
                       }}
                     />
                   </div>
-                  <div>
-                    <label
-                      style={{
-                        fontSize: 13,
-                        fontWeight: 500,
-                        color: 'var(--text-1)',
-                        display: 'block',
-                        marginBottom: 5,
-                      }}
-                    >
-                      Secret
-                    </label>
-                    <PasswordInput
-                      placeholder="optional"
-                      value={secret}
-                      onChange={(e) => setSecret(e.currentTarget.value)}
-                      styles={{
-                        input: {
-                          background: 'var(--bg-card)',
-                          border: '1px solid var(--border)',
-                          borderRadius: 5,
-                          fontSize: 13,
-                        },
-                      }}
-                    />
-                  </div>
-                </div>
+                  {subjectPolicy !== 'none' && (
+                    <>
+                      <div style={{ marginBottom: 12 }}>
+                        <label
+                          style={{
+                            fontSize: 13,
+                            fontWeight: 500,
+                            color: 'var(--text-1)',
+                            display: 'block',
+                            marginBottom: 5,
+                          }}
+                        >
+                          Task column
+                        </label>
+                        <Select
+                          data={columnData}
+                          value={subjectColumnId}
+                          onChange={setSubjectColumnId}
+                          styles={{
+                            input: {
+                              background: 'var(--bg-card)',
+                              border: '1px solid var(--border)',
+                              borderRadius: 5,
+                              fontSize: 13,
+                            },
+                          }}
+                        />
+                      </div>
+                      <div style={{ marginBottom: 12 }}>
+                        <label
+                          style={{
+                            fontSize: 13,
+                            fontWeight: 500,
+                            color: 'var(--text-1)',
+                            display: 'block',
+                            marginBottom: 5,
+                          }}
+                        >
+                          Task title template
+                        </label>
+                        <TextInput
+                          placeholder="webhook.received — {{date}}"
+                          value={subjectTitleTemplate}
+                          onChange={(e) => setSubjectTitleTemplate(e.currentTarget.value)}
+                          styles={{
+                            input: {
+                              background: 'var(--bg-card)',
+                              border: '1px solid var(--border)',
+                              borderRadius: 5,
+                              fontSize: 13,
+                            },
+                          }}
+                        />
+                      </div>
+                    </>
+                  )}
+                </>
               )}
-              <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--text-2)', marginBottom: 8 }}>
-                Only when (optional)
-              </div>
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 90px 1fr', gap: 10, marginBottom: 12 }}>
-                <div>
-                  <label
-                    style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', display: 'block', marginBottom: 5 }}
-                  >
-                    Field
-                  </label>
-                  <TextInput
-                    placeholder="ref"
-                    value={condField}
-                    onChange={(e) => setCondField(e.currentTarget.value)}
-                    styles={{
-                      input: {
-                        background: 'var(--bg-card)',
-                        border: '1px solid var(--border)',
-                        borderRadius: 5,
-                        fontSize: 13,
-                      },
-                    }}
-                  />
-                </div>
-                <div>
-                  <label
-                    style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', display: 'block', marginBottom: 5 }}
-                  >
-                    Op
-                  </label>
-                  <Select
-                    data={['eq', 'ne', 'contains', 'starts_with', 'ends_with'].map((o) => ({ value: o, label: o }))}
-                    value={condOp}
-                    onChange={(v) => setCondOp(v ?? 'eq')}
-                    allowDeselect={false}
-                    styles={{
-                      input: {
-                        background: 'var(--bg-card)',
-                        border: '1px solid var(--border)',
-                        borderRadius: 5,
-                        fontSize: 13,
-                      },
-                    }}
-                  />
-                </div>
-                <div>
-                  <label
-                    style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', display: 'block', marginBottom: 5 }}
-                  >
-                    Value
-                  </label>
-                  <TextInput
-                    placeholder="refs/heads/main"
-                    value={condValue}
-                    onChange={(e) => setCondValue(e.currentTarget.value)}
-                    styles={{
-                      input: {
-                        background: 'var(--bg-card)',
-                        border: '1px solid var(--border)',
-                        borderRadius: 5,
-                        fontSize: 13,
-                      },
-                    }}
-                  />
-                </div>
-              </div>
-              <div style={{ marginBottom: 12 }}>
-                <label
-                  style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', display: 'block', marginBottom: 5 }}
-                >
-                  Subject (what the run is about)
-                </label>
-                <Select
-                  data={sessionOptions}
-                  value={subjectPolicy}
-                  onChange={(v) => setSubjectPolicy(v ?? 'none')}
-                  allowDeselect={false}
-                  styles={{
-                    input: {
-                      background: 'var(--bg-card)',
-                      border: '1px solid var(--border)',
-                      borderRadius: 5,
-                      fontSize: 13,
-                    },
-                  }}
-                />
-              </div>
-              {subjectPolicy !== 'none' && (
+
+              {/* Slack fields */}
+              {kind === 'slack' && (
                 <>
                   <div style={{ marginBottom: 12 }}>
                     <label
@@ -876,12 +654,12 @@ export function TriggerFormPanel({
                         marginBottom: 5,
                       }}
                     >
-                      Task column
+                      Channel id
                     </label>
-                    <Select
-                      data={columnData}
-                      value={subjectColumnId}
-                      onChange={setSubjectColumnId}
+                    <TextInput
+                      placeholder="C0123ABC (blank = any)"
+                      value={channel}
+                      onChange={(e) => setChannel(e.currentTarget.value)}
                       styles={{
                         input: {
                           background: 'var(--bg-card)',
@@ -890,6 +668,74 @@ export function TriggerFormPanel({
                           fontSize: 13,
                         },
                       }}
+                    />
+                  </div>
+                  <div style={{ display: 'grid', gridTemplateColumns: '150px 1fr', gap: 12, marginBottom: 12 }}>
+                    <div>
+                      <label
+                        style={{
+                          fontSize: 13,
+                          fontWeight: 500,
+                          color: 'var(--text-1)',
+                          display: 'block',
+                          marginBottom: 5,
+                        }}
+                      >
+                        Text match
+                      </label>
+                      <Select
+                        data={[
+                          { value: 'contains', label: 'contains' },
+                          { value: 'eq', label: 'equals' },
+                          { value: 'regex', label: 'regex' },
+                          { value: 'starts_with', label: 'starts with' },
+                        ]}
+                        value={textOp}
+                        onChange={(v) => setTextOp(v ?? 'contains')}
+                        allowDeselect={false}
+                        styles={{
+                          input: {
+                            background: 'var(--bg-card)',
+                            border: '1px solid var(--border)',
+                            borderRadius: 5,
+                            fontSize: 13,
+                          },
+                        }}
+                      />
+                    </div>
+                    <div>
+                      <label
+                        style={{
+                          fontSize: 13,
+                          fontWeight: 500,
+                          color: 'var(--text-1)',
+                          display: 'block',
+                          marginBottom: 5,
+                        }}
+                      >
+                        Pattern
+                      </label>
+                      <TextInput
+                        placeholder="ship it (optional)"
+                        value={textContains}
+                        onChange={(e) => setTextContains(e.currentTarget.value)}
+                        styles={{
+                          input: {
+                            background: 'var(--bg-card)',
+                            border: '1px solid var(--border)',
+                            borderRadius: 5,
+                            fontSize: 13,
+                          },
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <div style={{ marginBottom: 12 }}>
+                    <Switch
+                      label="Report failures back to Slack"
+                      description="When a run from this trigger fails, reply in the same thread with the error."
+                      checked={notifyOnFailure}
+                      onChange={(e) => setNotifyOnFailure(e.currentTarget.checked)}
                     />
                   </div>
                   <div style={{ marginBottom: 12 }}>
@@ -902,12 +748,13 @@ export function TriggerFormPanel({
                         marginBottom: 5,
                       }}
                     >
-                      Task title template
+                      Subject (what the run is about)
                     </label>
-                    <TextInput
-                      placeholder="webhook.received — {{date}}"
-                      value={subjectTitleTemplate}
-                      onChange={(e) => setSubjectTitleTemplate(e.currentTarget.value)}
+                    <Select
+                      data={sessionOptions}
+                      value={subjectPolicy}
+                      onChange={(v) => setSubjectPolicy(v ?? 'none')}
+                      allowDeselect={false}
                       styles={{
                         input: {
                           background: 'var(--bg-card)',
@@ -918,74 +765,494 @@ export function TriggerFormPanel({
                       }}
                     />
                   </div>
+                  {subjectPolicy !== 'none' && (
+                    <>
+                      <div style={{ marginBottom: 12 }}>
+                        <label
+                          style={{
+                            fontSize: 13,
+                            fontWeight: 500,
+                            color: 'var(--text-1)',
+                            display: 'block',
+                            marginBottom: 5,
+                          }}
+                        >
+                          Task column
+                        </label>
+                        <Select
+                          data={columnData}
+                          value={subjectColumnId}
+                          onChange={setSubjectColumnId}
+                          styles={{
+                            input: {
+                              background: 'var(--bg-card)',
+                              border: '1px solid var(--border)',
+                              borderRadius: 5,
+                              fontSize: 13,
+                            },
+                          }}
+                        />
+                      </div>
+                      <div style={{ marginBottom: 12 }}>
+                        <label
+                          style={{
+                            fontSize: 13,
+                            fontWeight: 500,
+                            color: 'var(--text-1)',
+                            display: 'block',
+                            marginBottom: 5,
+                          }}
+                        >
+                          Task title template
+                        </label>
+                        <TextInput
+                          placeholder="slack.message — {{date}}"
+                          value={subjectTitleTemplate}
+                          onChange={(e) => setSubjectTitleTemplate(e.currentTarget.value)}
+                          styles={{
+                            input: {
+                              background: 'var(--bg-card)',
+                              border: '1px solid var(--border)',
+                              borderRadius: 5,
+                              fontSize: 13,
+                            },
+                          }}
+                        />
+                      </div>
+                    </>
+                  )}
                 </>
               )}
-            </>
-          )}
 
-          {/* Enabled toggle for edit mode (non-column) */}
-          {isEdit && kind !== 'column' && (
-            <Switch label="Enabled" checked={enabled} onChange={(e) => setEnabled(e.currentTarget.checked)} />
-          )}
+              {/* Webhook fields */}
+              {kind === 'webhook' && (
+                <>
+                  {!isEdit && (
+                    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 12 }}>
+                      <div>
+                        <label
+                          style={{
+                            fontSize: 13,
+                            fontWeight: 500,
+                            color: 'var(--text-1)',
+                            display: 'block',
+                            marginBottom: 5,
+                          }}
+                        >
+                          Verification
+                        </label>
+                        <Select
+                          data={[
+                            { value: 'none', label: 'None' },
+                            { value: 'hmac_sha256', label: 'HMAC SHA-256' },
+                            { value: 'shared_token', label: 'Shared token' },
+                          ]}
+                          value={verification}
+                          onChange={(v) => setVerification(v ?? 'none')}
+                          allowDeselect={false}
+                          styles={{
+                            input: {
+                              background: 'var(--bg-card)',
+                              border: '1px solid var(--border)',
+                              borderRadius: 5,
+                              fontSize: 13,
+                            },
+                          }}
+                        />
+                      </div>
+                      <div>
+                        <label
+                          style={{
+                            fontSize: 13,
+                            fontWeight: 500,
+                            color: 'var(--text-1)',
+                            display: 'block',
+                            marginBottom: 5,
+                          }}
+                        >
+                          Secret
+                        </label>
+                        <PasswordInput
+                          placeholder="optional"
+                          value={secret}
+                          onChange={(e) => setSecret(e.currentTarget.value)}
+                          styles={{
+                            input: {
+                              background: 'var(--bg-card)',
+                              border: '1px solid var(--border)',
+                              borderRadius: 5,
+                              fontSize: 13,
+                            },
+                          }}
+                        />
+                      </div>
+                    </div>
+                  )}
+                  <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--text-2)', marginBottom: 8 }}>
+                    Only when (optional)
+                  </div>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 90px 1fr', gap: 10, marginBottom: 12 }}>
+                    <div>
+                      <label
+                        style={{
+                          fontSize: 13,
+                          fontWeight: 500,
+                          color: 'var(--text-1)',
+                          display: 'block',
+                          marginBottom: 5,
+                        }}
+                      >
+                        Field
+                      </label>
+                      <TextInput
+                        placeholder="ref"
+                        value={condField}
+                        onChange={(e) => setCondField(e.currentTarget.value)}
+                        styles={{
+                          input: {
+                            background: 'var(--bg-card)',
+                            border: '1px solid var(--border)',
+                            borderRadius: 5,
+                            fontSize: 13,
+                          },
+                        }}
+                      />
+                    </div>
+                    <div>
+                      <label
+                        style={{
+                          fontSize: 13,
+                          fontWeight: 500,
+                          color: 'var(--text-1)',
+                          display: 'block',
+                          marginBottom: 5,
+                        }}
+                      >
+                        Op
+                      </label>
+                      <Select
+                        data={['eq', 'ne', 'contains', 'starts_with', 'ends_with'].map((o) => ({ value: o, label: o }))}
+                        value={condOp}
+                        onChange={(v) => setCondOp(v ?? 'eq')}
+                        allowDeselect={false}
+                        styles={{
+                          input: {
+                            background: 'var(--bg-card)',
+                            border: '1px solid var(--border)',
+                            borderRadius: 5,
+                            fontSize: 13,
+                          },
+                        }}
+                      />
+                    </div>
+                    <div>
+                      <label
+                        style={{
+                          fontSize: 13,
+                          fontWeight: 500,
+                          color: 'var(--text-1)',
+                          display: 'block',
+                          marginBottom: 5,
+                        }}
+                      >
+                        Value
+                      </label>
+                      <TextInput
+                        placeholder="refs/heads/main"
+                        value={condValue}
+                        onChange={(e) => setCondValue(e.currentTarget.value)}
+                        styles={{
+                          input: {
+                            background: 'var(--bg-card)',
+                            border: '1px solid var(--border)',
+                            borderRadius: 5,
+                            fontSize: 13,
+                          },
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <div style={{ marginBottom: 12 }}>
+                    <label
+                      style={{
+                        fontSize: 13,
+                        fontWeight: 500,
+                        color: 'var(--text-1)',
+                        display: 'block',
+                        marginBottom: 5,
+                      }}
+                    >
+                      Subject (what the run is about)
+                    </label>
+                    <Select
+                      data={sessionOptions}
+                      value={subjectPolicy}
+                      onChange={(v) => setSubjectPolicy(v ?? 'none')}
+                      allowDeselect={false}
+                      styles={{
+                        input: {
+                          background: 'var(--bg-card)',
+                          border: '1px solid var(--border)',
+                          borderRadius: 5,
+                          fontSize: 13,
+                        },
+                      }}
+                    />
+                  </div>
+                  {subjectPolicy !== 'none' && (
+                    <>
+                      <div style={{ marginBottom: 12 }}>
+                        <label
+                          style={{
+                            fontSize: 13,
+                            fontWeight: 500,
+                            color: 'var(--text-1)',
+                            display: 'block',
+                            marginBottom: 5,
+                          }}
+                        >
+                          Task column
+                        </label>
+                        <Select
+                          data={columnData}
+                          value={subjectColumnId}
+                          onChange={setSubjectColumnId}
+                          styles={{
+                            input: {
+                              background: 'var(--bg-card)',
+                              border: '1px solid var(--border)',
+                              borderRadius: 5,
+                              fontSize: 13,
+                            },
+                          }}
+                        />
+                      </div>
+                      <div style={{ marginBottom: 12 }}>
+                        <label
+                          style={{
+                            fontSize: 13,
+                            fontWeight: 500,
+                            color: 'var(--text-1)',
+                            display: 'block',
+                            marginBottom: 5,
+                          }}
+                        >
+                          Task title template
+                        </label>
+                        <TextInput
+                          placeholder="webhook.received — {{date}}"
+                          value={subjectTitleTemplate}
+                          onChange={(e) => setSubjectTitleTemplate(e.currentTarget.value)}
+                          styles={{
+                            input: {
+                              background: 'var(--bg-card)',
+                              border: '1px solid var(--border)',
+                              borderRadius: 5,
+                              fontSize: 13,
+                            },
+                          }}
+                        />
+                      </div>
+                    </>
+                  )}
+                </>
+              )}
 
-          {error && <div style={{ fontSize: 12, color: 'var(--mantine-color-red-6)', marginTop: 8 }}>{error}</div>}
-        </div>
+              {/* Enabled toggle for edit mode (non-column) */}
+              {isEdit && kind !== 'column' && (
+                <Switch label="Enabled" checked={enabled} onChange={(e) => setEnabled(e.currentTarget.checked)} />
+              )}
 
-        {/* Footer */}
+              {error && <div style={{ fontSize: 12, color: 'var(--mantine-color-red-6)', marginTop: 8 }}>{error}</div>}
+            </div>
+
+            {/* Footer */}
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                gap: 10,
+                padding: '16px 24px',
+                borderTop: '1px solid var(--border)',
+                flexShrink: 0,
+              }}
+            >
+              <button
+                onClick={onClose}
+                style={{
+                  background: 'none',
+                  border: '1px solid var(--border)',
+                  borderRadius: 6,
+                  padding: '8px 16px',
+                  fontSize: 13,
+                  fontWeight: 500,
+                  color: 'var(--text-2)',
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                  transition: 'all 0.12s',
+                }}
+                onMouseEnter={(e) => {
+                  (e.currentTarget as HTMLElement).style.color = 'var(--text-1)';
+                  (e.currentTarget as HTMLElement).style.background = 'var(--bg-hover)';
+                }}
+                onMouseLeave={(e) => {
+                  (e.currentTarget as HTMLElement).style.color = 'var(--text-2)';
+                  (e.currentTarget as HTMLElement).style.background = 'none';
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={submit}
+                disabled={saving || (kind === 'schedule' && !cronDesc.ok)}
+                style={{
+                  background: saving || (kind === 'schedule' && !cronDesc.ok) ? 'var(--accent-dim)' : 'var(--accent)',
+                  border: 'none',
+                  borderRadius: 6,
+                  padding: '8px 16px',
+                  fontSize: 13,
+                  fontWeight: 600,
+                  color:
+                    saving || (kind === 'schedule' && !cronDesc.ok) ? 'var(--accent-muted)' : 'var(--app-on-primary)',
+                  cursor: saving || (kind === 'schedule' && !cronDesc.ok) ? 'not-allowed' : 'pointer',
+                  fontFamily: 'inherit',
+                  transition: 'all 0.12s',
+                }}
+              >
+                {saving ? 'Saving…' : isEdit ? 'Update trigger' : 'Add trigger'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}
+
+function CopyRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)', marginBottom: 5 }}>{label}</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         <div
           style={{
-            display: 'flex',
-            justifyContent: 'flex-end',
-            gap: 10,
-            padding: '16px 24px',
-            borderTop: '1px solid var(--border)',
-            flexShrink: 0,
+            flex: 1,
+            fontSize: 12,
+            fontFamily: 'monospace',
+            color: 'var(--text-2)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
           }}
         >
-          <button
-            onClick={onClose}
-            style={{
-              background: 'none',
-              border: '1px solid var(--border)',
-              borderRadius: 6,
-              padding: '8px 16px',
-              fontSize: 13,
-              fontWeight: 500,
-              color: 'var(--text-2)',
-              cursor: 'pointer',
-              fontFamily: 'inherit',
-              transition: 'all 0.12s',
-            }}
-            onMouseEnter={(e) => {
-              (e.currentTarget as HTMLElement).style.color = 'var(--text-1)';
-              (e.currentTarget as HTMLElement).style.background = 'var(--bg-hover)';
-            }}
-            onMouseLeave={(e) => {
-              (e.currentTarget as HTMLElement).style.color = 'var(--text-2)';
-              (e.currentTarget as HTMLElement).style.background = 'none';
-            }}
-          >
-            Cancel
-          </button>
-          <button
-            onClick={submit}
-            disabled={saving || (kind === 'schedule' && !cronDesc.ok)}
-            style={{
-              background: saving || (kind === 'schedule' && !cronDesc.ok) ? 'var(--accent-dim)' : 'var(--accent)',
-              border: 'none',
-              borderRadius: 6,
-              padding: '8px 16px',
-              fontSize: 13,
-              fontWeight: 600,
-              color: saving || (kind === 'schedule' && !cronDesc.ok) ? 'var(--accent-muted)' : 'var(--app-on-primary)',
-              cursor: saving || (kind === 'schedule' && !cronDesc.ok) ? 'not-allowed' : 'pointer',
-              fontFamily: 'inherit',
-              transition: 'all 0.12s',
-            }}
-          >
-            {saving ? 'Saving…' : isEdit ? 'Update trigger' : 'Add trigger'}
-          </button>
+          {value}
         </div>
+        <CopyButton value={value}>
+          {({ copied, copy }) => (
+            <Button
+              size="compact-xs"
+              variant="light"
+              onClick={copy}
+              leftSection={copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+            >
+              {copied ? 'Copied' : 'Copy'}
+            </Button>
+          )}
+        </CopyButton>
+      </div>
+    </div>
+  );
+}
+
+function WebhookCreatedView({
+  created,
+  onDone,
+}: {
+  created: { url: string; secret: string; verification: string };
+  onDone: () => void;
+}) {
+  const curl = buildWebhookCurl(created.url, created.secret, created.verification);
+  const authLabel =
+    created.verification === 'none'
+      ? 'no auth'
+      : created.verification === 'hmac_sha256'
+        ? 'HMAC SHA-256'
+        : 'shared token';
+
+  return (
+    <>
+      <div style={{ flex: 1, overflowY: 'auto', padding: 24 }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-1)', marginBottom: 4 }}>
+          Webhook trigger created
+        </div>
+        <div style={{ fontSize: 12, color: 'var(--text-2)', marginBottom: 16, lineHeight: 1.5 }}>
+          Point your source at this URL. It is an idempotent start API for this workflow.
+        </div>
+        <CopyRow label="Request URL" value={created.url} />
+        {created.secret && <CopyRow label="Secret" value={created.secret} />}
+        <div style={{ marginBottom: 12 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 5 }}>
+            <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-1)' }}>Example request ({authLabel})</div>
+            <CopyButton value={curl}>
+              {({ copied, copy }) => (
+                <Button
+                  size="compact-xs"
+                  variant="light"
+                  onClick={copy}
+                  leftSection={copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+                >
+                  {copied ? 'Copied' : 'Copy curl'}
+                </Button>
+              )}
+            </CopyButton>
+          </div>
+          <pre
+            style={{
+              fontSize: 12,
+              fontFamily: 'monospace',
+              whiteSpace: 'pre',
+              overflowX: 'auto',
+              background: 'var(--bg-raised)',
+              border: '1px solid var(--border)',
+              padding: 8,
+              borderRadius: 6,
+              margin: 0,
+              color: 'var(--text-1)',
+            }}
+          >
+            {curl}
+          </pre>
+        </div>
+        <div style={{ fontSize: 12, color: 'var(--text-2)' }}>
+          Runs the workflow as you — the trigger&apos;s creator.
+        </div>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          gap: 10,
+          padding: '16px 24px',
+          borderTop: '1px solid var(--border)',
+          flexShrink: 0,
+        }}
+      >
+        <button
+          onClick={onDone}
+          style={{
+            background: 'var(--accent)',
+            border: 'none',
+            borderRadius: 6,
+            padding: '8px 16px',
+            fontSize: 13,
+            fontWeight: 600,
+            color: 'var(--app-on-primary)',
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+          }}
+        >
+          Done
+        </button>
       </div>
     </>
   );


### PR DESCRIPTION
Fixes palad-ai/palad-app#624

## Why the bug existed

After the triggers UI was redesigned, the create form moved into `TriggerFormPanel`, which treats a webhook create like any other trigger: it `POST`s and immediately closes via `onSaved()`. The backend still returns `webhook_url` / `webhook_secret` / `verification_strategy` from `create_webhook_trigger` (`app/controllers/api/v1/projects/workflows/triggers_controller.rb`), but the panel never read that response, so the ready-to-run cURL example was gone.

The old drawer (`WorkflowTriggersDrawer`) kept its `buildWebhookCurl` helper and its "Webhook trigger created" block — but that drawer is no longer used in production, so the success state was effectively lost.

## What changed

`TriggerFormPanel.tsx`:

- Ported `buildWebhookCurl` from the old drawer.
- Added a `created` state. On a **successful webhook create** (not on PATCH), the panel stays open on a success view instead of closing.
- The success view (`WebhookCreatedView`) shows:
  - the request URL and the secret when present, both copyable;
  - an example cURL matching the selected verification — `none` (JSON body, no auth), `hmac_sha256` (`X-Hub-Signature-256`), `shared_token` (`X-Webhook-Token`);
  - **Copy curl** (full command) and **Done**.
- **List-refresh fix:** once a webhook is created the trigger already exists on the server, so dismissing the panel *any* way — scrim, ✕, or **Done** — now routes through `onSaved` (close + reload). Previously ✕/scrim called `onClose` only and the new trigger did not appear until a manual refresh.

Editing an existing webhook is unchanged (verification/secret immutable, no cURL screen on PATCH). Non-webhook creates are unchanged — they close via `onSaved` with no success screen.

## Tests

Added to `TriggerFormPanel.test.tsx` (mirrors the old drawer tests):

- success view after create for `none` — URL + cURL shown, `onSaved` not called until **Done**;
- `shared_token` — secret + `X-Webhook-Token` cURL + **Copy curl**;
- `hmac_sha256` — `X-Hub-Signature-256` / `openssl dgst` cURL;
- dismissing the success view via ✕ calls `onSaved` (list refresh), not `onClose`;
- non-webhook trigger — no success screen, closes via `onSaved`.

`docker compose exec -T web make check_all` — green (rails-test, rubocop, brakeman, system-test, eslint, typescript, fsd, fe-test, vite-build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LnXH16Mk6wcHU631ZG8Yi