### PR TITLE
chore(deps): batch the bundler and npm minor/patch groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,7 +167,7 @@ gem "aws-sdk-bedrockruntime", "~> 1.83"
 # Bedrock control plane, for listing the inference profiles an account can actually invoke.
 # That list is the only truthful model catalogue for a Bedrock connection — it includes the
 # account's own application inference profiles, which is what enterprise deployments pin.
-gem "aws-sdk-bedrock", "~> 1.91"
+gem "aws-sdk-bedrock", "~> 1.92"
 gem "image_processing", "~> 2.1"
 gem "ruby-vips", "~> 2.3" # image_processing 2.0 no longer declares it; shrine.rb requires image_processing/vips
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,14 +106,14 @@ GEM
     auth-sanitizer (0.2.3)
       version_gem (~> 1.1, >= 1.1.14)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1283.0)
-    aws-sdk-bedrock (1.91.0)
+    aws-partitions (1.1284.0)
+    aws-sdk-bedrock (1.92.0)
       aws-sdk-core (~> 3, >= 3.254.0)
       aws-sigv4 (~> 1.5)
     aws-sdk-bedrockruntime (1.83.0)
       aws-sdk-core (~> 3, >= 3.254.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-core (3.254.1)
+    aws-sdk-core (3.255.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -121,6 +121,7 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
+      rexml (~> 3.4, >= 3.4.2)
     aws-sdk-kms (1.130.0)
       aws-sdk-core (~> 3, >= 3.254.0)
       aws-sigv4 (~> 1.5)
@@ -134,7 +135,7 @@ GEM
     bcrypt (3.1.22)
     benchmark (0.5.0)
     bigdecimal (4.1.2)
-    bootsnap (1.25.0)
+    bootsnap (1.26.0)
       msgpack (~> 1.5)
     brakeman (8.0.6)
       racc
@@ -167,9 +168,9 @@ GEM
       rexml
     crass (1.0.7)
     csv (3.3.6)
-    cuprite (0.17)
+    cuprite (0.18)
       capybara (~> 3.0)
-      ferrum (~> 0.17.0)
+      ferrum (~> 0.18.0)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -216,11 +217,10 @@ GEM
       net-http (~> 0.5)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
-    ferrum (0.17.2)
+    ferrum (0.18.0)
       addressable (~> 2.5)
       base64 (~> 0.2)
       concurrent-ruby (~> 1.1)
-      webrick (~> 1.7)
       websocket-driver (~> 0.7)
     ffi (1.17.4)
     ffi (1.17.4-aarch64-linux-gnu)
@@ -376,8 +376,8 @@ GEM
       net-pop
       net-smtp
     marcel (1.2.1)
-    matrix (0.4.2)
-    mcp (1.4.0)
+    matrix (0.4.3)
+    mcp (1.5.0)
       json_schemer (>= 2.4)
     method_source (1.1.0)
     mime-types (3.7.0)
@@ -653,7 +653,7 @@ GEM
     shrine (3.9.0)
       content_disposition (~> 1.0)
       down (~> 5.1)
-    simplecov (1.1.1)
+    simplecov (1.2.0)
     simpleidn (0.3.0)
     site_prism (6.0.1)
       addressable (~> 2.8, >= 2.8.4)
@@ -732,7 +732,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.9.2)
     websocket (1.2.11)
     websocket-client-simple (0.9.0)
       base64
@@ -770,7 +769,7 @@ DEPENDENCIES
   administrate-field-shrine
   alba
   audited
-  aws-sdk-bedrock (~> 1.91)
+  aws-sdk-bedrock (~> 1.92)
   aws-sdk-bedrockruntime (~> 1.83)
   aws-sdk-s3 (~> 1.229)
   bcrypt (~> 3.1.22)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@testing-library/user-event": "^14",
     "@types/rails__actioncable": "^8.0.3",
     "@types/react": "^19.2.18",
-    "@types/react-dom": "^19.2.5",
+    "@types/react-dom": "^19.2.7",
     "@types/react-syntax-highlighter": "^15",
     "@typescript-eslint/parser": "^8.68.0",
     "@vitest/coverage-v8": "4.1.11",
@@ -28,7 +28,7 @@
     "license-checker-rseidelsohn": "^5.0.1",
     "prettier": "^3.9.6",
     "prettier-plugin-packagejson": "^3.0.0",
-    "sass-embedded": "^1.103.1",
+    "sass-embedded": "^1.104.0",
     "steiger": "^0.6.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.68.0",
@@ -46,7 +46,7 @@
     "@codemirror/lang-python": "^6.2.1",
     "@codemirror/lang-sql": "^6.10.0",
     "@codemirror/lang-yaml": "^6.1.3",
-    "@codemirror/view": "^6.43.10",
+    "@codemirror/view": "^6.43.11",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
@@ -79,7 +79,7 @@
     "react-dom": "^19.2.8",
     "react-is": "^19.2.8",
     "react-markdown": "^10.1.0",
-    "react-resizable-panels": "^4.12.3",
+    "react-resizable-panels": "^4.12.4",
     "react-syntax-highlighter": "^16.1.1",
     "recharts": "^3.10.1",
     "rehype-raw": "^7.0.0",
@@ -90,7 +90,7 @@
   },
   "resolutions": {
     "@codemirror/state": "^6.7.1",
-    "@codemirror/view": "^6.43.10"
+    "@codemirror/view": "^6.43.11"
   },
   "scripts": {
     "tsc": "tsc",

--- a/yarn.lock
+++ b/yarn.lock
@@ -484,15 +484,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/view@npm:^6.43.10":
-  version: 6.43.10
-  resolution: "@codemirror/view@npm:6.43.10"
+"@codemirror/view@npm:^6.43.11":
+  version: 6.43.11
+  resolution: "@codemirror/view@npm:6.43.11"
   dependencies:
     "@codemirror/state": "npm:^6.7.0"
     crelt: "npm:^1.0.6"
     style-mod: "npm:^4.1.0"
     w3c-keyname: "npm:^2.2.4"
-  checksum: 10c0/03a53c16a1fe6c8cefcc4ae3e5a0ccc1f8533273df857ca67cd49b70dfc7c01f11b3db20edf7743fce7b264ff493a7da14c3ab46eb0edc89969eced14d046f93
+  checksum: 10c0/7e681944e4548b8d51dc868587135f39ceb0cf538c16f9d9c034af2ad3767bdd50656a6fdbc61cbaf8650c0439f3a162cf5e3c4adc9a7c64ff7718a420bafaa6
   languageName: node
   linkType: hard
 
@@ -2217,11 +2217,11 @@ __metadata:
   linkType: hard
 
 "@testing-library/user-event@npm:^14":
-  version: 14.6.6
-  resolution: "@testing-library/user-event@npm:14.6.6"
+  version: 14.6.7
+  resolution: "@testing-library/user-event@npm:14.6.7"
   peerDependencies:
     "@testing-library/dom": ">=7.21.4"
-  checksum: 10c0/2cb82d3a364a2a29da19bb5d2a614aedaa474ac6f599a42fc28c1926056f7b91f5cec37b33452bafcb3f6b37a950024da289dea88ead3c2056c6005c91c7f942
+  checksum: 10c0/21f5e01bea2699b069947ae06d0b0fbabe0e90d2a2206b8f56a3f46126d09bd85320cba3fd3910c4d18710b1873e6966fb9021668966c615aaa14bf35d7df3ef
   languageName: node
   linkType: hard
 
@@ -2429,12 +2429,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^19.2.5":
-  version: 19.2.5
-  resolution: "@types/react-dom@npm:19.2.5"
+"@types/react-dom@npm:^19.2.7":
+  version: 19.2.7
+  resolution: "@types/react-dom@npm:19.2.7"
   peerDependencies:
     "@types/react": ^19.2.0
-  checksum: 10c0/7a59467b043debf392d109daa1ba672e791f20ce6f24ae81fb54715f890f8119d24967e61e3644b6307428603b695b7d59e69eaf531bd1963a74a6cb462f5f49
+  checksum: 10c0/226ab7e2b62114125e2276b3dcc3a25060177a673f8abadb7e31f395003de72ad68075c6edc5f51b02dd1e47443920ee030239c474c47fad075ded7410836909
   languageName: node
   linkType: hard
 
@@ -7831,13 +7831,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resizable-panels@npm:^4.12.3":
-  version: 4.12.3
-  resolution: "react-resizable-panels@npm:4.12.3"
+"react-resizable-panels@npm:^4.12.4":
+  version: 4.12.4
+  resolution: "react-resizable-panels@npm:4.12.4"
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/dc3bee8529bdcbd7144a84798931cd02a83ba591fc67cf9e4eea344330c7ad00a3ff9dead0ccf84dc29679091ea153311ceae7739aa05799ce9c4efa4aff1752
+  checksum: 10c0/2c9ecf26af8897cd406a0e9d53a64328f9536dbed36a2a5b4328f03a09951ef6aa9647fad25401a26c05dfe575963ea1f66bcf1457e55aab21346d0ff2e19dfb
   languageName: node
   linkType: hard
 
@@ -8284,7 +8284,7 @@ __metadata:
     "@codemirror/lang-python": "npm:^6.2.1"
     "@codemirror/lang-sql": "npm:^6.10.0"
     "@codemirror/lang-yaml": "npm:^6.1.3"
-    "@codemirror/view": "npm:^6.43.10"
+    "@codemirror/view": "npm:^6.43.11"
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
     "@dnd-kit/utilities": "npm:^3.2.2"
@@ -8308,7 +8308,7 @@ __metadata:
     "@testing-library/user-event": "npm:^14"
     "@types/rails__actioncable": "npm:^8.0.3"
     "@types/react": "npm:^19.2.18"
-    "@types/react-dom": "npm:^19.2.5"
+    "@types/react-dom": "npm:^19.2.7"
     "@types/react-syntax-highlighter": "npm:^15"
     "@typescript-eslint/parser": "npm:^8.68.0"
     "@uiw/codemirror-theme-vscode": "npm:^4.25.11"
@@ -8341,13 +8341,13 @@ __metadata:
     react-dom: "npm:^19.2.8"
     react-is: "npm:^19.2.8"
     react-markdown: "npm:^10.1.0"
-    react-resizable-panels: "npm:^4.12.3"
+    react-resizable-panels: "npm:^4.12.4"
     react-syntax-highlighter: "npm:^16.1.1"
     recharts: "npm:^3.10.1"
     rehype-raw: "npm:^7.0.0"
     rehype-sanitize: "npm:^6.0.0"
     remark-gfm: "npm:^4.0.1"
-    sass-embedded: "npm:^1.103.1"
+    sass-embedded: "npm:^1.104.0"
     steiger: "npm:^0.6.0"
     typescript: "npm:^5.9.3"
     typescript-eslint: "npm:^8.68.0"
@@ -8419,162 +8419,162 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass-embedded-all-unknown@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-all-unknown@npm:1.103.1"
+"sass-embedded-all-unknown@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-all-unknown@npm:1.104.0"
   dependencies:
-    sass: "npm:1.103.1"
+    sass: "npm:1.104.0"
   conditions: (!cpu=arm | !cpu=arm64 | !cpu=riscv64 | !cpu=x64)
   languageName: node
   linkType: hard
 
-"sass-embedded-android-arm64@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-android-arm64@npm:1.103.1"
+"sass-embedded-android-arm64@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-android-arm64@npm:1.104.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"sass-embedded-android-arm@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-android-arm@npm:1.103.1"
+"sass-embedded-android-arm@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-android-arm@npm:1.104.0"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"sass-embedded-android-riscv64@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-android-riscv64@npm:1.103.1"
+"sass-embedded-android-riscv64@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-android-riscv64@npm:1.104.0"
   conditions: os=android & cpu=riscv64
   languageName: node
   linkType: hard
 
-"sass-embedded-android-x64@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-android-x64@npm:1.103.1"
+"sass-embedded-android-x64@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-android-x64@npm:1.104.0"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
-"sass-embedded-darwin-arm64@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-darwin-arm64@npm:1.103.1"
+"sass-embedded-darwin-arm64@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-darwin-arm64@npm:1.104.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"sass-embedded-darwin-x64@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-darwin-x64@npm:1.103.1"
+"sass-embedded-darwin-x64@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-darwin-x64@npm:1.104.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"sass-embedded-linux-arm64@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-linux-arm64@npm:1.103.1"
+"sass-embedded-linux-arm64@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-linux-arm64@npm:1.104.0"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"sass-embedded-linux-arm@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-linux-arm@npm:1.103.1"
+"sass-embedded-linux-arm@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-linux-arm@npm:1.104.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"sass-embedded-linux-musl-arm64@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-linux-musl-arm64@npm:1.103.1"
+"sass-embedded-linux-musl-arm64@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-linux-musl-arm64@npm:1.104.0"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"sass-embedded-linux-musl-arm@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-linux-musl-arm@npm:1.103.1"
+"sass-embedded-linux-musl-arm@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-linux-musl-arm@npm:1.104.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"sass-embedded-linux-musl-riscv64@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-linux-musl-riscv64@npm:1.103.1"
+"sass-embedded-linux-musl-riscv64@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-linux-musl-riscv64@npm:1.104.0"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"sass-embedded-linux-musl-x64@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-linux-musl-x64@npm:1.103.1"
+"sass-embedded-linux-musl-x64@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-linux-musl-x64@npm:1.104.0"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"sass-embedded-linux-riscv64@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-linux-riscv64@npm:1.103.1"
+"sass-embedded-linux-riscv64@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-linux-riscv64@npm:1.104.0"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"sass-embedded-linux-x64@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-linux-x64@npm:1.103.1"
+"sass-embedded-linux-x64@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-linux-x64@npm:1.104.0"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"sass-embedded-unknown-all@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-unknown-all@npm:1.103.1"
+"sass-embedded-unknown-all@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-unknown-all@npm:1.104.0"
   dependencies:
-    sass: "npm:1.103.1"
+    sass: "npm:1.104.0"
   conditions: (!os=android | !os=darwin | !os=linux | !os=win32)
   languageName: node
   linkType: hard
 
-"sass-embedded-win32-arm64@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-win32-arm64@npm:1.103.1"
+"sass-embedded-win32-arm64@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-win32-arm64@npm:1.104.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"sass-embedded-win32-x64@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded-win32-x64@npm:1.103.1"
+"sass-embedded-win32-x64@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded-win32-x64@npm:1.104.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"sass-embedded@npm:^1.103.1":
-  version: 1.103.1
-  resolution: "sass-embedded@npm:1.103.1"
+"sass-embedded@npm:^1.104.0":
+  version: 1.104.0
+  resolution: "sass-embedded@npm:1.104.0"
   dependencies:
     "@bufbuild/protobuf": "npm:^2.5.0"
     colorjs.io: "npm:^0.7.0"
     immutable: "npm:^5.1.5"
     rxjs: "npm:^7.4.0"
-    sass-embedded-all-unknown: "npm:1.103.1"
-    sass-embedded-android-arm: "npm:1.103.1"
-    sass-embedded-android-arm64: "npm:1.103.1"
-    sass-embedded-android-riscv64: "npm:1.103.1"
-    sass-embedded-android-x64: "npm:1.103.1"
-    sass-embedded-darwin-arm64: "npm:1.103.1"
-    sass-embedded-darwin-x64: "npm:1.103.1"
-    sass-embedded-linux-arm: "npm:1.103.1"
-    sass-embedded-linux-arm64: "npm:1.103.1"
-    sass-embedded-linux-musl-arm: "npm:1.103.1"
-    sass-embedded-linux-musl-arm64: "npm:1.103.1"
-    sass-embedded-linux-musl-riscv64: "npm:1.103.1"
-    sass-embedded-linux-musl-x64: "npm:1.103.1"
-    sass-embedded-linux-riscv64: "npm:1.103.1"
-    sass-embedded-linux-x64: "npm:1.103.1"
-    sass-embedded-unknown-all: "npm:1.103.1"
-    sass-embedded-win32-arm64: "npm:1.103.1"
-    sass-embedded-win32-x64: "npm:1.103.1"
+    sass-embedded-all-unknown: "npm:1.104.0"
+    sass-embedded-android-arm: "npm:1.104.0"
+    sass-embedded-android-arm64: "npm:1.104.0"
+    sass-embedded-android-riscv64: "npm:1.104.0"
+    sass-embedded-android-x64: "npm:1.104.0"
+    sass-embedded-darwin-arm64: "npm:1.104.0"
+    sass-embedded-darwin-x64: "npm:1.104.0"
+    sass-embedded-linux-arm: "npm:1.104.0"
+    sass-embedded-linux-arm64: "npm:1.104.0"
+    sass-embedded-linux-musl-arm: "npm:1.104.0"
+    sass-embedded-linux-musl-arm64: "npm:1.104.0"
+    sass-embedded-linux-musl-riscv64: "npm:1.104.0"
+    sass-embedded-linux-musl-x64: "npm:1.104.0"
+    sass-embedded-linux-riscv64: "npm:1.104.0"
+    sass-embedded-linux-x64: "npm:1.104.0"
+    sass-embedded-unknown-all: "npm:1.104.0"
+    sass-embedded-win32-arm64: "npm:1.104.0"
+    sass-embedded-win32-x64: "npm:1.104.0"
     supports-color: "npm:^8.1.1"
     sync-child-process: "npm:^1.0.2"
     varint: "npm:^6.0.0"
@@ -8617,13 +8617,13 @@ __metadata:
       optional: true
   bin:
     sass: dist/bin/sass.js
-  checksum: 10c0/85b2273883d60dc7a7d86f6df2a99774036035aa21c36219ad8e7923e0929840a7e20421e0b357639e7d9301efccec66c87068bc072cfbe14af6c455b5cc7f66
+  checksum: 10c0/10714839dff288aef70a7ba880bdb2406135fe9bd03f30989703c6a258245aff494f6e239bd6cbd2e27cfb9c8bdf2d489de2a5676be9dcaeab6cda56a7ab3aa9
   languageName: node
   linkType: hard
 
-"sass@npm:1.103.1":
-  version: 1.103.1
-  resolution: "sass@npm:1.103.1"
+"sass@npm:1.104.0":
+  version: 1.104.0
+  resolution: "sass@npm:1.104.0"
   dependencies:
     "@parcel/watcher": "npm:^2.4.1"
     chokidar: "npm:^5.0.0"
@@ -8634,7 +8634,7 @@ __metadata:
       optional: true
   bin:
     sass: sass.js
-  checksum: 10c0/8c786a201d9484e9968784d672372fabb342f3b4d1c4629ffdcfba92e4f2c00e659f4e32244c870850f7c2d254ce773da3fc1ec40b4282ccd113c0c086fa36bd
+  checksum: 10c0/f43dafaf582526bece2e854f73eecab433300b641468e56966ed97717e7eb06db2c010f8b6bdfccd6ff6b4c07083732ef0d524dfe12a1a19e9e5c953083c06a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Batches this week's two dependabot **group** PRs into one branch so they cost one CI matrix
instead of two. Both cherry-picks applied to the current `develop` tip with no lockfile drift
(`git diff 21ab1e7e..develop -- Gemfile Gemfile.lock package.json yarn.lock` is empty), so the
locks are dependabot's own — nothing was hand-merged or regenerated.

Supersedes #228 and #231. Both were green on their own branches.

### Bundler (#228) — minor/patch

| Gem | From | To | What changed |
| --- | --- | --- | --- |
| bootsnap | 1.25.0 | 1.26.0 | Fixes a corrupted precompile cache entry when a cached YAML file is edited without changing size; handles a non-stdlib top-level `Coverage` constant; works around a SEGV when `Bootsnap.instrumentation` raises. Bug fixes only. |
| mcp | 1.4.0 | 1.5.0 | Client now answers server→client `ping` with the empty result the spec requires (previously `Method not found` over Streamable HTTP, silence over stdio — servers that liveness-check dropped our long-lived sessions). Adds `authorization_request_validator`; refresh is now scoped to the issuing authorization server. Additive; tokens stored by earlier releases carry no issuer and keep refreshing. |
| simplecov | 1.1.1 | 1.2.0 | Large additive release (`simplecov patch`, `track_tests`, `cover_views`, CLI subcommands). Upgrade notes: existing config keeps working, legacy filter/threshold forms warn with their replacements, and successful runs now write a bounded `coverage/.history.json` — already covered by `.gitignore:58`. |
| cuprite | 0.17 | 0.18 | Driver for our Capybara system tests (`test/application_system_test_case.rb`), pulls ferrum 0.17.2 → 0.18.0. The full backend suite — system tests included — was green on #228. |
| aws-sdk-bedrock | 1.91.0 | 1.92.0 | Routine SDK regeneration; also moves aws-sdk-core 3.254.1 → 3.255.0 and aws-partitions. |

### npm (#231) — minor/patch

| Package | From | To | What changed |
| --- | --- | --- | --- |
| @codemirror/view | 6.43.10 | 6.43.11 | Patch. |
| react-resizable-panels | 4.12.3 | 4.12.4 | Skips pointer capture for a detached `Separator`; `Separator` ARIA values use group-relative panel indices. |
| @testing-library/user-event | 14.6.6 | 14.6.7 | Normalizes DataTransfer format aliases; iframe support for `user.keyboard`. |
| @types/react-dom | 19.2.5 | 19.2.7 | Types only. |
| sass-embedded | 1.103.1 | 1.104.0 | Minor. |

### Not included

The four remaining dependabot PRs are majors and stay on their own, per the policy in
`.github/dependabot.yml` ("majors stay on their own so a breaking change is never buried
inside a batch"):

- **#229 / #230 — sentry-ruby, sentry-rails 6.7.0 → 7.0.0.** Red on CI, not a flake:
  `config/initializers/sentry.rb:24` sets `config.enable_logs`, which 7.0.0 removed, and the image
  build dies at `assets:precompile` with
  `NoMethodError: undefined method 'enable_logs=' for an instance of Sentry::Configuration`.
  Beyond the one line, 7.0.0 turns Logs *and* Metrics on by default, defaults
  `config.otlp.setup_otlp_traces_exporter`/`setup_propagator` to false, and deprecates
  `send_default_pii` (which we set to `true`) in favour of granular `data_collection`. That is a
  config migration with a Sentry-quota and PII blast radius, not a version bump. #230 additionally
  drags `json` 2.21.2 → 3.0.2.
- **#232 / #233 — vitest, @vitest/coverage-v8 4.1.11 → 5.0.0.** These have to move as a pair —
  `package.json` pins `@vitest/coverage-v8` to an exact version because it peer-depends on the
  matching vitest — so neither PR is mergeable alone, and the *combination* is what no CI run has
  executed. Node (24.18.1 in the image) and Vite (^8.2.2) both clear v5's new floors, and #232 was
  green, which covers the runtime breaking changes (mocks cleared by default, unawaited async
  assertions now fail, `toHaveTextContent` strict, hoistables must be top-level). What is *not*
  covered: `.github/workflows/ci.yml:102` only sets `run-coverage: 1` on pushes, so a PR never runs
  `yarn test --coverage`. v5 rewrote `coverage.include`/`exclude` matching (relative-to-root,
  picomatch `contains` dropped) and coverage-v8 5.0.0 swapped its istanbul dependencies for
  `@vitest/istanbul-lib-*`. Both can move which files land in the denominator against the
  `vitest.config.ts` floors (71/65/66/73) and which reporters exist — and the first run that would
  find out is the develop push *after* the merge. Worth its own PR with a coverage run done by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
