### PR TITLE
feat(antigravity): offer models, collect usage, skip the first-run wizard

### DIFF
--- a/app/services/agents/antigravity_cli_adapter.rb
+++ b/app/services/agents/antigravity_cli_adapter.rb
@@ -36,6 +36,17 @@ module Agents
     SETTINGS_PATH = ".gemini/antigravity-cli/settings.json"
     OAUTH_TOKEN_PATH = ".gemini/antigravity-cli/antigravity-oauth-token"
 
+    # Where `agy` records that its first-run wizard is done. Confirmed against the
+    # real binary by completing the wizard in a container and diffing the whole
+    # filesystem: the colour-scheme picker and the "Terms of Service & Data Use"
+    # screen are gated on this file alone — nothing in settings.json, the state
+    # proto, the installation id or the summaries database moves when they are
+    # answered. Without it every session opens on the wizard and waits for a
+    # keypress, which an automatic session never sends.
+    ONBOARDING_PATH = ".gemini/antigravity-cli/cache/onboarding.json"
+
+    WORKSPACE = "/workspace"
+
     def self.default_config_paths
       [ "~/.gemini/antigravity-cli/settings.json", "~/.gemini/config/mcp_config.json", "GEMINI.md" ]
     end
@@ -75,21 +86,40 @@ module Agents
     end
 
     def config_files(credentials, _workflow_config = {})
-      {
-        "#{home_dir}/#{SETTINGS_PATH}" => settings.to_json,
-        config_path => generate_config(credentials).to_json
-      }
+      first_run_files.merge(config_path => generate_config(credentials).to_json)
     end
 
     # Written before auth starts so the auth terminal already has telemetry/tips
-    # disabled when `agy` itself launches (see AgentAuthStrategy#before_exec).
+    # disabled and the first-run wizard out of the way when `agy` itself launches
+    # (see AgentAuthStrategy#before_exec). Seeding the wizard as done does not
+    # skip the login itself — verified against the real binary: with no token
+    # file present `agy` still opens on its "Select login method" prompt.
     def auth_setup_files
-      { "#{home_dir}/#{SETTINGS_PATH}" => settings.to_json }
+      first_run_files
     end
 
+    # Hosts the model traffic goes to. Both spellings are listed because the
+    # proxy addon matches a tracked domain or a subdomain of it, and
+    # `daily-cloudcode-pa.googleapis.com` — which the binary calls in practice —
+    # is neither of `cloudcode-pa.googleapis.com`. Google's telemetry sink
+    # (`play.googleapis.com/log`) is deliberately not tracked.
+    MITM_DOMAINS = %w[
+      cloudcode-pa.googleapis.com
+      daily-cloudcode-pa.googleapis.com
+      aicode.googleapis.com
+    ].freeze
+
     def default_env_vars(_session)
-      { "AGY_CLI_HIDE_LOGO" => "1" }
+      {
+        "AGY_CLI_HIDE_LOGO" => "1",
+        "MITM_LOG_PATH" => "/var/log/mitm/http.log",
+        "MITM_TRACKED_DOMAINS" => MITM_DOMAINS.join(",")
+      }
     end
+
+    def mitm_tracked_domains = MITM_DOMAINS.dup
+
+    def session_log_paths = super + %w[/var/log/mitm/http.log]
 
     # Reject credentials saved by the earlier API-key implementation before
     # launching `agy`. Those rows contain `api_key`, not an OAuth access token;
@@ -104,12 +134,115 @@ module Agents
       { valid: false, error_code: "oauth_token_missing" }
     end
 
+    # Automatic sessions run the same TUI as interactive ones, like every other
+    # adapter here — they finish by calling finish_session/fail_session, not by
+    # exiting a one-shot print run.
+    #
+    # The trailing `-i` is load-bearing. AgentSessionStrategy#launch_agent_in_tmux
+    # appends the prompt as a positional argument, and `agy` — unlike claude,
+    # codex, cursor and gemini — refuses one outright: `Error: unexpected argument
+    # "…". Prompts are read only from -p/--print, -i/--prompt-interactive, or
+    # stdin`. Ending the command with `-i` makes the appended prompt that flag's
+    # value, which starts the TUI on that prompt and keeps the session going.
     def session_command(mode:, prompt: nil, model: nil)
       parts = [ "agy" ]
       parts += [ "--model", Shellwords.shellescape(model) ] if model.present?
       parts << "--dangerously-skip-permissions"
-      parts += [ "--print", "--output-format", "stream-json" ] if mode == "non_interactive"
+      parts << "-i" if mode == "non_interactive" && prompt.present?
       parts.join(" ")
