### PR TITLE
fix(assets): allow spaces in folders and answer 422 instead of 500

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -29,6 +29,9 @@ module Api
       # Fail closed: a controller shipped without a policy denies (403) instead of 500.
       rescue_from Pundit::NotDefinedError, with: :user_not_authorized
       rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+      # A failed validation is the client's problem, not a server fault: without this, every
+      # `save!`/`create!` in the tree answers 500 with no hint of which field was rejected.
+      rescue_from ActiveRecord::RecordInvalid, with: :record_invalid
 
       private
 
@@ -70,6 +73,12 @@ module Api
 
       def record_not_found
         render json: { error: "Record not found" }, status: :not_found
+      end
+
+      def record_invalid(exception)
+        messages = exception.record ? exception.record.errors.full_messages : []
+        messages = [ exception.message ] if messages.empty?
+        render json: { error: messages.to_sentence, errors: messages }, status: :unprocessable_entity
       end
     end
   end

--- a/app/controllers/api/v1/company/assets_controller.rb
+++ b/app/controllers/api/v1/company/assets_controller.rb
@@ -52,12 +52,15 @@ module Api
           @current_company || raise(ActiveRecord::RecordNotFound)
         end
 
+        # Uniqueness is per (scope, folder): the lookup must key on both, or an upload into a
+        # different folder moves the existing asset instead of creating a new one.
         def find_or_initialize_asset(scope)
-          asset = scope.assets.find_or_initialize_by(name: asset_params[:name]) do |a|
+          folder = Asset.normalize_folder(asset_params[:folder])
+          asset = scope.assets.find_or_initialize_by(name: asset_params[:name], folder: folder) do |a|
             a.created_by = current_user
           end
           asset.restore! if asset.persisted? && asset.deleted?
-          asset.assign_attributes(asset_params.except(:name))
+          asset.assign_attributes(asset_params.except(:name, :folder))
           asset
         end
 

--- a/app/controllers/api/v1/projects/assets_controller.rb
+++ b/app/controllers/api/v1/projects/assets_controller.rb
@@ -40,12 +40,16 @@ module Api
           redirect_to url, allow_other_host: true # brakeman:ignore — Shrine-generated URL, not user input
         end
 
+        # Name alone does not identify an asset — uniqueness is per (scope, folder), so the
+        # lookup has to carry the folder too. Matching on name only made an upload into a
+        # different folder *move* the existing asset instead of creating a new one.
         def find_or_initialize_asset(scope)
-          asset = scope.assets.find_or_initialize_by(name: asset_params[:name]) do |a|
+          folder = Asset.normalize_folder(asset_params[:folder])
+          asset = scope.assets.find_or_initialize_by(name: asset_params[:name], folder: folder) do |a|
             a.created_by = current_user
           end
           asset.restore! if asset.persisted? && asset.deleted?
-          asset.assign_attributes(asset_params.except(:name))
+          asset.assign_attributes(asset_params.except(:name, :folder))
           asset
         end
 

--- a/app/frontend/shared/resources/assets/AssetsContent.test.tsx
+++ b/app/frontend/shared/resources/assets/AssetsContent.test.tsx
@@ -590,6 +590,65 @@ describe('AssetsContent', () => {
     expect(file).not.toHaveProperty('mime_type');
   });
 
