### PR TITLE
refactor(sentry): take sentry-ruby/sentry-rails 7.0.0 without changing behaviour

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,7 +305,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    json (3.0.2)
+    json (2.21.2)
     json_schemer (2.5.0)
       bigdecimal
       hana (~> 1.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,7 +305,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    json (2.21.2)
+    json (3.0.2)
     json_schemer (2.5.0)
       bigdecimal
       hana (~> 1.3)
@@ -643,10 +643,10 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     securerandom (0.4.1)
-    sentry-rails (6.7.0)
+    sentry-rails (7.0.0)
       railties (>= 5.2.0)
-      sentry-ruby (~> 6.7.0)
-    sentry-ruby (6.7.0)
+      sentry-ruby (~> 7.0.0)
+    sentry-ruby (7.0.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -20,7 +20,17 @@ Sentry.init do |config|
   # ran the command; it says nothing about the app, and it carries no useful stacktrace.
   config.excluded_exceptions += %w[SystemExit]
   config.send_default_pii = true
-  config.enable_logs = !running_console
+  # sentry-ruby 7 removed `enable_logs` — logs are unconditionally on, and the gate that
+  # used to sit in front of them is gone. Nothing is lost here: the only thing that turns
+  # this app's log lines into Sentry log events is the `:logger` patch below, which is
+  # still opt-in, so a console session with no patches still emits no logs.
+  #
+  # The one flag that did change meaning is Rails structured logging. Under 6.7 it was
+  # *derived* from enable_logs (`rails.structured_logging.enabled = enable_logs if nil`),
+  # so it followed the same console rule; under 7.0 it defaults to true regardless. Set it
+  # explicitly to the value 6.7 would have derived, so a `rails console` still ships
+  # nothing and the web/worker processes keep the subscribers they already had.
+  config.rails.structured_logging.enabled = !running_console
   config.enabled_patches = running_console ? [] : [ :logger ]
   config.traces_sample_rate = 1.0
   config.traces_sampler = lambda do |context|


### PR DESCRIPTION
Takes `sentry-ruby` / `sentry-rails` 6.7.0 → 7.0.0 with **no change in what this app sends
to Sentry**. Supersedes #229 and #230, both of which were red.

### Why the bare bump fails

`config/initializers/sentry.rb` set `config.enable_logs`, which 7.0.0 removed. Both dependabot
PRs died in the image build at `assets:precompile`:

```
NoMethodError: undefined method 'enable_logs=' for an instance of Sentry::Configuration
```

Backend *and* frontend checks fail together because they share that build.

### What each 7.0 breaking change means here

**`enable_logs` removed, Logs on by default.** No replacement gate is needed. The only thing
that turns this app's `::Logger` output into Sentry log events is the `:logger` patch, and that
is still opt-in through `enabled_patches` (`register_patch(:logger)` just lost its internal
`if config.enable_logs`). A console session keeps `enabled_patches = []`, so it still emits
nothing. Nothing in `app/`, `lib/` or `config/` calls `Sentry.logger` directly.

**Rails structured logging — the one that actually changes.** Under 6.7,
`sentry-rails/configuration.rb` had:

```ruby
after(:configured) do
  rails.structured_logging.enabled = enable_logs if rails.structured_logging.enabled.nil?
end
```

so it *followed* `enable_logs` and was off in a console. 7.0 deletes that hook and defaults
`@enabled` to `true`, which would start shipping ActiveRecord + ActionController log
subscribers from `rails console` too. Set explicitly to `!running_console` — exactly the value
6.7 derived.

**`enable_metrics` removed, Metrics on by default.** No change: 6.7.0 already defaulted
`enable_metrics` to `true` (`configuration.rb:582`) and this app never set it.

**`config.otlp.setup_otlp_traces_exporter` / `setup_propagator` default to false.** Inert —
`otlp` is a `sentry-opentelemetry` option and that gem is not in the Gemfile.

**`send_default_pii` deprecated.** Left at `true` on purpose. `send_default_pii=` calls
`DataCollection.backfill(self)`, which for a truthy value returns the permissive defaults —
i.e. 7.0 reproduces the old behaviour by construction. Hand-transcribing thirteen
`data_collection.*` fields for zero behavioural change is how you introduce a difference, not
how you avoid one. It costs one deprecation line at boot, and the real migration belongs in its
own PR before 8.0 removes the flag.

One deliberate small difference comes free with 7.0 and is kept: its new `after(:configured)`
hook folds `Rails.application.config.filter_parameters` into
`data_collection.url_query_params`, so query strings are filtered where 6.7 sent them whole.
That is strictly less PII leaving the app.

### Also in this PR

Dropped the unrelated `json` 2.21.2 → **3.0.2** major that #230 resolved in as a rider.
`sentry-ruby` 7.0.0 does not depend on `json` at all, and the strictest constraint anywhere in
`Gemfile.lock` is `json (>= 2.3)`, so 2.21.2 still satisfies the graph. A json major deserves
its own PR.

### Verification

CI is the check that matters here: the failure mode is a boot-time `NoMethodError` during
`assets:precompile`, which the image build in both check jobs exercises before a single test
runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
