### PR TITLE
feat(tools): offer Slack, Coder and Assets as picker groups

### DIFF
--- a/app/controllers/web/company/projects/sessions_controller.rb
+++ b/app/controllers/web/company/projects/sessions_controller.rb
@@ -97,6 +97,9 @@ class Web::Company::Projects::SessionsController < Web::Company::Projects::Appli
     {
       agents: agents.map { |a| { id: a.id, name: a.title.presence || a.name } },
       tools: tools.map { |t| { id: t.id, name: t.display_name.presence || t.name } },
+      # Tag groups the picker offers as one-click attach ("Board management" →
+      # every board tool), the same ones the workflow builder offers.
+      tool_groups: Tools::PickerGroups.for_project(current_project),
       skills: skills.map { |s| { id: s.id, name: s.title.presence || s.name } },
       mcp_servers: mcp_servers.map { |m| { id: m.id, name: m.name } },
       assets: assets.map { |a| { id: a.id, name: a.folder.present? ? "#{a.folder}/#{a.name}" : a.name } },

--- a/app/frontend/pages/Projects/Sessions/NewPage.tsx
+++ b/app/frontend/pages/Projects/Sessions/NewPage.tsx
@@ -3,6 +3,7 @@ import { Box } from '@mantine/core';
 
 import { SessionNewForm } from 'shared/components/SessionNewForm';
 import type { ConfigItemOption, NamedItem, SessionCostHint } from 'shared/components/SessionNewForm';
+import type { ToolGroup } from 'shared/lib/toolPicker';
 import { PageHeader } from 'shared/ui/PageHeader';
 
 import { persistentProjectLayout, setPageLayout } from '../ProjectLayout';
@@ -27,6 +28,7 @@ interface Props {
   agentModels?: AgentModelsEntry[];
   agents?: NamedItem[];
   tools?: NamedItem[];
+  toolGroups?: ToolGroup[];
   skills?: NamedItem[];
   mcpServers?: NamedItem[];
   repositories?: NamedItem[];
@@ -41,6 +43,7 @@ const ProjectSessionNewPage = () => {
     agentModels = [],
     agents = [],
     tools = [],
+    toolGroups = [],
     skills = [],
     mcpServers = [],
     repositories = [],
@@ -59,6 +62,7 @@ const ProjectSessionNewPage = () => {
           agentModels={agentModels}
           agents={agents}
           tools={tools}
+          toolGroups={toolGroups}
           skills={skills}
           mcpServers={mcpServers}
           repositories={repositories}

--- a/app/frontend/pages/Projects/Sessions/NewSessionDrawer.tsx
+++ b/app/frontend/pages/Projects/Sessions/NewSessionDrawer.tsx
@@ -35,6 +35,7 @@ export function NewSessionDrawer({ projectId, opened, onClose }: Props) {
           agentModels={options.agentModels}
           agents={options.agents}
           tools={options.tools}
+          toolGroups={options.toolGroups}
           skills={options.skills}
           mcpServers={options.mcpServers}
           repositories={options.repositories}

--- a/app/frontend/pages/Projects/Sessions/useCreateOptions.ts
+++ b/app/frontend/pages/Projects/Sessions/useCreateOptions.ts
@@ -2,6 +2,7 @@ import { router, usePage } from '@inertiajs/react';
 import { useEffect } from 'react';
 
 import { ConfigItemOption } from 'shared/components/SessionNewForm';
+import type { ToolGroup } from 'shared/lib/toolPicker';
 
 interface NamedItem {
   id: number;
@@ -23,6 +24,7 @@ interface WorkflowOption {
 export interface CreateOptions {
   agents: NamedItem[];
   tools: NamedItem[];
+  toolGroups: ToolGroup[];
   skills: NamedItem[];
   mcpServers: NamedItem[];
   assets: NamedItem[];

--- a/app/frontend/pages/Projects/Workflows/BaseResourcesTab.tsx
+++ b/app/frontend/pages/Projects/Workflows/BaseResourcesTab.tsx
@@ -2,15 +2,11 @@ import { MultiSelect, Switch } from '@mantine/core';
 
 import type { ConfigItemPicker } from '@/types/generated';
 
+import { toolIdsFromPickerValue, toolPickerData, toolPickerValue, type ToolGroup } from 'shared/lib/toolPicker';
+
 interface NamedItem {
   id: number;
   name: string;
-}
-
-interface ToolGroup {
-  tag: string;
-  label: string;
-  toolIds: number[];
 }
 
 interface Workflow {
@@ -36,8 +32,6 @@ interface BaseResourcesTabProps {
   onWorkflowChange: (field: string, value: unknown) => void;
 }
 
-const GROUP_PREFIX = 'grp:';
-
 export function BaseResourcesTab({
   workflow,
   tools,
@@ -50,36 +44,9 @@ export function BaseResourcesTab({
   readOnly,
   onWorkflowChange,
 }: BaseResourcesTabProps) {
-  const groupedToolIds = new Set(toolGroups.flatMap((g) => g.toolIds));
-
-  const toolSelectData = [
-    ...toolGroups.map((g) => ({ value: `${GROUP_PREFIX}${g.tag}`, label: g.label })),
-    ...tools
-      .filter((i) => i?.id != null && !groupedToolIds.has(i.id))
-      .map((i) => ({ value: String(i.id), label: i.name ?? '' })),
-  ];
-
-  const toToolValue = (ids: number[]) => {
-    const set = new Set(Array.isArray(ids) ? ids : []);
-    const groupTokens = toolGroups
-      .filter((g) => g.toolIds.some((id) => set.has(id)))
-      .map((g) => `${GROUP_PREFIX}${g.tag}`);
-    const individual = [...set].filter((id) => !groupedToolIds.has(id)).map(String);
-    return [...groupTokens, ...individual];
-  };
-
-  const fromToolValue = (values: string[]): number[] => {
-    const ids = new Set<number>();
-    (Array.isArray(values) ? values : []).forEach((v) => {
-      if (v.startsWith(GROUP_PREFIX)) {
-        const group = toolGroups.find((g) => `${GROUP_PREFIX}${g.tag}` === v);
-        group?.toolIds.forEach((id) => ids.add(id));
-      } else {
-        ids.add(Number(v));
-      }
-    });
-    return [...ids];
-  };
+  const toolSelectData = toolPickerData(tools, toolGroups);
+  const toToolValue = (ids: number[]) => toolPickerValue(ids, toolGroups);
+  const fromToolValue = (values: string[]) => toolIdsFromPickerValue(values, toolGroups);
 
   const toSelectData = (items: NamedItem[]) =>
     Array.isArray(items)

--- a/app/frontend/pages/Projects/Workflows/BuilderPage.tsx
+++ b/app/frontend/pages/Projects/Workflows/BuilderPage.tsx
@@ -9,6 +9,7 @@ import type { ConfigItemPicker } from '@/types/generated';
 
 import { RunWorkflowDrawer } from 'shared/components/RunWorkflowDrawer';
 import { apiFetch } from 'shared/lib/apiFetch';
+import type { ToolGroup } from 'shared/lib/toolPicker';
 import {
   apiV1ProjectWorkflowPath,
   apiV1ProjectWorkflowStepsPath,
@@ -38,11 +39,6 @@ interface NamedItem {
   name: string;
 }
 
-interface ToolGroup {
-  tag: string;
-  label: string;
-  toolIds: number[];
-}
 interface SubStep {
   id: number;
   name: string;

--- a/app/frontend/pages/Projects/Workflows/SessionEditorPanel.tsx
+++ b/app/frontend/pages/Projects/Workflows/SessionEditorPanel.tsx
@@ -15,17 +15,13 @@ import { useState } from 'react';
 
 import type { ConfigItemPicker } from '@/types/generated';
 
+import { toolIdsFromPickerValue, toolPickerData, toolPickerValue, type ToolGroup } from 'shared/lib/toolPicker';
+
 import classes from './BuilderPage.module.css';
 
 interface NamedItem {
   id: number;
   name: string;
-}
-
-interface ToolGroup {
-  tag: string;
-  label: string;
-  toolIds: number[];
 }
 
 interface AssetSpec {
@@ -157,8 +153,6 @@ function AssetRows({ specs, onChange, showNamePattern, disabled, kind }: AssetRo
   );
 }
 
-const GROUP_PREFIX = 'grp:';
-
 interface AgentModel {
   modelId: string;
   displayName: string;
@@ -220,35 +214,9 @@ export function SessionEditorPanel({
     .filter((c) => c?.id != null)
     .map((c) => ({ value: String(c.id), label: c.itemType === 'secret' ? `${c.name} (secret)` : c.name }));
 
-  const groupedToolIds = new Set(toolGroups.flatMap((g) => g.toolIds));
-  const toolSelectData = [
-    ...toolGroups.map((g) => ({ value: `${GROUP_PREFIX}${g.tag}`, label: g.label })),
-    ...tools
-      .filter((i) => i?.id != null && !groupedToolIds.has(i.id))
-      .map((i) => ({ value: String(i.id), label: i.name ?? '' })),
-  ];
-
-  const toToolValue = (ids: number[]) => {
-    const set = new Set(Array.isArray(ids) ? ids : []);
-    const groupTokens = toolGroups
-      .filter((g) => g.toolIds.some((id) => set.has(id)))
-      .map((g) => `${GROUP_PREFIX}${g.tag}`);
-    const individual = [...set].filter((id) => !groupedToolIds.has(id)).map(String);
-    return [...groupTokens, ...individual];
-  };
-
-  const fromToolValue = (values: string[]): number[] => {
-    const ids = new Set<number>();
-    (Array.isArray(values) ? values : []).forEach((v) => {
-      if (v.startsWith(GROUP_PREFIX)) {
-        const group = toolGroups.find((g) => `${GROUP_PREFIX}${g.tag}` === v);
-        group?.toolIds.forEach((id) => ids.add(id));
-      } else {
-        ids.add(Number(v));
-      }
-    });
-    return [...ids];
-  };
+  const toolSelectData = toolPickerData(tools, toolGroups);
+  const toToolValue = (ids: number[]) => toolPickerValue(ids, toolGroups);
+  const fromToolValue = (values: string[]) => toolIdsFromPickerValue(values, toolGroups);
 
   const toSelectData = (items: NamedItem[]) =>
     Array.isArray(items)

--- a/app/frontend/shared/components/SessionNewForm.test.tsx
+++ b/app/frontend/shared/components/SessionNewForm.test.tsx
@@ -218,4 +218,63 @@ describe('SessionNewForm', () => {
 
     fetchSpy.mockRestore();
   });
+
+  it('offers a tool group as one entry instead of its members', async () => {
+    const user = userEvent.setup();
+    renderAuthedPage(
+      <SessionNewForm
+        {...makeProps({
+          projectId: 3,
+          tools: [
+            { id: 10, name: 'Board List Tasks' },
+            { id: 11, name: 'Board Move Task' },
+            { id: 20, name: 'Echo Greeter' },
+          ],
+          toolGroups: [{ tag: 'board', label: 'Board management', toolIds: [10, 11] }],
+        })}
+      />,
+      { props: authProps(['claude_code']) },
+    );
+
+    await user.click(screen.getByRole('combobox', { name: /tools/i }));
+
+    expect(await screen.findByText('Board management')).toBeInTheDocument();
+    expect(screen.queryByText('Board List Tasks')).not.toBeInTheDocument();
+    expect(screen.queryByText('Board Move Task')).not.toBeInTheDocument();
+    // An ungrouped tool is still attachable on its own.
+    expect(screen.getByText('Echo Greeter')).toBeInTheDocument();
+  });
+
+  it('sends every member id when a tool group is selected', async () => {
+    const user = userEvent.setup();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { id: 'sess-9' } }),
+    } as Response);
+
+    renderAuthedPage(
+      <SessionNewForm
+        {...makeProps({
+          projectId: 3,
+          tools: [
+            { id: 10, name: 'Board List Tasks' },
+            { id: 11, name: 'Board Move Task' },
+          ],
+          toolGroups: [{ tag: 'board', label: 'Board management', toolIds: [10, 11] }],
+        })}
+      />,
+      { props: authProps(['claude_code']) },
+    );
+
+    await user.click(screen.getByText('Claude Code'));
+    await user.click(screen.getByRole('combobox', { name: /tools/i }));
+    await user.click(await screen.findByText('Board management'));
+    await user.click(screen.getByRole('button', { name: /start session/i }));
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(JSON.parse(init!.body as string).terminalSession.toolIds).toEqual([10, 11]);
+
+    fetchSpy.mockRestore();
+  });
 });

--- a/app/frontend/shared/components/SessionNewForm.tsx
+++ b/app/frontend/shared/components/SessionNewForm.tsx
@@ -8,6 +8,7 @@ import type { ConfigItemPicker } from '@/types/generated';
 
 import { apiFetch } from 'shared/lib/apiFetch';
 import { useProjectPermissions } from 'shared/lib/hooks/useProjectPermissions';
+import { toolIdsFromPickerValue, toolPickerData, type ToolGroup } from 'shared/lib/toolPicker';
 import { apiV1TerminalSessionsPath } from 'shared/routes';
 import { AGENT_BRAND_COLORS } from 'shared/theme/vendorColors';
 import { FormSection, ModeCards, RuntimeTiles } from 'shared/ui/sessions';
@@ -35,6 +36,12 @@ export interface SessionNewFormProps {
   agentModels?: AgentModelsEntry[];
   agents?: NamedItem[];
   tools?: NamedItem[];
+  /**
+   * Tag groups offered as one entry each ("Board management", "Slack"), exactly
+   * as the workflow builder offers them — attaching a family of tools one by
+   * one is what the groups exist to avoid.
+   */
+  toolGroups?: ToolGroup[];
   skills?: NamedItem[];
   mcpServers?: NamedItem[];
   repositories?: NamedItem[];
@@ -91,6 +98,7 @@ export const SessionNewForm = ({
   agentModels = [],
   agents = [],
   tools = [],
+  toolGroups = [],
   skills = [],
   mcpServers = [],
   repositories = [],
@@ -130,6 +138,10 @@ export const SessionNewForm = ({
   const [selectedAssets, setSelectedAssets] = useState<string[]>([]);
   const [selectedConfigItems, setSelectedConfigItems] = useState<string[]>([]);
 
+  // `selectedTools` holds picker values — a group token stands for all of its
+  // members, so every id-shaped use goes through the expanded list.
+  const selectedToolIds = useMemo(() => toolIdsFromPickerValue(selectedTools, toolGroups), [selectedTools, toolGroups]);
+
   const resolvedProjectId = fixedProjectId ? String(fixedProjectId) : projectId;
   const showProjectSelector = !fixedProjectId && projects && projects.length > 0;
 
@@ -153,7 +165,7 @@ export const SessionNewForm = ({
     if (selectedPersona) count++;
     if (selectedModel) count++;
     count +=
-      selectedTools.length +
+      selectedToolIds.length +
       selectedSkills.length +
       selectedMcpServers.length +
       selectedRepos.length +
@@ -164,7 +176,7 @@ export const SessionNewForm = ({
   }, [
     selectedPersona,
     selectedModel,
-    selectedTools,
+    selectedToolIds,
     selectedSkills,
     selectedMcpServers,
     selectedRepos,
@@ -192,7 +204,7 @@ export const SessionNewForm = ({
             initialPrompt: mode === 'non_interactive' ? initialPrompt : null,
             requestedModel: selectedModel || undefined,
             configuredAgentId: selectedPersona ? Number(selectedPersona) : undefined,
-            toolIds: selectedTools.length > 0 ? selectedTools.map(Number) : undefined,
+            toolIds: selectedToolIds.length > 0 ? selectedToolIds : undefined,
             skillIds: selectedSkills.length > 0 ? selectedSkills.map(Number) : undefined,
             mcpServerIds: selectedMcpServers.length > 0 ? selectedMcpServers.map(Number) : undefined,
             repositoryIds: selectedRepos.length > 0 ? selectedRepos.map(Number) : undefined,
@@ -238,7 +250,7 @@ export const SessionNewForm = ({
     bmadEnabled,
     selectedModel,
     selectedPersona,
-    selectedTools,
+    selectedToolIds,
     selectedSkills,
     selectedMcpServers,
     selectedRepos,
@@ -370,7 +382,7 @@ export const SessionNewForm = ({
         <MultiSelect
           label="Tools"
           placeholder="Select tools..."
-          data={tools.map((t) => ({ value: String(t.id), label: t.name }))}
+          data={toolPickerData(tools, toolGroups)}
           value={selectedTools}
           onChange={setSelectedTools}
           searchable
@@ -492,9 +504,9 @@ export const SessionNewForm = ({
                   {agents.find((a) => String(a.id) === selectedPersona)?.name ?? 'Persona'}
                 </Badge>
               )}
-              {selectedTools.length > 0 && (
+              {selectedToolIds.length > 0 && (
                 <Badge size="xs" variant="outline" color="yellow">
-                  {selectedTools.length} tool{selectedTools.length > 1 ? 's' : ''}
+                  {selectedToolIds.length} tool{selectedToolIds.length > 1 ? 's' : ''}
                 </Badge>
               )}
               {selectedSkills.length > 0 && (

--- a/app/frontend/shared/lib/toolPicker.test.ts
+++ b/app/frontend/shared/lib/toolPicker.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { toolIdsFromPickerValue, toolPickerData, toolPickerValue, type ToolGroup } from './toolPicker';
+
+const tools = [
+  { id: 10, name: 'Board List Tasks' },
+  { id: 11, name: 'Board Move Task' },
+  { id: 20, name: 'Slack Post Message' },
+  { id: 30, name: 'Echo Greeter' },
+];
+
+const groups: ToolGroup[] = [
+  { tag: 'board', label: 'Board management', toolIds: [10, 11] },
+  { tag: 'slack', label: 'Slack', toolIds: [20] },
+];
+
+describe('toolPicker', () => {
+  it('offers each group once and keeps its members out of the flat list', () => {
+    expect(toolPickerData(tools, groups)).toEqual([
+      { value: 'grp:board', label: 'Board management' },
+      { value: 'grp:slack', label: 'Slack' },
+      { value: '30', label: 'Echo Greeter' },
+    ]);
+  });
+
+  it('lists every tool individually when no group is offered', () => {
+    expect(toolPickerData(tools, [])).toHaveLength(4);
+  });
+
+  it('collapses grouped ids into their token and leaves ungrouped ids alone', () => {
+    expect(toolPickerValue([10, 11, 30], groups)).toEqual(['grp:board', '30']);
+  });
+
+  it('expands a group token back into every member id', () => {
+    expect(toolIdsFromPickerValue(['grp:board', '30'], groups)).toEqual([10, 11, 30]);
+    expect(toolIdsFromPickerValue(['grp:board', 'grp:slack'], groups)).toEqual([10, 11, 20]);
+  });
+
+  it('round-trips a selection of whole groups', () => {
+    const ids = toolIdsFromPickerValue(toolPickerValue([10, 11, 20], groups), groups);
+
+    expect(ids).toEqual([10, 11, 20]);
+  });
+});

--- a/app/frontend/shared/lib/toolPicker.ts
+++ b/app/frontend/shared/lib/toolPicker.ts
@@ -1,0 +1,65 @@
+export interface ToolGroup {
+  tag: string;
+  label: string;
+  toolIds: number[];
+}
+
+export interface ToolOption {
+  id: number;
+  name: string;
+}
+
+const GROUP_PREFIX = 'grp:';
+
+const groupValue = (group: ToolGroup) => `${GROUP_PREFIX}${group.tag}`;
+
+const memberIds = (groups: ToolGroup[]) =>
+  new Set((Array.isArray(groups) ? groups : []).flatMap((g) => g.toolIds ?? []));
+
+/**
+ * A tag group ("Board management", "Slack") is offered as ONE picker entry that
+ * attaches every tool carrying the tag — members are never listed one by one.
+ * The picker's value is therefore not the raw id list: grouped ids collapse
+ * into their group token, and only ungrouped tools stand on their own.
+ *
+ * Shared by all three tool pickers (workflow base resources, step session
+ * editor, new session) so a group behaves identically wherever it is offered.
+ */
+export function toolPickerData(tools: ToolOption[], groups: ToolGroup[] = []) {
+  const members = memberIds(groups);
+
+  return [
+    ...(Array.isArray(groups) ? groups : []).map((g) => ({ value: groupValue(g), label: g.label })),
+    ...(Array.isArray(tools) ? tools : [])
+      .filter((t) => t?.id != null && !members.has(t.id))
+      .map((t) => ({ value: String(t.id), label: t.name ?? '' })),
+  ];
+}
+
+/** Tool ids → picker values (group tokens + ungrouped ids). */
+export function toolPickerValue(ids: number[], groups: ToolGroup[] = []): string[] {
+  const selected = new Set(Array.isArray(ids) ? ids : []);
+  const members = memberIds(groups);
+
+  return [
+    ...(Array.isArray(groups) ? groups : [])
+      .filter((g) => (g.toolIds ?? []).some((id) => selected.has(id)))
+      .map(groupValue),
+    ...[...selected].filter((id) => !members.has(id)).map(String),
+  ];
+}
+
+/** Picker values → tool ids, expanding every group token into its members. */
+export function toolIdsFromPickerValue(values: string[], groups: ToolGroup[] = []): number[] {
+  const ids = new Set<number>();
+
+  (Array.isArray(values) ? values : []).forEach((v) => {
+    if (v.startsWith(GROUP_PREFIX)) {
+      (Array.isArray(groups) ? groups : []).find((g) => groupValue(g) === v)?.toolIds?.forEach((id) => ids.add(id));
+    } else {
+      ids.add(Number(v));
+    }
+  });
+
+  return [...ids];
+}

--- a/app/services/tools/registry.rb
+++ b/app/services/tools/registry.rb
@@ -33,11 +33,15 @@ module Tools
       end
 
       # Groups the tool picker offers as one-click attach ("Board management"
-      # attaches every board tool). Driven by TagCatalog — a group entry with
-      # its user-attachable tool names.
+      # attaches every board tool, "Slack" every Slack tool). Driven by
+      # TagCatalog — one visible entry with its user-attachable tool names.
+      #
+      # Session audience only: the personal MCP tools share tags with the
+      # session ones (:board, :sessions), and a user-audience tool has no
+      # shadow row to attach to a step.
       def ui_groups
-        TagCatalog.ui_entries.select { |e| e.presentation == :group }.filter_map do |e|
-          names = tagged(e.tag).select(&:user_attachable).map(&:name).sort
+        TagCatalog.ui_entries.filter_map do |e|
+          names = tagged(e.tag).select { |d| d.audience == :session && d.user_attachable }.map(&:name).sort
           next if names.empty?
 
           { tag: e.tag.to_s, label: e.label, tool_names: names }

--- a/app/services/tools/tag_catalog.rb
+++ b/app/services/tools/tag_catalog.rb
@@ -1,38 +1,44 @@
 # frozen_string_literal: true
 
 module Tools
-  # Single source of truth for how tool tags present in the UI tool pickers.
+  # Single source of truth for how tool tags present in the UI tool pickers
+  # (workflow Base Resources + the step session editor).
   #
   # Each entry declares, per tag:
-  # - label:        human-readable name shown in the picker
-  # - ui_visible:   whether the picker surfaces this tag at all (service and
-  #                 provider-only tags stay hidden — they auto-inject, are
-  #                 builder-bound, or are surfaced through a managed server)
-  # - presentation: :group    — the picker shows ONE entry that attaches every
-  #                             tool carrying the tag ("Board management")
-  #                 :individual — the tools show one by one, grouped under the
-  #                             label as a heading
+  # - label:      human-readable name shown in the picker
+  # - ui_visible: whether the picker offers this tag. A visible tag becomes ONE
+  #               picker entry that attaches every session tool carrying it
+  #               ("Board management", "Slack") — its members are never offered
+  #               one by one. Hidden tags stay out of the picker entirely: they
+  #               auto-inject, are builder-bound, or are surfaced through a
+  #               managed server.
   #
-  # A tag not listed here is treated as hidden. A user_attachable tool that
-  # matches no ui_visible group/individual tag falls through to the picker's
-  # ungrouped list (see Registry.tag_catalog_for_pickers).
+  # A tag not listed here is treated as hidden. A user_attachable session tool
+  # that matches no visible tag falls through to the picker's ungrouped list.
+  #
+  # A tool must not carry two visible tags — it would land in two picker groups
+  # whose selections fight over the same ids (asserted in Tools::RegistryTest).
   module TagCatalog
-    Entry = Struct.new(:tag, :label, :ui_visible, :presentation, keyword_init: true)
+    Entry = Struct.new(:tag, :label, :ui_visible, keyword_init: true)
 
     ENTRIES = [
-      Entry.new(tag: :board, label: "Board management", ui_visible: true, presentation: :group),
-      Entry.new(tag: :messaging, label: "Messaging", ui_visible: true, presentation: :individual),
-      Entry.new(tag: :slack, label: "Slack", ui_visible: false, presentation: :individual),
-      Entry.new(tag: :coder, label: "Coder", ui_visible: false, presentation: :group),
-      Entry.new(tag: :workflow_control, label: "Workflow control", ui_visible: false, presentation: :individual),
-      Entry.new(tag: :async_results, label: "Async results", ui_visible: false, presentation: :individual),
-      Entry.new(tag: :session_lifecycle, label: "Session lifecycle", ui_visible: false, presentation: :individual),
-      Entry.new(tag: :repositories, label: "Repositories", ui_visible: false, presentation: :individual),
+      Entry.new(tag: :board, label: "Board management", ui_visible: true),
+      Entry.new(tag: :slack, label: "Slack", ui_visible: true),
+      Entry.new(tag: :coder, label: "Coder", ui_visible: true),
+      Entry.new(tag: :assets, label: "Assets", ui_visible: true),
       # Read-only supervision of the OTHER sessions in the project. Its own tag
       # rather than the personal server's :sessions, so a user-audience tool can
       # never be resolved into a picker group.
-      Entry.new(tag: :session_supervision, label: "Session supervision", ui_visible: true, presentation: :group),
-      Entry.new(tag: :builder, label: "Aixle Builder", ui_visible: false, presentation: :individual)
+      Entry.new(tag: :session_supervision, label: "Session supervision", ui_visible: true),
+      # Umbrella over every chat provider. The picker groups by provider
+      # (:slack), so this one stays hidden — otherwise the Slack tools would be
+      # offered twice, under two competing entries.
+      Entry.new(tag: :messaging, label: "Messaging", ui_visible: false),
+      Entry.new(tag: :workflow_control, label: "Workflow control", ui_visible: false),
+      Entry.new(tag: :async_results, label: "Async results", ui_visible: false),
+      Entry.new(tag: :session_lifecycle, label: "Session lifecycle", ui_visible: false),
+      Entry.new(tag: :repositories, label: "Repositories", ui_visible: false),
+      Entry.new(tag: :builder, label: "Aixle Builder", ui_visible: false)
     ].freeze
 
     BY_TAG = ENTRIES.index_by(&:tag).freeze
@@ -50,12 +56,7 @@ module Tools
         entry(tag)&.ui_visible || false
       end
 
-      def group?(tag)
-        e = entry(tag)
-        e&.ui_visible && e.presentation == :group
-      end
-
-      # Ordered, UI-facing entries (for serializing the catalog to the client).
+      # Ordered, UI-facing entries — one picker group each.
       def ui_entries
         ENTRIES.select(&:ui_visible)
       end

--- a/test/services/tools/picker_groups_test.rb
+++ b/test/services/tools/picker_groups_test.rb
@@ -19,10 +19,25 @@ class Tools::PickerGroupsTest < ActiveSupport::TestCase
     assert expected.any?
   end
 
-  test "only group-presentation catalog tags appear" do
+  test "only visible catalog tags appear" do
     tags = Tools::PickerGroups.for_project(@project).map { |g| g[:tag] }
+
     assert_includes tags, "board"
-    assert_not_includes tags, "messaging"  # visible but individual, not a group
-    assert_not_includes tags, "builder"    # hidden
+    assert_not_includes tags, "messaging" # umbrella over :slack, hidden
+    assert_not_includes tags, "builder"   # hidden
+  end
+
+  test "a group whose tools this project cannot see is dropped" do
+    # Slack tools are gated on the integration, so an unconnected project must
+    # not be offered an empty "Slack" entry.
+    assert_not_includes Tools::PickerGroups.for_project(@project).map { |g| g[:tag] }, "slack"
+
+    create(:integration, :active, provider: :slack, project: @project, company: @project.company)
+    slack = Tools::PickerGroups.for_project(@project).find { |g| g[:tag] == "slack" }
+
+    assert_equal "Slack", slack[:label]
+    expected = Tool.visible_for_project(@project).select { |t| t.tags.include?("slack") }.map(&:id).sort
+    assert_equal expected, slack[:tool_ids].sort
+    assert expected.any?
   end
 end

--- a/test/services/tools/registry_test.rb
+++ b/test/services/tools/registry_test.rb
@@ -50,4 +50,28 @@ class Tools::RegistryTest < ActiveSupport::TestCase
     assert_equal 22, defs.count { |d| d.inject_rules.include?(:workflow_step_session) }
     assert_equal 3, defs.count { |d| d.inject_rules.intersect?(%i[container_tools_present non_interactive_session]) }
   end
+
+  test "ui_groups offer one entry per visible tag, session tools only" do
+    groups = Tools::Registry.ui_groups
+
+    assert_equal %w[board slack coder assets session_supervision], groups.map { |g| g[:tag] }
+    assert_equal "Slack", groups.find { |g| g[:tag] == "slack" }[:label]
+    assert_equal %w[slack_delete_message slack_post_message slack_read_thread slack_update_message],
+                 groups.find { |g| g[:tag] == "slack" }[:tool_names]
+
+    defs = groups.flat_map { |g| g[:tool_names] }.map { |n| Tools::Registry.fetch(n) }
+
+    # A personal (audience :user) tool shares tags with the session ones but has
+    # no shadow row, so it must never be pulled into a picker group.
+    assert defs.all? { |d| d.audience == :session }, "picker groups must hold session tools only"
+    assert defs.all?(&:user_attachable)
+  end
+
+  test "no tool carries two picker-visible tags" do
+    doubled = Tools::Registry.definitions.values.select do |d|
+      d.tags.count { |t| Tools::TagCatalog.ui_visible?(t) } > 1
+    end
+
+    assert_empty doubled.map(&:name), "a tool in two picker groups would fight over its own ids"
+  end
 end

--- a/test/services/tools/tag_catalog_test.rb
+++ b/test/services/tools/tag_catalog_test.rb
@@ -3,19 +3,19 @@
 require "test_helper"
 
 class Tools::TagCatalogTest < ActiveSupport::TestCase
-  test "board is a visible group; service and provider tags are hidden" do
-    assert Tools::TagCatalog.ui_visible?(:board)
-    assert Tools::TagCatalog.group?(:board)
-    assert_equal "Board management", Tools::TagCatalog.label(:board)
-
-    %i[workflow_control async_results session_lifecycle repositories builder slack coder].each do |tag|
-      assert_not Tools::TagCatalog.ui_visible?(tag), "#{tag} must stay out of the picker"
+  test "the picker-facing tags are visible with their labels" do
+    { board: "Board management", slack: "Slack", coder: "Coder",
+      assets: "Assets", session_supervision: "Session supervision" }.each do |tag, label|
+      assert Tools::TagCatalog.ui_visible?(tag), "#{tag} must be offered in the picker"
+      assert_equal label, Tools::TagCatalog.label(tag)
     end
   end
 
-  test "messaging is visible but individual, not a group" do
-    assert Tools::TagCatalog.ui_visible?(:messaging)
-    assert_not Tools::TagCatalog.group?(:messaging)
+  test "service tags and the messaging umbrella stay out of the picker" do
+    # :messaging would double up on the Slack tools, which carry both tags.
+    %i[messaging workflow_control async_results session_lifecycle repositories builder].each do |tag|
+      assert_not Tools::TagCatalog.ui_visible?(tag), "#{tag} must stay out of the picker"
+    end
   end
 
   test "unknown tags default to hidden with a humanized label" do
@@ -23,7 +23,7 @@ class Tools::TagCatalogTest < ActiveSupport::TestCase
     assert_equal "Nope", Tools::TagCatalog.label(:nope)
   end
 
-  test "ui_entries lists only visible tags" do
-    assert_equal %i[board messaging session_supervision], Tools::TagCatalog.ui_entries.map(&:tag)
+  test "ui_entries lists only visible tags, in picker order" do
+    assert_equal %i[board slack coder assets session_supervision], Tools::TagCatalog.ui_entries.map(&:tag)
   end
 end


### PR DESCRIPTION
## Why

The workflow/session tool picker was supposed to let you attach a whole family of tools in one click. In practice only **Board management** and **Session supervision** worked that way — Slack, Coder and the asset tools were listed one by one.

The cause: `Tools::TagCatalog` carried a `presentation` axis with an `:individual` mode that nothing ever rendered. A tag marked individual was `ui_visible: true` but `Registry.ui_groups` only emitted `presentation == :group`, so its tools fell through to the picker's flat list — the "Messaging" label was dead code.

## What changed

- **Collapsed the `presentation` axis.** A visible tag is now exactly one picker entry that attaches every session tool carrying it.
- **`:slack`, `:coder`, `:assets` are visible groups.** `:messaging` stays hidden — the Slack tools carry both tags, and two visible groups would fight over the same ids (now asserted by a test).
- **`ui_groups` filters by audience.** It resolved `tagged(:board)` without one, so the board group carried 18 personal-MCP tool names (`setup_board`, `trigger_task_workflow`, …) next to the 14 session ones. Nothing broke only because `PickerGroups` intersects by name with `Tool.visible_for_project` and those names have no shadow row — a single name collision between `PersonalTools::X` and `InternalTools::X` would have leaked a user-audience tool into the picker.

Groups the picker now offers:

| Group | Tools |
| --- | --- |
| Board management | 14 |
| Slack | 4 |
| Coder | 5 |
| Assets | 2 |
| Session supervision | 2 |

The builder needed no frontend change for this: `BaseResourcesTab` / `SessionEditorPanel` render whatever groups the prop carries. Empty groups are dropped, so Slack and Coder only appear once their integration is connected.

## Tests

`tag_catalog_test` rewritten; `picker_groups_test` gains the "a group whose tools this project cannot see is dropped" case (via connecting Slack); `registry_test` gains the `ui_groups` composition/ordering test and the invariant that no tool carries two picker-visible tags.

`test/services/tools/` — 51 runs, 173 assertions, 0 failures. Rubocop clean on the touched paths.

## Sessions started by hand

A second commit carries the same groups to `/sessions/new` and the sessions-list drawer, which were still handing out a flat list of every visible tool. `create_options` now serves `tool_groups`, and `SessionNewForm` renders them under the builder's rules. The token logic moved into `shared/lib/toolPicker` (with unit tests) so all three pickers share one implementation instead of two copies that had started to drift.

## A group is all-or-nothing

By design: there is no case for attaching a single member of a group on its own. So the picker marks a group selected as soon as any member is attached, and the next edit normalizes that partial set to the whole group. Paths that bypass the picker — MCP `update_workflow_step`, the Aixle Builder, the raw API — can still write a partial set; it survives until someone opens the picker on that step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