+  // The file is in cache storage by the time the folder is typed, so a folder the server will
+  // refuse has to be caught before the POST — otherwise the upload is thrown away on a 422.
+  it('blocks the save and flags the field when the folder is a path rather than a name', async () => {
+    renderPage(<AssetsContent {...baseProps} assets={[]} />);
+    await userEvent.click(screen.getByRole('button', { name: /upload your first file/i }));
+
+    completeUpload([{ name: 'notes.md', key: 'cache/ccc333-notes.md' }]);
+    await userEvent.type(await screen.findByLabelText(/folder/i), 'docs/sub');
+    await userEvent.click(screen.getByRole('button', { name: /save 1 file/i }));
+
+    expect(await screen.findByText('Folder cannot contain slashes or control characters')).toBeInTheDocument();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    // The uploaded file stays staged so the user can fix the folder and retry.
+    expect(screen.getByRole('button', { name: /save 1 file/i })).toBeInTheDocument();
+  });
+
+  // Asset names are free-form, and the folder is half of the same path — a space is not a reason
+  // to refuse the upload.
+  it('posts a folder that contains spaces, trimmed at the ends only', async () => {
+    renderPage(<AssetsContent {...baseProps} assets={[]} />);
+    await userEvent.click(screen.getByRole('button', { name: /upload your first file/i }));
+
+    completeUpload([{ name: 'notes.md', key: 'cache/ddd444-notes.md' }]);
+    await userEvent.type(await screen.findByLabelText(/folder/i), '  Q3 reports  ');
+    await userEvent.click(screen.getByRole('button', { name: /save 1 file/i }));
+
+    expect(lastPostedAsset().folder).toBe('Q3 reports');
+  });
+
+  it('shows the message the server rejected the asset with, and keeps the modal open', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Folder must not contain slashes or control characters' }), {
+        status: 422,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    renderPage(<AssetsContent {...baseProps} assets={[]} />);
+    await userEvent.click(screen.getByRole('button', { name: /upload your first file/i }));
+
+    completeUpload([{ name: 'notes.md', key: 'cache/eee555-notes.md' }]);
+    await userEvent.click(await screen.findByRole('button', { name: /save 1 file/i }));
+
+    expect(await screen.findByText('Folder must not contain slashes or control characters')).toBeInTheDocument();
+    expect(router.reload).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /save 1 file/i })).toBeInTheDocument();
+  });
+
+  it('falls back to the generic failure toast when the server sends no message', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(null, { status: 500 }));
+    renderPage(<AssetsContent {...baseProps} assets={[]} />);
+    await userEvent.click(screen.getByRole('button', { name: /upload your first file/i }));
+
+    completeUpload([{ name: 'notes.md', key: 'cache/fff666-notes.md' }]);
+    await userEvent.click(await screen.findByRole('button', { name: /save 1 file/i }));
+
+    expect(await screen.findByText('Failed to save uploaded files')).toBeInTheDocument();
+    expect(router.reload).not.toHaveBeenCalled();
+  });
+
   it('sends each uploaded file its own filename, falling back to "file" when Uppy reports none', async () => {
     renderPage(<AssetsContent {...baseProps} assets={[]} />);
     await userEvent.click(screen.getByRole('button', { name: /upload your first file/i }));

--- a/app/frontend/shared/resources/assets/AssetsContent.tsx
+++ b/app/frontend/shared/resources/assets/AssetsContent.tsx
@@ -42,6 +42,22 @@ const MAX_FILE_SIZE = 1024 * 1024 * 1024;
 // Api::V1::AssetsController#cache_key.
 const CACHE_PREFIX = 'cache/';
 
+// Mirrors Asset::FOLDER_FORMAT / RESERVED_FOLDERS / FOLDER_MAX_LENGTH. Catching it here keeps the
+// file — already uploaded to cache storage by the time the folder is typed — from being thrown
+// away on a server-side 422. A folder is one flat name: spaces are fine, path separators are not.
+// eslint-disable-next-line no-control-regex -- control characters are exactly what this rejects
+const FOLDER_FORBIDDEN = /[/\\\x00-\x1f\x7f]/;
+const RESERVED_FOLDERS = ['.', '..'];
+const FOLDER_MAX_LENGTH = 100;
+const FOLDER_HINT = 'One folder name — spaces are fine, "/" is not';
+
+function folderError(folder: string): string | null {
+  if (FOLDER_FORBIDDEN.test(folder)) return 'Folder cannot contain slashes or control characters';
+  if (RESERVED_FOLDERS.includes(folder)) return 'That folder name is not usable';
+  if (folder.length > FOLDER_MAX_LENGTH) return `Folder must be ${FOLDER_MAX_LENGTH} characters or fewer`;
+  return null;
+}
+
 interface CachedFileDescriptor {
   id: string;
   storage: string;
@@ -81,6 +97,18 @@ function cachedFileDescriptor(key: unknown, uploadURL: string | undefined, filen
   return { id, storage: 'cache', metadata: { filename } };
 }
 
+// The API answers a rejected asset with `{ error: "<full messages>" }`; surfacing it beats the
+// static "Failed to save" toast, which told the user nothing about which field was refused.
+async function readErrorMessage(res: Response): Promise<string | null> {
+  try {
+    const body: unknown = await res.json();
+    const error = (body as { error?: unknown })?.error;
+    return typeof error === 'string' && error.length > 0 ? error : null;
+  } catch {
+    return null;
+  }
+}
+
 interface AssetsContentProps {
   assets: Asset[];
   assetVersions?: AssetVersion[];
@@ -118,6 +146,7 @@ export function AssetsContent({
   const [isUploading, setIsUploading] = useState(false);
   const [uploadedFiles, setUploadedFiles] = useState<Array<{ name: string; cachedFile: CachedFileDescriptor }>>([]);
   const [uploadFolder, setUploadFolder] = useState('');
+  const [uploadFolderError, setUploadFolderError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -240,8 +269,17 @@ export function AssetsContent({
 
   const handleSaveUpload = useCallback(async () => {
     if (!createEndpoint || uploadedFiles.length === 0) return;
+
+    const folder = uploadFolder.trim();
+    const invalid = folder && folderError(folder);
+    if (invalid) {
+      setUploadFolderError(invalid);
+      return;
+    }
+    setUploadFolderError(null);
     setIsSaving(true);
     let successCount = 0;
+    let failureMessage: string | null = null;
 
     for (const f of uploadedFiles) {
       try {
@@ -249,37 +287,47 @@ export function AssetsContent({
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            asset: { name: f.name, folder: uploadFolder || null, file: f.cachedFile },
+            asset: { name: f.name, folder: folder || null, file: f.cachedFile },
           }),
         });
-        if (res.ok) successCount++;
+        if (res.ok) {
+          successCount++;
+        } else {
+          failureMessage ??= await readErrorMessage(res);
+        }
       } catch {
         /* continue with remaining files */
       }
     }
 
     setIsSaving(false);
+
+    if (successCount === 0) {
+      // Every file was refused: keep the modal and the already-cached uploads in place so the
+      // user can fix the folder and retry instead of re-picking the files.
+      notifications.show({ message: failureMessage ?? 'Failed to save uploaded files', color: 'red' });
+      return;
+    }
+
     setUploadOpen(false);
     setUploadedFiles([]);
     setUploadFolder('');
     setUploadProgress(0);
     uppyRef.current?.cancelAll();
 
-    if (successCount > 0) {
-      notifications.show({
-        message: `${successCount} file${successCount > 1 ? 's' : ''} uploaded`,
-        color: 'green',
-      });
-      router.reload();
-    } else {
-      notifications.show({ message: 'Failed to save uploaded files', color: 'red' });
-    }
+    notifications.show({
+      message: `${successCount} file${successCount > 1 ? 's' : ''} uploaded`,
+      color: 'green',
+    });
+    if (failureMessage) notifications.show({ message: failureMessage, color: 'red' });
+    router.reload();
   }, [createEndpoint, uploadedFiles, uploadFolder]);
 
   const handleCloseUpload = useCallback(() => {
     setUploadOpen(false);
     setUploadedFiles([]);
     setUploadFolder('');
+    setUploadFolderError(null);
     setUploadProgress(0);
     uppyRef.current?.cancelAll();
   }, []);
@@ -568,9 +616,13 @@ export function AssetsContent({
               <TextInput
                 label="Folder (optional)"
                 placeholder="Leave empty for root"
-                description="Lowercase letters, numbers, hyphens, underscores"
+                description={FOLDER_HINT}
+                error={uploadFolderError}
                 value={uploadFolder}
-                onChange={(e) => setUploadFolder(e.currentTarget.value)}
+                onChange={(e) => {
+                  setUploadFolder(e.currentTarget.value);
+                  setUploadFolderError(null);
+                }}
               />
               <Group justify="flex-end">
                 <Button

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 class Asset < ApplicationRecord
+  # A folder is one flat, human-readable label — spaces and non-Latin scripts included; asset
+  # names have always been free-form, and the folder is half of the same path. What it may not
+  # be is a *path*: a separator would let it address a directory of its own choosing under
+  # /workspace/assets, and a control character would make the directory unnameable at the far
+  # end. Everything that consumes the path shell-escapes it.
+  FOLDER_FORMAT = /\A[^\/\\\x00-\x1F\x7F]+\z/
+  # "." and ".." pass the format but name a directory that already exists.
+  RESERVED_FOLDERS = %w[. ..].freeze
+  FOLDER_MAX_LENGTH = 100
+
   belongs_to :scope, polymorphic: true
   belongs_to :created_by, class_name: "User"
   belongs_to :step_run, optional: true
@@ -8,14 +18,19 @@ class Asset < ApplicationRecord
 
   has_many :versions, class_name: "AssetVersion", dependent: :destroy, inverse_of: :asset
 
+  before_validation :normalize_folder
+
   validates :name, presence: true
   validates :name, uniqueness: { scope: %i[scope_type scope_id folder], message: "already exists in this scope",
                                  conditions: -> { where(deleted_at: nil) } }
   validates :scope_type, presence: true, inclusion: { in: %w[Company Project] }
   validates :scope_id, presence: true
   validates :status, presence: true, inclusion: { in: %w[active pending_review dismissed] }
-  validates :folder, format: { with: /\A[a-zA-Z0-9_-]+\z/, message: "must only contain letters, digits, hyphens, or underscores" },
-                     allow_blank: true
+  validates :folder,
+            format: { with: FOLDER_FORMAT, message: "must not contain slashes or control characters" },
+            exclusion: { in: RESERVED_FOLDERS, message: "is not a usable folder name" },
+            length: { maximum: FOLDER_MAX_LENGTH },
+            allow_blank: true
 
   scope :active, -> { where(deleted_at: nil, status: "active") }
   scope :publicly_shared, -> { where(public: true).where.not(public_token: nil) }
@@ -49,6 +64,22 @@ class Asset < ApplicationRecord
           .or(active.where(scope_type: "Company", scope_id: project.company_id))
   }
   scope :visible_for_company, ->(company) { for_company(company) }
+
+  # Canonical form of a folder label: trimmed, with blank meaning "root" (nil). Every write and
+  # every lookup has to agree on it — `find_by(folder: " docs ")` would otherwise miss the row
+  # stored as "docs" and silently create a duplicate asset.
+  def self.normalize_folder(value)
+    value.is_a?(String) ? value.strip.presence : value.presence
+  end
+
+  # The folder rules as a predicate, for callers that reject a bad argument before building the
+  # record (agent tools, which owe their caller a message rather than a RecordInvalid).
+  def self.invalid_folder?(value)
+    folder = normalize_folder(value)
+    return false if folder.nil?
+
+    !folder.match?(FOLDER_FORMAT) || RESERVED_FOLDERS.include?(folder) || folder.length > FOLDER_MAX_LENGTH
+  end
 
   def picker_name
     folder.present? ? "#{folder}/#{name}" : name
@@ -123,5 +154,11 @@ class Asset < ApplicationRecord
 
   def self.ransackable_associations(_auth_object = nil)
     %w[scope created_by terminal_session versions]
+  end
+
+  private
+
+  def normalize_folder
+    self.folder = self.class.normalize_folder(folder)
   end
 end

--- a/app/services/asset_export_service.rb
+++ b/app/services/asset_export_service.rb
@@ -18,6 +18,7 @@ class AssetExportService
   private
 
   def find_or_create_asset(folder, is_public)
+    folder = Asset.normalize_folder(folder)
     existing = Asset.find_by(
       scope_type: "Project",
       scope_id: @project.id,

--- a/app/services/container_strategies/workflow_step_strategy.rb
+++ b/app/services/container_strategies/workflow_step_strategy.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "shellwords"
+
 module ContainerStrategies
   # WorkflowStepStrategy
   # Strategy for workflow step containers — reuses AgentSessionStrategy behavior
@@ -202,8 +204,12 @@ module ContainerStrategies
     end
 
     def download_to_container(container, url, target_path)
-      rewritten = rewrite_url_for_container(url)
-      runtime.exec(container, [ "sh", "-c", "curl -sSL -o '#{target_path}' '#{rewritten}'" ])
+      # Asset names are user-supplied and free-form (spaces and quotes included), so the path has
+      # to be escaped rather than wrapped in quotes — a name carrying one would otherwise rewrite
+      # this command instead of naming a file.
+      safe_path = Shellwords.escape(target_path)
+      safe_url = Shellwords.escape(rewrite_url_for_container(url))
+      runtime.exec(container, [ "sh", "-c", "curl -sSL -o #{safe_path} #{safe_url}" ])
       Rails.logger.info("[WorkflowStepStrategy] Downloaded → #{target_path}")
     end
 

--- a/app/services/internal_tools/promote_asset.rb
+++ b/app/services/internal_tools/promote_asset.rb
@@ -18,8 +18,8 @@ module InternalTools
       param :name, type: :string, required: true,
                    description: "Name of the workflow output asset to promote (as produced by the run)."
       param :folder, type: :string,
-                     description: "Optional destination folder within project assets " \
-                                  "(letters, digits, hyphens, underscores only)."
+                     description: "Optional destination folder within project assets: one flat name, " \
+                                  "no slashes (spaces are allowed)."
     end
 
     def execute
@@ -32,8 +32,15 @@ module InternalTools
       promoter = workflow_run&.user
       return error("Cannot determine the promoting user") unless promoter
 
+      if Asset.invalid_folder?(params[:folder])
+        return error("Invalid folder '#{params[:folder]}': one flat name, no slashes or control characters, " \
+                     "at most #{Asset::FOLDER_MAX_LENGTH} characters")
+      end
+
+      folder = Asset.normalize_folder(params[:folder])
+
       result = AssetExportService.new(wra, project: project, user: promoter)
-                                 .export!(folder: params[:folder].presence)
+                                 .export!(folder: folder)
 
       asset = result[:asset]
       success({

--- a/app/services/internal_tools/share_asset.rb
+++ b/app/services/internal_tools/share_asset.rb
@@ -48,7 +48,7 @@ module InternalTools
       if params[:asset_id].present?
         scope.find_by(id: params[:asset_id])
       else
-        scope.find_by(name: params[:name], folder: params[:folder].presence)
+        scope.find_by(name: params[:name], folder: Asset.normalize_folder(params[:folder]))
       end
     end
   end

--- a/db/migrate/20260911140000_normalize_asset_folders.rb
+++ b/db/migrate/20260911140000_normalize_asset_folders.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Asset folders are now canonicalized on write (Asset.normalize_folder): trimmed, with blank
+# meaning "root" (NULL). Uploads look a folder up by exact string, so a legacy row stored as ""
+# or with padding would never be matched again — and "" collides with NULL under
+# index_assets_on_scope_folder_name (it keys on COALESCE(folder, '')), so the miss surfaces as a
+# unique violation rather than a second row.
+#
+# Conservative by construction: a row whose normalized folder is already taken by a live sibling
+# is left exactly as it is — it keeps working the way it does today, and the collision is
+# reported instead of failing the deploy.
+#
+# Idempotent: after the pass every folder is already in canonical form, so a re-run matches
+# nothing.
+class NormalizeAssetFolders < ActiveRecord::Migration[8.1]
+  class MigAsset < ActiveRecord::Base
+    self.table_name = "assets"
+  end
+
+  def up
+    MigAsset.where.not(folder: nil).find_each do |asset|
+      normalized = asset.folder.strip.presence
+      next if normalized == asset.folder
+
+      begin
+        asset.update_columns(folder: normalized)
+      rescue ActiveRecord::RecordNotUnique
+        say "Asset ##{asset.id}: #{normalized.inspect} is already taken in this scope, left as-is"
+      end
+    end
+  end
+
+  # Not reversible: the original padding is recorded nowhere, and restoring it would put the rows
+  # back into the unreachable state this migration exists to clear.
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_11_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_11_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"

--- a/test/controllers/api/v1/company/assets_controller_test.rb
+++ b/test/controllers/api/v1/company/assets_controller_test.rb
@@ -26,6 +26,32 @@ module Api
           assert_response :created
         end
 
+        test "create answers 422 and names the offending field for an invalid folder" do
+          post :create, params: {
+            asset: { name: "doc.md", folder: "docs/sub", file: document_file_cache_data }
+          }
+
+          assert_response :unprocessable_entity
+          assert_match(/folder/i, response.parsed_body["error"])
+        end
+
+        # The lookup used to key on name alone, so this second upload moved the first asset into
+        # the new folder instead of creating a sibling.
+        test "create makes a separate asset when the same filename lands in another folder" do
+          post :create, params: {
+            asset: { name: "readme.md", folder: "docs", file: document_file_cache_data }
+          }
+          assert_response :created
+
+          assert_difference -> { @company.assets.count }, 1 do
+            post :create, params: {
+              asset: { name: "readme.md", folder: "reports", file: document_file_cache_data }
+            }
+          end
+
+          assert_equal %w[docs reports], @company.assets.where(name: "readme.md").map(&:folder).sort
+        end
+
         # The browser upload path posts only name/folder/file — no size, no type
         # — so the version has to derive both, otherwise the Assets list renders
         # "—" in the Size column for everything uploaded through the UI.

--- a/test/controllers/api/v1/projects/assets_controller_test.rb
+++ b/test/controllers/api/v1/projects/assets_controller_test.rb
@@ -44,6 +44,71 @@ module Api
           assert version["contentType"].present?
         end
 
+        # An invalid folder used to reach `save!` unrescued and answer 500, so the client got no
+        # way to tell a typo apart from an outage.
+        test "create answers 422 and names the offending field for an invalid folder" do
+          post :create, params: {
+            project_id: @project.id,
+            asset: {
+              name: "proj-doc.md",
+              folder: "docs/sub",
+              file: document_file_cache_data
+            }
+          }
+
+          assert_response :unprocessable_entity
+          assert_match(/folder/i, response.parsed_body["error"])
+          assert { !@project.assets.exists?(name: "proj-doc.md") }
+        end
+
+        test "create trims a padded folder and keeps the spaces inside it" do
+          post :create, params: {
+            project_id: @project.id,
+            asset: { name: "proj-doc.md", folder: "  Q3 reports  ", file: document_file_cache_data }
+          }
+
+          assert_response :created
+          assert_equal "Q3 reports", response.parsed_body["folder"]
+        end
+
+        # The lookup used to key on name alone, so this second upload moved the first asset into
+        # the new folder (and appended a version) instead of creating a sibling.
+        test "create makes a separate asset when the same filename lands in another folder" do
+          post :create, params: {
+            project_id: @project.id,
+            asset: { name: "readme.md", folder: "docs", file: document_file_cache_data }
+          }
+          assert_response :created
+
+          assert_difference -> { @project.assets.count }, 1 do
+            post :create, params: {
+              project_id: @project.id,
+              asset: { name: "readme.md", folder: "reports", file: document_file_cache_data }
+            }
+          end
+
+          assert_response :created
+          assert_equal %w[docs reports], @project.assets.where(name: "readme.md").map(&:folder).sort
+        end
+
+        test "create appends a version to the existing asset when name and folder both match" do
+          post :create, params: {
+            project_id: @project.id,
+            asset: { name: "readme.md", folder: "docs", file: document_file_cache_data }
+          }
+          assert_response :created
+
+          assert_no_difference -> { @project.assets.count } do
+            post :create, params: {
+              project_id: @project.id,
+              asset: { name: "readme.md", folder: "docs", file: document_file_cache_data }
+            }
+          end
+
+          assert_response :created
+          assert_equal 2, @project.assets.find_by(name: "readme.md", folder: "docs").versions.count
+        end
+
         test "destroy soft-deletes asset" do
           asset = create(:asset, :with_project_scope, scope: @project, created_by: @user)
 

--- a/test/models/asset_test.rb
+++ b/test/models/asset_test.rb
@@ -60,27 +60,56 @@ class AssetTest < ActiveSupport::TestCase
   # ====== Folder ======
 
   test "folder allows valid names" do
-    %w[architecture reports my-docs templates_v2].each do |name|
+    [ "architecture", "reports", "my-docs", "templates_v2", "Q3 reports", "Отчёты", "notes (draft)" ].each do |name|
       asset = build(:asset, folder: name, scope: @company, created_by: @owner)
-      assert { asset.valid? }
+      assert asset.valid?, asset.errors.full_messages.to_sentence
     end
   end
 
-  test "folder rejects slashes" do
-    asset = build(:asset, folder: "level1/level2", scope: @company, created_by: @owner)
-    assert { !asset.valid? }
-    assert { asset.errors[:folder].present? }
+  # A folder is one flat label, not a path: a separator would let it address a directory of its
+  # own choosing under /workspace/assets.
+  test "folder rejects path separators, traversal and control characters" do
+    [ "level1/level2", "level1\\level2", ".", "..", "tabbed\tname", "a" * 101 ].each do |name|
+      asset = build(:asset, folder: name, scope: @company, created_by: @owner)
+      assert { !asset.valid? }
+      assert { asset.errors[:folder].present? }
+    end
   end
 
-  test "folder rejects spaces" do
+  # Asset names have always been free-form, and the folder is half of the same path — every
+  # consumer shell-escapes it, so there is nothing for a space to break.
+  test "folder allows spaces" do
     asset = build(:asset, folder: "my folder", scope: @company, created_by: @owner)
-    assert { !asset.valid? }
-    assert { asset.errors[:folder].present? }
+    assert asset.valid?, asset.errors.full_messages.to_sentence
   end
 
   test "folder allows blank" do
     asset = build(:asset, folder: nil, scope: @company, created_by: @owner)
     assert { asset.valid? }
+  end
+
+  test "folder is trimmed on write and a blank folder is stored as root" do
+    asset = create(:asset, folder: "  docs  ", scope: @company, created_by: @owner)
+    assert_equal "docs", asset.folder
+
+    rooted = create(:asset, folder: "   ", scope: @company, created_by: @owner)
+    assert_nil rooted.folder
+  end
+
+  test ".normalize_folder canonicalizes a lookup key the same way a write is canonicalized" do
+    assert_equal "docs", Asset.normalize_folder(" docs ")
+    assert_equal "my folder", Asset.normalize_folder("  my folder  ")
+    assert_nil Asset.normalize_folder("")
+    assert_nil Asset.normalize_folder(nil)
+  end
+
+  test ".invalid_folder? mirrors the validation for callers that reject before building a record" do
+    assert { !Asset.invalid_folder?("my folder") }
+    assert { !Asset.invalid_folder?(nil) }
+    assert { !Asset.invalid_folder?("  ") }
+    assert { Asset.invalid_folder?("docs/sub") }
+    assert { Asset.invalid_folder?("..") }
+    assert { Asset.invalid_folder?("a" * 101) }
   end
 
   test "same name in different folders is allowed" do

--- a/test/services/internal_tools/promote_asset_test.rb
+++ b/test/services/internal_tools/promote_asset_test.rb
@@ -69,6 +69,25 @@ class InternalTools::PromoteAssetTest < ActiveSupport::TestCase
     assert_includes payload["share_url"], "/share/#{asset.public_token}"
   end
 
+  # An invalid folder used to surface to the agent as a raw RecordInvalid from deep inside the
+  # export service; it is the agent's own argument, so it gets a tool error it can act on.
+  test "returns a tool error naming the rule when the folder is invalid" do
+    result = run_tool(name: "report.md", folder: "docs/sub")
+
+    assert_equal 1, result[:exit_code]
+    assert_includes result[:stderr], "docs/sub"
+    assert { Asset.where(scope: @project, name: "report.md").none? }
+  end
+
+  test "promotes into the trimmed folder, spaces inside it kept" do
+    result = run_tool(name: "report.md", folder: "  Q3 reports  ")
+
+    assert_equal 0, result[:exit_code]
+    payload = JSON.parse(result[:stdout])
+    assert_equal "Q3 reports", payload["folder"]
+    assert_equal "Q3 reports", Asset.find(payload["asset_id"]).folder
+  end
+
   test "returns error when no matching workflow output asset exists" do
     result = run_tool(name: "missing.md")
 


### PR DESCRIPTION
## The bug

Uploading an asset into a folder with a space fails — and fails opaquely.

`Asset`'s folder validation was `/\A[a-zA-Z0-9_-]+\z/`, so `my folder` (or a pasted `docs ` with a trailing space) was rejected inside `save!`. `api/v1` rescued `Pundit::*` and `RecordNotFound` but **not** `ActiveRecord::RecordInvalid`, so the request answered **500**. The picker only checks `res.ok`, so the user got `Failed to save uploaded files` with no field named — after the file had already been uploaded to cache storage.

## Why the restriction was the wrong half of the fix

`Asset#name` is validated for presence and uniqueness, but never for its character set — so `/workspace/assets/<folder>/<name>` already carries spaces, quotes and anything else a filename can hold. The folder is the other half of the same path, and the consumer that builds a shell command out of it escapes it (`SessionContextService#download_file_to_container`). There was nothing for a space to break.

What a folder must not be is a *path of its own*. The rule is now:

| verdict | value |
|---|---|
| allowed | `my folder`, `Q3 reports`, `Отчёты`, `notes (draft)` |
| rejected | `/` and `\` — a separator would let the folder address a directory of its own choosing under `/workspace/assets` |
| rejected | control characters — the directory would be unnameable at the far end |
| rejected | `.` and `..` — they pass the format but name a directory that already exists |
| rejected | over 100 characters |

Folders are also canonicalized on write **and on lookup** (`Asset.normalize_folder`): trimmed, blank meaning root (`nil`). Both sides have to agree or `find_by(folder: " docs ")` misses the row stored as `docs`.

## The three layers

- **Model** — `FOLDER_FORMAT` / `RESERVED_FOLDERS` / `FOLDER_MAX_LENGTH`, `before_validation :normalize_folder`, and `Asset.invalid_folder?` as the predicate for callers that owe their caller a message rather than a `RecordInvalid` (agent tools).
- **API** — `rescue_from ActiveRecord::RecordInvalid` in `Api::V1::ApplicationController` answers **422** with `{ error: "<full messages>", errors: [...] }`. This covers the whole `api/v1` tree, not just assets.
- **Picker** — restates the same rule client-side (`folderError()`, a hand-kept mirror of the model constants — there is no shared fixture, so the two move together only by review), shows the server's message when the POST is refused, and **keeps the modal and the staged uploads** on a total failure so the folder can be fixed and retried instead of re-picking the files.

## Two neighbours fixed while in the area

- `find_or_initialize_asset` keyed on **name alone** while uniqueness is per `(scope, folder)`. Uploading `readme.md` into `reports/` when `docs/readme.md` existed *moved* the existing asset and appended a version, instead of creating a sibling. Both the project and company controllers now key on both.
- `WorkflowStepStrategy#download_to_container` built the curl command by wrapping the target path in single quotes without escaping it, over an asset name whose character set nothing checks. A name carrying a quote rewrote the command rather than naming a file. Now `Shellwords.escape`, matching what `SessionContextService` already does.

## Migration

`20260911140000_normalize_asset_folders` puts existing rows into the canonical form. A legacy `""` or padded value would otherwise never be matched again — and `""` collides with `NULL` under `index_assets_on_scope_folder_name` (it keys on `COALESCE(folder, '')`), so the miss surfaces as a unique violation rather than a second row. Conservative: a row whose normalized folder is already taken is left as-is and reported, so it cannot fail the deploy.

## Tests

- model: spaces/Cyrillic/parens accepted; `/`, `\`, `.`, `..`, tab and 101 chars rejected; trimming; `normalize_folder` / `invalid_folder?`
- both asset controllers: 422 naming the field, padded folder trimmed with inner spaces kept, sibling-per-folder, version-append when name+folder match
- `promote_asset`: tool error naming the rule, promotion into a trimmed folder
- picker: invalid folder blocks the POST, a folder with spaces is posted trimmed, the server message is surfaced, generic fallback

Rebased onto #248, which landed in the same file: the new picker tests use its `key`-based `completeUpload` shape rather than the `uploadURL` fallback, and `readErrorMessage` sits beside its `cachedFileDescriptor` helper. The existing system test uploads into `docs`, which the relaxed rule still accepts.

`make check_all` was not run locally — this worktree lives outside the container mount (no `web` container, no gems or `node_modules` on the host). CI has the verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