+    end
+
+    # =================================================================
+    # Available Models
+    # =================================================================
+
+    # What `agy models` itself calls (captured off the wire through the session
+    # image's own MITM proxy). The request body is a bare `{}`; the response
+    # carries every model the account can see, plus the ordering the CLI shows.
+    MODELS_URL = "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels"
+
+    # Not decoration: this endpoint gates on the client User-Agent. The exact
+    # same Bearer token answers 403 with curl's default agent and 200 with an
+    # `antigravity/cli/<version> (aidev_client…)` one — the `aidev_client` token
+    # alone is not enough, the `antigravity/cli/<version>` prefix is what is
+    # checked. `daily-cloudcode-pa.googleapis.com` (what the binary happened to
+    # call) and the stable host above return byte-identical payloads.
+    MODELS_USER_AGENT = "antigravity/cli/1.1.27 (aidev_client; os_type=linux; arch=amd64; auth_method=consumer)"
+
+    # The 14 ids Antigravity offers for agent sessions, in its own order, as of
+    # 2026-09-12. The API returns 33 models; the rest are internal (tab
+    # completion, chat experiments, commit messages) and `--model` is not meant
+    # to take them, so the list here mirrors what the live call filters down to.
+    FALLBACK_MODELS = [
+      { model_id: "gemini-3.8-flash-high", display_name: "Gemini 3.8 Flash (High)" },
+      { model_id: "gemini-3.8-flash-medium", display_name: "Gemini 3.8 Flash (Medium)" },
+      { model_id: "gemini-3.8-flash-low", display_name: "Gemini 3.8 Flash (Low)" },
+      { model_id: "gemini-3.7-flash-high", display_name: "Gemini 3.7 Flash (High)" },
+      { model_id: "gemini-3.7-flash-medium", display_name: "Gemini 3.7 Flash (Medium)" },
+      { model_id: "gemini-3.7-flash-low", display_name: "Gemini 3.7 Flash (Low)" },
+      { model_id: "gemini-3.6-flash-high", display_name: "Gemini 3.6 Flash (High)" },
+      { model_id: "gemini-3.6-flash-medium", display_name: "Gemini 3.6 Flash (Medium)" },
+      { model_id: "gemini-3.6-flash-low", display_name: "Gemini 3.6 Flash (Low)" },
+      { model_id: "gemini-pro-agent", display_name: "Gemini 3.1 Pro (High)" },
+      { model_id: "gemini-3.1-pro-low", display_name: "Gemini 3.1 Pro (Low)" },
+      { model_id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6 (Thinking)" },
+      { model_id: "claude-opus-4-6-thinking", display_name: "Claude Opus 4.6 (Thinking)" },
+      { model_id: "gpt-oss-120b-medium", display_name: "GPT-OSS 120B (Medium)" }
+    ].freeze
+
+    # Straight from the same response's `deprecatedModelIds`, which maps a
+    # retired id to the one that replaces it.
+    RETIRED_MODEL_REPLACEMENTS = { "gemini-3.1-pro-high" => "gemini-pro-agent" }.freeze
+
+    def fetch_available_models(credentials, credential: nil)
+      fetch_available_models_with_source(credentials, credential: credential)[:models]
+    end
+
+    # The stored access token is short-lived (about an hour) and nothing renews
+    # it on our side — `agy` refreshes in its own container and we never read
+    # that back — so an expired token is the normal case, not an error worth
+    # surfacing. Every failure path falls back to the pinned list, which is what
+    # keeps the model picker populated instead of empty.
+    def fetch_available_models_with_source(credentials, credential: nil)
+      token = credentials.is_a?(Hash) ? credentials["access_token"] : nil
+      return { models: FALLBACK_MODELS, source: :fallback } if token.blank?
+
+      response = request_models(token)
+      return { models: FALLBACK_MODELS, source: :fallback } unless response.is_a?(Net::HTTPSuccess)
+
+      models = agent_models(JSON.parse(response.body))
+      models.present? ? { models: models, source: :api } : { models: FALLBACK_MODELS, source: :fallback }
+    rescue StandardError => e
+      Rails.logger.warn("[AntigravityCliAdapter] fetch_available_models failed: #{e.message}")
+      { models: FALLBACK_MODELS, source: :fallback }
+    end
+
+    # =================================================================
+    # Usage collection
+    # =================================================================
+
+    # There is no telemetry path to read: the binary carries no
+    # `OTEL_EXPORTER_OTLP_*` support and no `otlpEndpoint` setting, only Google's
+    # own client pointed at `play.googleapis.com/log`, so nothing can be
+    # re-pointed at our collector. The MITM log is the only source that covers
+    # interactive and automatic sessions alike, and it does work against this
+    # CLI: `agy` is a Go binary, which honours HTTPS_PROXY and SSL_CERT_FILE, so
+    # the proxy half of the session image's logger captures it (the
+    # `http2-logger.js` half only patches Node and never sees it) — verified by
+    # capturing a full `fetchAvailableModels` round trip through it.
+    def collect_usage(terminal_session, artifacts = {})
+      if terminal_session.usage_statistic.present?
+        Rails.logger.info("[AntigravityCliAdapter] Session #{terminal_session.id}: usage already recorded, skipping")
+        return
+      end
+
+      events = extract_events_from_mitm(artifacts["logs/http.log"])
+      if events.empty?
+        Rails.logger.warn("[AntigravityCliAdapter] No usage events in MITM log for session #{terminal_session.id}")
+        return
+      end
+
+      UsageStatistics::Accumulator.record(terminal_session: terminal_session, events: events, source: "mitm")
     end
 
     def context_file_path = "#{home_dir}/.gemini/GEMINI.md"
@@ -136,10 +269,165 @@ module Agents
 
     private
 
+    # Same rule the proxy addon filters on (docker/base/logger/mitm_logger.py
+    # ::_should_log): the host is the tracked domain itself or a subdomain of it.
+    # A bare suffix test would also accept a lookalike host, which must never be
+    # read as vendor traffic.
+    def tracked_host?(host)
+      host = host.to_s.downcase
+      return false if host.blank?
+
+      MITM_DOMAINS.any? { |domain| host == domain || host.end_with?(".#{domain}") }
+    end
+
+    def extract_events_from_mitm(log_content)
+      return [] if log_content.blank?
+
+      log_content.each_line.filter_map do |line|
+        entry = JSON.parse(line.strip)
+        next unless entry["direction"] == "response"
+        next unless tracked_host?(entry["host"])
+
+        body = decode_body(entry)
+        next if body.blank?
+
+        usage_event(body, entry["ts"])
+      rescue JSON::ParserError
+        next
+      end
+    end
+
+    # Counts are pulled out by pattern rather than by parsing the whole body: a
+    # streamed response's final chunk is where they arrive, and the logged body
+    # can be a truncated tail — the same approach Codex and Grok take.
+    #
+    # The field names are Google's `usageMetadata` block, which is what every
+    # other client of this Code Assist backend (Gemini CLI included) receives.
+    # This has NOT been confirmed against a live Antigravity completion: the
+    # account available for testing fails Antigravity's eligibility check
+    # ("not currently available in your location"), so no completion call
+    # reaches the wire at all. The capture side is verified; these field names
+    # are the part still to confirm against a real run.
+    def usage_event(text, timestamp)
+      prompt_tokens = count_field(text, "promptTokenCount")
+      candidate_tokens = count_field(text, "candidatesTokenCount")
+      return nil if prompt_tokens.nil? && candidate_tokens.nil?
+
+      thoughts = count_field(text, "thoughtsTokenCount").to_i
+
+      {
+        "model" => text[/"modelVersion"\s*:\s*"([^"]+)"/, 1] || text[/"model"\s*:\s*"([^"]+)"/, 1],
+        "timestamp" => timestamp,
+        "tokenUsage" => {
+          "inputTokens" => prompt_tokens.to_i,
+          # Google reports thinking tokens outside candidatesTokenCount but bills
+          # them as output, so they are added here rather than only recorded.
+          "outputTokens" => candidate_tokens.to_i + thoughts,
+          "cacheReadTokens" => count_field(text, "cachedContentTokenCount").to_i,
+          "cacheWriteTokens" => 0,
+          "reasoningTokens" => thoughts,
+          # Antigravity bills against a subscription quota, not per token, and
+          # Google publishes no per-token price for this backend — so tokens are
+          # recorded and cost deliberately is not invented.
+          "totalCents" => 0.0
+        },
+        "source" => "mitm"
+      }
+    end
+
+    def count_field(text, field)
+      text[/"#{field}"\s*:\s*(\d+)/, 1]&.to_i
+    end
+
+    def decode_body(entry)
+      body = entry["body"].to_s
+      return "" if body.blank?
+
+      entry["body_encoding"] == "base64" ? Base64.decode64(body).force_encoding("UTF-8") : body
+    rescue ArgumentError
+      ""
+    end
+
+    def request_models(token)
+      uri = URI(MODELS_URL)
+      req = Net::HTTP::Post.new(uri)
+      req["Authorization"] = "Bearer #{token}"
+      req["User-Agent"] = MODELS_USER_AGENT
+      req["Content-Type"] = "application/json"
+      req.body = "{}"
+
+      Net::HTTP.start(uri.hostname, uri.port, use_ssl: true, open_timeout: 5, read_timeout: 10) do |http|
+        http.request(req)
+      end
+    end
+
+    # `agentModelSorts` is the CLI's own answer to "which models may an agent
+    # session run, and in what order" — the same 14 ids `agy models` prints —
+    # while `models` is the full catalogue keyed by id. Take the order from the
+    # first, the display names from the second.
+    def agent_models(payload)
+      catalogue = payload["models"]
+      return [] unless catalogue.is_a?(Hash)
+
+      sorted_ids(payload).filter_map do |id|
+        entry = catalogue[id]
+        next if entry.nil?
+
+        display_name = entry["displayName"].presence || id
+        { model_id: id, display_name: display_name, description: context_description(entry) }.compact
+      end
+    end
+
+    def sorted_ids(payload)
+      Array(payload["agentModelSorts"]).flat_map do |sort|
+        Array(sort["groups"]).flat_map { |group| Array(group["modelIds"]) }
+      end.uniq
+    end
+
+    def context_description(entry)
+      max_tokens = entry["maxTokens"].to_i
+      return nil unless max_tokens.positive?
+
+      size = if max_tokens >= 1_000_000
+        "#{(max_tokens / 1_000_000.0).round}M"
+      elsif max_tokens >= 1_000
+        "#{(max_tokens / 1_000.0).round}K"
+      else
+        max_tokens.to_s
+      end
+      "#{size} token context"
+    end
+
+    # Everything `agy` would otherwise stop and ask a human for on a first run in
+    # a fresh container: the colour scheme, the data-use consent, and folder
+    # trust. All three are answered here so a session opens straight on the
+    # prompt.
+    def first_run_files
+      {
+        "#{home_dir}/#{SETTINGS_PATH}" => settings.to_json,
+        "#{home_dir}/#{ONBOARDING_PATH}" => onboarding_state.to_json
+      }
+    end
+
     def settings
       # Omitting modelProvider selects Antigravity's OAuth-backed default
       # backend. Explicitly selecting "gemini" instead requires GEMINI_API_KEY.
-      { "enableTelemetry" => false, "showTips" => false }
+      #
+      # trustedWorkspaces is the shape `agy` itself writes when a user answers
+      # "Yes, I trust this folder"; pre-seeding it skips that prompt.
+      { "enableTelemetry" => false, "showTips" => false, "trustedWorkspaces" => [ WORKSPACE ] }
+    end
+
+    # `consumerOnboardingComplete` is the half that matters for an account signed
+    # in with plain Google OAuth (`auth_method: "consumer"`); the enterprise flag
+    # is written as false by the CLI itself in that case, and is kept here so the
+    # file matches what a real completed wizard leaves behind.
+    def onboarding_state
+      {
+        "consumerOnboardingComplete" => true,
+        "enterpriseOnboardingComplete" => false,
+        "onboardingComplete" => true
+      }
     end
   end
 end

--- a/docker/base/logger/mitm_logger.py
+++ b/docker/base/logger/mitm_logger.py
@@ -8,8 +8,10 @@ When empty, all traffic is logged.
 """
 import base64
 import datetime
+import gzip
 import json
 import os
+import zlib
 from pathlib import Path
 from typing import Any, Dict, Optional, Set
 
@@ -45,10 +47,65 @@ def _looks_like_text(raw: bytes) -> bool:
         return False
 
 
-def _encode_body(raw: Optional[bytes], content_type: str) -> Dict[str, Any]:
+def _decompress(raw: bytes, content_encoding: str) -> Optional[bytes]:
+    """Undo Content-Encoding. None means "compressed, and we could not undo it".
+
+    Bodies are captured off the wire (the streaming interceptor in
+    responseheaders sees exactly what the server sent), so a gzip'd JSON
+    response arrives here still compressed. Decoding those bytes as UTF-8 turns
+    the whole body into replacement characters, which is how it used to be
+    stored: unparseable, and silently so. Google's code-assist endpoints gzip
+    every JSON response, so this is the difference between a usable usage log
+    and a log full of U+FFFD.
+    """
+    enc = (content_encoding or "").lower().strip()
+    if not enc or enc == "identity":
+        return raw
+
+    try:
+        if enc in ("gzip", "x-gzip"):
+            return gzip.decompress(raw)
+        if enc == "deflate":
+            try:
+                return zlib.decompress(raw)
+            except zlib.error:
+                return zlib.decompress(raw, -zlib.MAX_WBITS)
+        if enc == "br":
+            import brotli  # type: ignore
+
+            return brotli.decompress(raw)
+        if enc == "zstd":
+            import zstandard  # type: ignore
+
+            return zstandard.ZstdDecompressor().decompress(raw)
+    except Exception:
+        # Truncated or unsupported — fall through to "keep the bytes as binary"
+        # rather than storing a mangled transliteration of them.
+        return None
+    return None
+
+
+def _encode_body(
+    raw: Optional[bytes], content_type: str, content_encoding: str = ""
+) -> Dict[str, Any]:
     """Encode body for JSON storage. Returns dict with body + metadata."""
     if not raw:
         return {"body": "", "body_encoding": "text", "body_truncated": False}
+
+    decoded = _decompress(raw, content_encoding)
+    if decoded is None:
+        # Still compressed: base64 it, never text.
+        truncated = False
+        data = raw
+        if MAX_BODY > 0 and len(data) > MAX_BODY:
+            data = data[:MAX_BODY]
+            truncated = True
+        return {
+            "body": base64.b64encode(data).decode("ascii"),
+            "body_encoding": "base64",
+            "body_truncated": truncated,
+        }
+    raw = decoded
 
     if _is_text_content(content_type) or (not content_type and _looks_like_text(raw)):
         try:
@@ -77,7 +134,9 @@ def _encode_body(raw: Optional[bytes], content_type: str) -> Dict[str, Any]:
 def _serialize_request(flow: http.HTTPFlow) -> Dict[str, Any]:
     req = flow.request
     ct = req.headers.get("content-type", "")
-    body_info = _encode_body(req.raw_content, ct)
+    body_info = _encode_body(
+        req.raw_content, ct, req.headers.get("content-encoding", "")
+    )
 
     return {
         "ts": datetime.datetime.utcnow().isoformat() + "Z",
@@ -101,7 +160,9 @@ def _serialize_response(flow: http.HTTPFlow) -> Optional[Dict[str, Any]]:
 
     req = flow.request
     ct = resp.headers.get("content-type", "")
-    body_info = _encode_body(resp.raw_content, ct)
+    body_info = _encode_body(
+        resp.raw_content, ct, resp.headers.get("content-encoding", "")
+    )
 
     return {
         "ts": datetime.datetime.utcnow().isoformat() + "Z",
@@ -178,7 +239,9 @@ def response(flow: http.HTTPFlow) -> None:
     buf: Optional[bytearray] = flow.metadata.get("_body_buf")
     if buf is not None:
         ct = flow.response.headers.get("content-type", "")
-        body_info = _encode_body(bytes(buf), ct)
+        body_info = _encode_body(
+            bytes(buf), ct, flow.response.headers.get("content-encoding", "")
+        )
         entry = _serialize_response_with_body(flow, body_info)
     else:
         entry = _serialize_response(flow)

--- a/docs/operations/antigravity-cli.md
+++ b/docs/operations/antigravity-cli.md
@@ -14,13 +14,40 @@ Aixle connects Antigravity the same way as every other CLI: from Profile or Onbo
 
 Account OAuth is fully supported here, unlike the earlier design of this doc assumed: `agy` itself detects that a container has no D-Bus session bus and automatically persists the login to a file instead of the host OS keyring (confirmed in the CLI's own log output: `composite_token_storage.go: Using file-based token storage because no D-Bus session bus detected`), so it is safe to capture and move between ephemeral containers exactly like every other adapter's credential file. A completed real login confirmed the file: `~/.gemini/antigravity-cli/antigravity-oauth-token` (no extension), written as `{"token":{"access_token":...,"token_type":"Bearer","refresh_token":...,"expiry":"<ISO8601>"},"auth_method":"consumer"}` — nested under `token`, unlike `GeminiCliAdapter`'s flat `oauth_creds.json`. `AgentAuthStrategy#before_cleanup` captures that file (`Agents::AntigravityCliAdapter#config_path`) and the backend stores it in the encrypted `AgentCredential` record; on the next session, `#config_files` writes it back in the same shape before `agy` starts.
 
+## Eligibility
+
+`agy` runs its own eligibility check at startup and can refuse the account outright:
+
+```
+⚠ Eligibility Check
+  Eligibility check failed: Your current account is not eligible for Antigravity,
+  because it is not currently available in your location.
+```
+
+Observed 2026-09-12 with a Google Workspace account signed in through the normal consumer OAuth flow. Auth, the model catalogue and `agy models` all still work in that state — what fails is every completion call, so no model traffic reaches the wire at all. Anything that has to be confirmed against a real turn (the usage field names below) needs an account that passes this check, or an egress region that does.
+
+## Models
+
+`#fetch_available_models` calls `POST https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels` with a `{}` body and the credential's Bearer token — the same call `agy models` makes, captured through the session image's own MITM proxy.
+
+Two things about that endpoint are easy to get wrong:
+
+- **It gates on the User-Agent.** The same token answers 403 with curl's default agent and 200 with `antigravity/cli/<version> (aidev_client; …)`. The bare `aidev_client` token is not enough — the `antigravity/cli/<version>` prefix is what is checked.
+- **The response is bigger than the model picker should be.** `models` holds 33 entries, including internal ones (tab completion, chat experiments, commit messages) that `--model` is not meant to take. `agentModelSorts` is the CLI's own agent list — the 14 ids `agy models` prints, in its order — so the adapter takes the order from there and the display names from `models`. `deprecatedModelIds` feeds `RETIRED_MODEL_REPLACEMENTS`, and `defaultAgentModelId` was `gemini-3.8-flash-high` when this was written.
+
+The stored access token lives about an hour and nothing on our side renews it — `agy` refreshes inside its own container and that file is only captured back during an auth session — so an expired token is the normal case and the adapter falls back to a pinned copy of the 14-model list. Server-side refresh would need Google's client secret, which is embedded in the binary; that is a deliberate decision, not an oversight. The cheaper alternative is to capture the refreshed token file at the end of every agent session, the way auth sessions already do.
+
 ## Runtime contract
 
 - Interactive sessions run `agy --dangerously-skip-permissions` inside the existing container sandbox.
-- Automatic sessions use `agy --print --output-format stream-json`; the standard Aixle context instructs the agent to call `finish_session` or `fail_session`.
+- Automatic sessions run the same TUI with a trailing `-i`, and the standard Aixle context instructs the agent to call `finish_session` or `fail_session` — the same shape as every other runtime here. The `-i` is required, not stylistic: `AgentSessionStrategy#launch_agent_in_tmux` appends the prompt as a positional argument and `agy` refuses one (`Error: unexpected argument "…". Prompts are read only from -p/--print, -i/--prompt-interactive, or stdin`), so the flag is what turns the appended prompt into its value.
+- The first-run wizard is answered upfront, in both auth and agent sessions. `agy` otherwise opens every fresh container on its colour-scheme picker, then a "Terms of Service & Data Use" consent screen, then a folder-trust prompt — each waiting on a keypress an automatic session never sends. Folder trust is `trustedWorkspaces: ["/workspace"]` in `settings.json`; the other two are gated on `~/.gemini/antigravity-cli/cache/onboarding.json` (`{"consumerOnboardingComplete": true, "enterpriseOnboardingComplete": false, "onboardingComplete": true}`). That file was found by completing the wizard in a container and diffing the whole filesystem — nothing in `settings.json`, `jetski_state.pbtxt`, `installation_id` or `conversation_summaries.db` changes when those screens are answered. Seeding it does not skip the login: with no token file present `agy` still opens on "Select login method". Note the consent screen's checkbox is a telemetry opt-in, and seeding it as answered means the session runs with `enableTelemetry: false` — opted out, never opted in on the user's behalf.
 - MCP servers use `~/.gemini/config/mcp_config.json` and the documented `serverUrl` schema.
 - Antigravity imports Gemini-compatible `GEMINI.md` and skills, so Aixle writes those established paths.
-- Vendor telemetry is disabled. Antigravity does not expose an OTLP export contract; automatic-run token counts remain available in its stream-JSON result and terminal log.
+- Vendor telemetry is disabled, and there is no OTLP path to re-point at our collector: the 1.1.27/1.2.1 binary carries no `OTEL_EXPORTER_OTLP_*` support and no `otlpEndpoint` setting — only OTel SDK limit variables and Google's own client, which ships to `play.googleapis.com/log`. The Gemini CLI's `telemetry.otlpEndpoint` block does not exist in this fork.
+- Usage comes from the MITM log, the only source that covers interactive and automatic runs alike now that OTLP is out. `#mitm_tracked_domains` lists `cloudcode-pa.googleapis.com`, `daily-cloudcode-pa.googleapis.com` and `aicode.googleapis.com` (Google's telemetry sink `play.googleapis.com/log` is deliberately not tracked), `#default_env_vars` passes them to the proxy, `#session_log_paths` collects `/var/log/mitm/http.log`, and `#collect_usage` folds the counts in through `UsageStatistics::Accumulator`. Capture is verified against the real binary: `agy` is Go, so it honours `HTTPS_PROXY`/`SSL_CERT_FILE` and the mitmproxy half of the logger sees it — a full `fetchAvailableModels` round trip was captured end to end. (The `http2-logger.js` half only patches Node's http modules and never sees this CLI.)
+- **The token field names are not yet confirmed against a live completion.** `#usage_event` reads Google's `usageMetadata` block (`promptTokenCount`, `candidatesTokenCount`, `thoughtsTokenCount`, `cachedContentTokenCount`), which is what every other client of this Code Assist backend receives — but no Antigravity completion has been observed on the wire, because the account available for testing fails Antigravity's own eligibility check (see below). Confirm the names against a real run before trusting the numbers.
+- Cost is left at zero on purpose. Antigravity bills against a subscription quota rather than per token, and Google publishes no per-token price for this backend, so tokens are recorded and cost is not invented. `fetchAvailableModels` does return a per-model `quotaInfo` (`remainingFraction`, `resetTime`), which is the natural source for a future `#fetch_subscription_usage`.
 
 Build from the `docker/` directory:
 
@@ -29,3 +56,5 @@ docker build -f antigravity-cli/Dockerfile -t aixle/antigravity-cli:latest .
 ```
 
 The image downloads the pinned `agy` 1.1.27 release and verifies Google's published SHA-256 checksum during each build. Record the emitted `agy --version` value with the published image digest for rollback traceability.
+
+**The build-time pin does not hold at runtime.** `agy` runs its own background updater (`agy --bg-updater`) and overwrites `/usr/local/bin/agy` in place: a container started from this image on 2026-09-11 reported 1.1.27 on first launch and 1.2.1 a few minutes later, from the same image. So the checksum verified at build time says nothing about the binary a session actually runs, and a bad upstream release reaches production without an image rebuild. Disabling the updater needs a supported switch (none documented yet) — until then treat the pin as a floor, not a guarantee.

--- a/test/services/agents/antigravity_cli_adapter_test.rb
+++ b/test/services/agents/antigravity_cli_adapter_test.rb
@@ -36,6 +36,7 @@ module Agents
       settings = JSON.parse(files["/home/antigravity/.gemini/antigravity-cli/settings.json"])
       assert_not_includes settings, "modelProvider"
       refute settings["enableTelemetry"]
+      assert_equal [ "/workspace" ], settings["trustedWorkspaces"]
       assert_equal(
         { "token" => { "access_token" => "tok-123", "refresh_token" => "refresh-123" }, "auth_method" => "consumer" },
         JSON.parse(files[@adapter.config_path])
@@ -48,19 +49,35 @@ module Agents
     # backend-written script; only the pre-login settings file is seeded upfront.
     test "seeds only OAuth-compatible settings before login, no bespoke script" do
       files = @adapter.auth_setup_files
-      assert_equal({ "enableTelemetry" => false, "showTips" => false },
+      assert_equal({ "enableTelemetry" => false, "showTips" => false, "trustedWorkspaces" => [ "/workspace" ] },
                    JSON.parse(files["/home/antigravity/.gemini/antigravity-cli/settings.json"]))
-      assert_equal [ "/home/antigravity/.gemini/antigravity-cli/settings.json" ], files.keys
+      assert_equal [ "/home/antigravity/.gemini/antigravity-cli/settings.json",
+                     "/home/antigravity/.gemini/antigravity-cli/cache/onboarding.json" ], files.keys
+    end
+
+    # Every session otherwise opens on the colour-scheme picker and the data-use
+    # consent screen and waits for a keypress no automatic session ever sends.
+    test "answers the first-run wizard so no session opens on it" do
+      [ @adapter.auth_setup_files, @adapter.config_files({ "access_token" => "tok-123" }) ].each do |files|
+        onboarding = JSON.parse(files["/home/antigravity/.gemini/antigravity-cli/cache/onboarding.json"])
+        assert onboarding["onboardingComplete"]
+        assert onboarding["consumerOnboardingComplete"]
+        refute onboarding["enterpriseOnboardingComplete"]
+      end
     end
 
     test "drives the auth terminal through the bare CLI, same as every other adapter" do
       assert_equal [], @adapter.auth_launch_commands_for("agent")
     end
 
-    test "uses print mode only for automatic sessions" do
+    # `agy` rejects a positional prompt ("unexpected argument"), so the trailing
+    # -i is what turns the prompt AgentSessionStrategy appends into a flag value.
+    test "runs the TUI in both modes and takes an automatic session prompt through -i" do
       assert_equal "agy --dangerously-skip-permissions", @adapter.session_command(mode: "interactive")
-      assert_equal "agy --model gemini-3.5-pro --dangerously-skip-permissions --print --output-format stream-json",
-                   @adapter.session_command(mode: "non_interactive", model: "gemini-3.5-pro")
+      assert_equal "agy --dangerously-skip-permissions",
+                   @adapter.session_command(mode: "non_interactive", prompt: nil)
+      assert_equal "agy --model gemini-3.5-pro --dangerously-skip-permissions -i",
+                   @adapter.session_command(mode: "non_interactive", prompt: "ship it", model: "gemini-3.5-pro")
     end
 
     test "generates Antigravity MCP schema" do
@@ -71,8 +88,10 @@ module Agents
       assert_equal({ "X-Key" => "x" }, entry["headers"])
     end
 
-    test "default_env_vars only hides the CLI logo, no credential is passed via env" do
-      assert_equal({ "AGY_CLI_HIDE_LOGO" => "1" }, @adapter.default_env_vars(@session))
+    test "default_env_vars carries no credential material" do
+      env = @adapter.default_env_vars(@session)
+      assert_equal "1", env["AGY_CLI_HIDE_LOGO"]
+      assert_equal %w[AGY_CLI_HIDE_LOGO MITM_LOG_PATH MITM_TRACKED_DOMAINS], env.keys.sort
     end
 
     test "credential_preflight accepts a valid OAuth token" do
@@ -90,7 +109,152 @@ module Agents
                    @adapter.credential_preflight(runtime, container, "abc123"))
     end
 
+    # =========================================================================
+    # fetch_available_models
+    # =========================================================================
+
+    # `agentModelSorts` is what the CLI itself shows; the full `models` map also
+    # carries internal entries (tab completion, chat experiments) that `--model`
+    # is not meant to take, so anything outside the sort order is dropped.
+    test "fetch_available_models takes the CLI's own agent list, not the whole catalogue" do
+      body = {
+        "models" => {
+          "gemini-3.8-flash-high" => { "displayName" => "Gemini 3.8 Flash (High)", "maxTokens" => 1_048_576 },
+          "claude-sonnet-4-6" => { "displayName" => "Claude Sonnet 4.6 (Thinking)" },
+          "tab_flash_lite_preview" => { "maxTokens" => 32_768 }
+        },
+        "agentModelSorts" => [
+          { "groups" => [ { "modelIds" => [ "gemini-3.8-flash-high", "claude-sonnet-4-6", "not-in-catalogue" ] } ] }
+        ]
+      }.to_json
+      stub_request(:post, AntigravityCliAdapter::MODELS_URL)
+        .to_return(status: 200, body: body, headers: { "Content-Type" => "application/json" })
+
+      result = @adapter.fetch_available_models_with_source({ "access_token" => "tok-123" })
+
+      assert_equal :api, result[:source]
+      assert_equal(
+        [ { model_id: "gemini-3.8-flash-high", display_name: "Gemini 3.8 Flash (High)",
+            description: "1M token context" },
+          { model_id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6 (Thinking)" } ],
+        result[:models]
+      )
+    end
+
+    # The endpoint 403s on any User-Agent that is not one of Google's own
+    # clients, so the header is part of the request, not decoration.
+    test "fetch_available_models identifies itself as the Antigravity CLI" do
+      stub = stub_request(:post, AntigravityCliAdapter::MODELS_URL)
+        .with(headers: { "User-Agent" => AntigravityCliAdapter::MODELS_USER_AGENT,
+                         "Authorization" => "Bearer tok-123" }, body: "{}")
+        .to_return(status: 200, body: { "models" => {}, "agentModelSorts" => [] }.to_json)
+
+      @adapter.fetch_available_models({ "access_token" => "tok-123" })
+
+      assert_requested stub
+    end
+
+    # The stored access token expires in about an hour and nothing on our side
+    # renews it, so a rejected call is the normal case — the picker still has to
+    # come back populated.
+    test "fetch_available_models falls back to the pinned list on a stale token" do
+      stub_request(:post, AntigravityCliAdapter::MODELS_URL).to_return(status: 403, body: "")
+
+      result = @adapter.fetch_available_models_with_source({ "access_token" => "expired" })
+
+      assert_equal :fallback, result[:source]
+      assert_equal AntigravityCliAdapter::FALLBACK_MODELS, result[:models]
+    end
+
+    test "fetch_available_models falls back without ever calling out when there is no token" do
+      result = @adapter.fetch_available_models_with_source({ "auth_method" => "consumer" })
+
+      assert_equal({ models: AntigravityCliAdapter::FALLBACK_MODELS, source: :fallback }, result)
+    end
+
+    test "migrates a stored default off the model id Antigravity retired" do
+      assert_equal "gemini-pro-agent", @adapter.migrate_model_id("gemini-3.1-pro-high")
+      assert_equal "claude-sonnet-4-6", @adapter.migrate_model_id("claude-sonnet-4-6")
+    end
+
+    # =========================================================================
+    # Usage collection
+    # =========================================================================
+
+    test "tracks the model hosts and collects the proxy log the counts come from" do
+      env = @adapter.default_env_vars(@session)
+      assert_equal "/var/log/mitm/http.log", env["MITM_LOG_PATH"]
+      assert_equal "cloudcode-pa.googleapis.com,daily-cloudcode-pa.googleapis.com,aicode.googleapis.com",
+                   env["MITM_TRACKED_DOMAINS"]
+      assert_includes @adapter.session_log_paths, "/var/log/mitm/http.log"
+    end
+
+    test "collect_usage records the usageMetadata counts from the proxy log" do
+      log = [
+        mitm_response("daily-cloudcode-pa.googleapis.com", {
+          "modelVersion" => "gemini-3.8-flash-high",
+          "usageMetadata" => { "promptTokenCount" => 1200, "candidatesTokenCount" => 300,
+                               "thoughtsTokenCount" => 45, "cachedContentTokenCount" => 800 }
+        }),
+        mitm_response("play.googleapis.com", {
+          "usageMetadata" => { "promptTokenCount" => 999_999, "candidatesTokenCount" => 999_999 }
+        })
+      ].join
+
+      @adapter.collect_usage(@session, { "logs/http.log" => log })
+
+      stat = @session.reload.usage_statistic
+      assert_equal 1200, stat.input_tokens
+      # Thinking tokens are billed as output and reported outside candidatesTokenCount.
+      assert_equal 345, stat.output_tokens
+      assert_equal 800, stat.cache_read_tokens
+      assert_equal [ "gemini-3.8-flash-high" ], stat.models
+      # Subscription quota, not metered per token — no price is invented.
+      assert_equal 0, stat.cost_cents
+    end
+
+    # Google gzips every JSON response from this backend, and the proxy addon
+    # stores a body it could not decompress as base64 rather than as mangled text.
+    test "collect_usage reads a body the proxy had to store as base64" do
+      payload = { "usageMetadata" => { "promptTokenCount" => 10, "candidatesTokenCount" => 5 } }.to_json
+      log = mitm_response("cloudcode-pa.googleapis.com", nil,
+                          body: Base64.strict_encode64(payload), encoding: "base64")
+
+      @adapter.collect_usage(@session, { "logs/http.log" => log })
+
+      assert_equal 10, @session.reload.usage_statistic.input_tokens
+    end
+
+    test "collect_usage leaves the session alone when the log holds no counts" do
+      @adapter.collect_usage(@session, { "logs/http.log" => mitm_response("cloudcode-pa.googleapis.com", { "ok" => true }) })
+
+      assert_nil @session.reload.usage_statistic
+    end
+
+    # A lookalike host must never be read as vendor traffic.
+    test "collect_usage ignores a host that merely ends with the tracked name" do
+      log = mitm_response("evil-cloudcode-pa.googleapis.com.attacker.test", {
+        "usageMetadata" => { "promptTokenCount" => 5, "candidatesTokenCount" => 5 }
+      })
+
+      @adapter.collect_usage(@session, { "logs/http.log" => log })
+
+      assert_nil @session.reload.usage_statistic
+    end
+
     private
+
+    def mitm_response(host, payload, body: nil, encoding: "text")
+      {
+        "ts" => "2026-09-12T11:00:00Z",
+        "direction" => "response",
+        "status_code" => 200,
+        "host" => host,
+        "path" => "/v1internal:generateContent",
+        "body" => body || payload.to_json,
+        "body_encoding" => encoding
+      }.to_json + "\n"
+    end
 
     def preflight_runtime(auth_content)
       filesystem = {}


### PR DESCRIPTION
## Why

An Antigravity session could not pick a model, reported zero tokens and zero cost, and opened every fresh container on a first-run wizard that waits for a keypress an automatic session never sends. This is what a run looked like and what the platform recorded for it: `COST —`, `TOTAL TOKENS —`, `MODELS —`.

Everything below was confirmed against the real `agy` binary in a container — the CLI's own traffic captured through the session image's proxy, its state files diffed across a completed wizard — rather than inferred from the Gemini CLI it forked.

## What changed

**The session no longer opens on a wizard.** Folder trust is `trustedWorkspaces: ["/workspace"]` in `settings.json`. The colour-scheme picker and the "Terms of Service & Data Use" consent screen are gated on one file nobody had found: `~/.gemini/antigravity-cli/cache/onboarding.json`. It was located by completing the wizard in a container and diffing the whole filesystem — nothing in `settings.json`, `jetski_state.pbtxt`, `installation_id` or the summaries database moves when those screens are answered. Seeding it does not skip the login: with no token file present `agy` still opens on "Select login method" (verified).

Note for review: that consent screen's checkbox is a telemetry opt-in. Seeding it as answered means sessions run with `enableTelemetry: false` — opted out, never opted in on a user's behalf.

**Automatic sessions run the TUI, like every other runtime here.** `--print --output-format stream-json` is gone; they finish through `finish_session`/`fail_session`. The trailing `-i` is load-bearing rather than stylistic — `AgentSessionStrategy#launch_agent_in_tmux` appends the prompt positionally, and `agy` refuses that outright:

```
Error: unexpected argument "…".
Prompts are read only from -p/--print, -i/--prompt-interactive, or stdin.
```

**The model picker is populated.** `#fetch_available_models` calls the endpoint `agy models` itself calls. Two things that are easy to get wrong:

- It gates on the User-Agent. The same Bearer token answers **403** with curl's default agent and **200** with `antigravity/cli/<version> (aidev_client; …)`. A bare `aidev_client` is not enough — the `antigravity/cli/<version>` prefix is what is checked.
- The response holds 33 models, but only the 14 in `agentModelSorts` are meant for `--model`; the rest are internal (tab completion, chat experiments, commit messages). `deprecatedModelIds` feeds `RETIRED_MODEL_REPLACEMENTS`.

The stored access token lives about an hour and nothing on our side renews it (`agy` refreshes inside its own container and that file is only captured back during an auth session), so the pinned fallback list is the normal path, not the exception. Both paths verified end to end through our own Ruby: `source=api, count=14` with a live token, `source=fallback, count=14` with the stored one.

**Usage is collected from the proxy log.** There is no OTLP alternative to weigh up: the binary carries no `OTEL_EXPORTER_OTLP_*` support and no `otlpEndpoint` setting, only Google's own client pointed at `play.googleapis.com/log`, so nothing can be re-pointed at our collector. The MITM log is the one source that covers interactive and automatic runs alike, and it does work against this CLI — `agy` is a Go binary, so it honours `HTTPS_PROXY`/`SSL_CERT_FILE` and the mitmproxy half of the logger sees it (the `http2-logger.js` half only patches Node and never would).

**Shared fix: the proxy logger destroyed compressed bodies.** It encoded `raw_content` — the bytes as they came off the wire — and chose text-vs-binary from the Content-Type alone, so a gzip'd `application/json` response was decoded as UTF-8 with `errors="replace"` and stored as solid U+FFFD. Google gzips every JSON response from this backend, so nothing downstream could have parsed a thing. This lands in `docker/base/logger/mitm_logger.py`, which every agent image shares; today's other runtimes are unaffected because their providers answer uncompressed.

## What is NOT verified, and why

**The token field names.** `#usage_event` reads Google's `usageMetadata` block (`promptTokenCount`, `candidatesTokenCount`, `thoughtsTokenCount`, `cachedContentTokenCount`) — what every other client of this Code Assist backend receives — but no Antigravity completion has been seen on the wire, because every account available for testing fails Antigravity's own eligibility check:

```
⚠ Eligibility Check
  Eligibility check failed: Your current account is not eligible for Antigravity,
  because it is not currently available in your location.
```

Asking the backend directly shows what that actually means, and it is not what the message says:

```json
"ineligibleTiers": [{ "reasonCode": "UNSUPPORTED_LOCATION", "tierId": "free-tier" }],
"allowedTiers":    [{ "id": "standard-tier", "userDefinedCloudaicompanionProject": true, "usesGcpTos": true }]
```

The account's region is fine (`fetchUserInfo` → `regionCode: NL`). The **free tier** is geo-limited; the tier backed by a user's own Google Cloud project is allowed. That is the second option in `agy`'s login prompt, and reaching it needs a GCP project id the platform does not yet store — see below. The capture side is verified; these field names are the part still to confirm against a real turn.

## Follow-ups this opens (not in this PR)

- **Cloud-project auth is half-supported.** An `auth_method: "gcp"` login saves fine, but nothing stores or injects the project id, so the next session lands on `Enter Google Cloud Project ID` and waits there while the platform reports it as `ready`. Needs: capture the id in the auth session, pass `GOOGLE_CLOUD_PROJECT` into session containers, and extend `#credential_preflight` to require it for that auth method.
- **Cost is deliberately zero.** Antigravity bills against a subscription quota and Google publishes no per-token price for this backend, so tokens are recorded and cost is not invented. `fetchAvailableModels` returns a per-model `quotaInfo` (`remainingFraction`, `resetTime`) — the natural source for a `#fetch_subscription_usage`.
- **The version pin does not hold at runtime.** `agy` runs its own background updater and overwrites `/usr/local/bin/agy` in place: the same image reported 1.1.27 on first launch and 1.2.1 minutes later. The build-time checksum says nothing about the binary a session actually runs.
- **Server-side token refresh needs Google's client secret** (a plain refresh with the client id alone answers `400 client_secret is missing`). The secret is embedded in the binary; embedding it here is a call to make deliberately, not by default. The cheaper alternative is capturing the refreshed token file at the end of every agent session, the way auth sessions already do.

## Testing

`docker compose exec -T web make check_all` — green except `system-test`, which is not this branch: the same two errors (`Unable to find field "Email"`, screenshot shows a blank page — the React app never executes) reproduce on the untouched base commit `21084ee8` in the same local stack. Backend tests, rubocop, brakeman, eslint, typescript, fsd, vitest and vite-build all pass; coverage 91.92% backend / 81.03% frontend. Left for CI to confirm.

The adapter's own suite covers the wizard seeding, both `session_command` modes, the model parsing (including the User-Agent the endpoint demands and the fallback on a stale token), and usage collection (including a base64 body, and a lookalike host that must not be read as vendor traffic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
