### PR TITLE
fix(sentry): drop enable_logs from the Temporal worker Sentry.init

### DIFF
--- a/bin/temporal_worker
+++ b/bin/temporal_worker
@@ -19,7 +19,10 @@ if Settings.sentry.temporal_dsn.present? && !Rails.env.development?
     config.release = Settings.app.version
     config.environment = Rails.env
     config.send_default_pii = true
-    config.enable_logs = true
+    # sentry-ruby 7 removed `enable_logs` (logs are unconditionally on), and calling it
+    # raises NoMethodError from inside Sentry.init — which crashed this process on boot.
+    # See the same migration in config/initializers/sentry.rb; this second Sentry.init,
+    # which replaces that configuration for the worker, was missed by it.
     config.traces_sample_rate = 1.0
     config.profiles_sample_rate = 1.0
   end


### PR DESCRIPTION
## What broke

Every `worker-ruby` pod in production is in `CrashLoopBackOff`, failing at boot:

```
bin/temporal_worker:22:in 'block in <main>': undefined method 'enable_logs=' for an instance of Sentry::Configuration (NoMethodError)

    config.enable_logs = true
	from /usr/local/bundle/gems/sentry-ruby-7.0.0/lib/sentry-ruby.rb:266:in 'Sentry.init'
```

`sentry-ruby` 7.0.0 removed `enable_logs`. #242 migrated `config/initializers/sentry.rb` for
it, but `bin/temporal_worker` calls `Sentry.init` a **second** time — with its own
`Settings.sentry.temporal_dsn`, after `config/environment` — and that call still carried the
flag.

`assets:precompile` never loads `bin/temporal_worker`, so the image built green and the
failure surfaced only in the cluster.

## Why it looked like a concurrency-limit problem

No worker polls the Temporal task queue, so `workflow_execution_workflow_v2` never starts and
every `WorkflowRun` created after the rollout stays in `pending` — no `TerminalSession` row,
no admission, nothing for the queue to grant. On screen that reads as sessions stuck waiting
for capacity.

Production, project 27, at the time of diagnosis:

| | |
|---|---|
| pool `project:27` | `limit=20`, `occupied=6`, **`queued=0`** |
| `SessionConcurrencyLimit` | `max_sessions=20` |
| policy | `enabled=true`, `paused=false` |
| `WorkflowRun` `running` | 4 |
| `WorkflowRun` `pending` | 5, oldest `2026-09-12T12:54:47Z` |

12:54 is the minute the sentry-7 image finished rolling out; the last run that started was
12:53:50. The admission queue was never the constraint.

Second-order damage while the worker is down: `SessionAdmissionReconciler` does not run
either — `cleanup_lag_seconds: 807`, `uncertain_operations: 23`, `pinned_reservations: 2`.
Those should clear on their own once the worker is back.

## The change

Drop the line. Under 7.0 logs are unconditionally on, and this `Sentry.init` sets no
`enabled_patches`, so the `:logger` patch that would turn the worker's own log output into
Sentry log events stays off — same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
