### PR TITLE
test(ci): boot bin/temporal_worker in the check suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Application Management
-.PHONY: deps db-prepare db-reset check check_all be_check_all fe_check_all be_check fe_check lint typescript test rails-test fe-test rubocop rubocop-fix eslint eslint-fix fsd fsd-fix db_dump db_restore db_restore_remote brakeman license-report license-report-ruby license-report-js default setup git-hooks up down reset worker shell build-web build-otlp-ingest build-agents restore-dump help
+.PHONY: deps db-prepare db-reset check check_all be_check_all fe_check_all be_check fe_check lint typescript test rails-test fe-test worker-boot rubocop rubocop-fix eslint eslint-fix fsd fsd-fix db_dump db_restore db_restore_remote brakeman license-report license-report-ruby license-report-js default setup git-hooks up down reset worker shell build-web build-otlp-ingest build-agents restore-dump help
 
 DOCKER_COMPOSE ?= docker compose
 
@@ -79,6 +79,11 @@ define run_be_checks
 	@# React SPA never mounts → system tests fail "Unable to find field Email". Unset it so
 	@# test chunks resolve relative to the Capybara test server.
 	@( env -u VITE_RUBY_ASSET_HOST -u ASSET_HOST VITE_RUBY_MODE=test bin/vite build --force > $(CHECK_RESULTS)/vite-build.log 2>&1; echo $$? > $(CHECK_RESULTS)/vite-build.status )
+	@echo "Running the worker boot smoke (nothing else in the repo ever loads bin/temporal_worker)..."
+	@# Sequential, not part of the parallel batch below: it boots Rails against the test
+	@# database and the tools registry reconciles on boot, so racing it against the suite
+	@# writing the same database buys a few seconds and a class of flake.
+	@( bin/worker_boot_check > $(CHECK_RESULTS)/worker-boot.log 2>&1; echo $$? > $(CHECK_RESULTS)/worker-boot.status )
 	@echo "Running rails-test, rubocop, brakeman, system-test in parallel (DB-touching runs serialized by flock)..."
 	@( $(RAILS_TEST_COV_ENV) $(TEST_LOCK) bundle exec rails test > $(CHECK_RESULTS)/rails-test.log 2>&1; echo $$? > $(CHECK_RESULTS)/rails-test.status ) & \
 	 ( SKIP_COVERAGE=1 $(TEST_LOCK) bundle exec rails test:system   > $(CHECK_RESULTS)/system-test.log 2>&1; echo $$? > $(CHECK_RESULTS)/system-test.status ) & \
@@ -192,6 +197,11 @@ rails-test:
 # Run frontend tests (Vitest, node-only — no backend). Runs inside the web container; also part of check_all.
 fe-test:
 	yarn test
+
+# Boot bin/temporal_worker far enough to prove it can start (see the script header).
+# Part of be_check_all; standalone here for a quick local check after touching the worker.
+worker-boot:
+	bin/worker_boot_check
 
 # Run Rubocop
 rubocop:

--- a/bin/worker_boot_check
+++ b/bin/worker_boot_check
@@ -1,0 +1,100 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Boot smoke for bin/temporal_worker.
+#
+# WHY THIS EXISTS: nothing in the repository ever loaded bin/temporal_worker.
+# `assets:precompile` does not, the test suite does not, and rubocop only parses
+# it. So a runtime error in that file reached production as a green build. On
+# 2026-09-12 it did: sentry-ruby 7.0.0 removed `enable_logs`, the worker's own
+# second `Sentry.init` still set it, every worker-ruby pod hit CrashLoopBackOff,
+# and — because the raise happened inside `Sentry.init` itself, above the
+# `begin/rescue` that reports fatal errors — Sentry never heard about it either.
+# Nothing polled the Temporal task queue for nearly two hours and every
+# WorkflowRun created in that window sat in `pending`.
+#
+# WHAT IT PROVES: the worker process gets as far as announcing its registry,
+# which means Rails booted, `Sentry.init` ran against the real gem, the workflow
+# and activity classes all loaded, and each one could be instantiated. That is
+# the whole class of failure above, at the cost of one Rails boot.
+#
+# WHAT IT DOES NOT PROVE: anything past the registry announcement — schedule
+# sync, the Temporal connection, task polling. Those need a live server, which
+# this check deliberately does not require (TEMPORAL_ENABLED=false).
+
+require "timeout"
+
+# The last thing the worker logs before it needs a Temporal server. Reaching it
+# means every workflow and activity class loaded and instantiated.
+MARKER = "Ruby worker - registered activities"
+
+# A Rails boot plus the registry walk. Generous: a cold CI container with a cold
+# bootsnap cache is much slower than a warm local one, and a flake here reads as
+# a broken worker.
+TIMEOUT_SECONDS = Integer(ENV.fetch("WORKER_BOOT_CHECK_TIMEOUT", "180"))
+
+# Sentry.init only runs when a DSN is configured and the environment is not
+# development — so a check that left either alone would skip the very block that
+# broke production. The DSN is never dialled during init (the transport is lazy
+# and lives in a background thread we kill seconds later), so a syntactically
+# valid unreachable one is enough to execute the real configuration path.
+child_env = {
+  "RAILS_ENV" => "test",
+  "TEMPORAL_ENABLED" => "false",
+  "SENTRY_TEMPORAL_DSN" => ENV.fetch("SENTRY_TEMPORAL_DSN", "https://worker-boot-check@example.invalid/1")
+}
+
+worker = File.expand_path("temporal_worker", __dir__)
+output = +""
+found = false
+
+# Array form so the command is exec'd directly rather than through a shell, and
+# stderr folded into stdout — the crash this exists to catch prints there.
+io = IO.popen(child_env, [ worker ], "r", err: [ :child, :out ])
+
+begin
+  Timeout.timeout(TIMEOUT_SECONDS) do
+    io.each_line do |line|
+      output << line
+      next unless line.include?(MARKER)
+
+      found = true
+      break
+    end
+  end
+rescue Timeout::Error
+  output << "\n[worker_boot_check] timed out after #{TIMEOUT_SECONDS}s\n"
+ensure
+  # The worker is a long-running process: on a pass it is still alive and still
+  # holding a DB connection, so it has to be taken down either way. TERM first so
+  # it can close cleanly; KILL only if it ignores that. Every "already gone" error
+  # is benign here — it means the child exited on its own, which `found` judges.
+  #
+  # The pipe is deliberately not closed: IO#close on a popen handle reaps the
+  # child a second time and raises ECHILD after the waits below. This script exits
+  # within milliseconds of here, so the descriptor goes with the process.
+  begin
+    Process.kill("TERM", io.pid)
+    Timeout.timeout(10) { Process.wait(io.pid) }
+  rescue Timeout::Error
+    begin
+      Process.kill("KILL", io.pid)
+      Process.wait(io.pid)
+    rescue Errno::ESRCH, Errno::ECHILD
+      nil
+    end
+  rescue Errno::ESRCH, Errno::ECHILD
+    nil
+  end
+end
+
+if found
+  puts "[worker_boot_check] OK — bin/temporal_worker reached #{MARKER.inspect}"
+  exit 0
+end
+
+warn "[worker_boot_check] FAILED — bin/temporal_worker never reached #{MARKER.inspect}."
+warn "[worker_boot_check] The worker cannot boot; every Temporal schedule and task would stop."
+warn "[worker_boot_check] --- worker output ---"
+warn output.empty? ? "(no output)" : output
+exit 1


### PR DESCRIPTION
## Why

Nothing in this repository ever loaded `bin/temporal_worker`. `assets:precompile` does not, the
test suite does not, and rubocop only parses it. So a runtime error in that file reaches
production as a green build.

On 2026-09-12 one did. `sentry-ruby` 7.0.0 removed `enable_logs`; the worker's own second
`Sentry.init` still set it:

```
bin/temporal_worker:22:in 'block in <main>': undefined method 'enable_logs=' for an instance of Sentry::Configuration (NoMethodError)
	from /usr/local/bundle/gems/sentry-ruby-7.0.0/lib/sentry-ruby.rb:266:in 'Sentry.init'
```

Every `worker-ruby` pod hit CrashLoopBackOff. Because the raise happened *inside* `Sentry.init`,
above the `begin/rescue` at the bottom of the file that reports fatal errors, Sentry never heard
about it. Nothing polled the Temporal task queue for nearly two hours, and every `WorkflowRun`
created in that window sat in `pending` — with the admission pool at `occupied: 6` of `limit: 20`
and `queued: 0`, so on screen it read as a concurrency limit that was in fact nowhere near full.

Fixed in #253. This is the check that would have caught it before the merge.

## What it proves

The worker reaches `Ruby worker - registered activities` — so Rails booted, `Sentry.init` ran
against the real gem, and every workflow and activity class loaded *and* could be instantiated.

It needs no Temporal server: `TEMPORAL_ENABLED=false`, and the marker is printed before the first
call that would need one. What it does not cover is everything past that line — schedule sync, the
connection, task polling.

`Sentry.init` only runs when a DSN is configured and the environment is not development, so the
check supplies both. Without that it would skip the very block that broke production.

## Placement

Sequential in `run_be_checks` rather than part of the parallel batch: it boots Rails against the
test database and the tools registry reconciles on boot, so racing it against the suite writing
the same database buys a few seconds and a class of flake. Also available standalone as
`make worker-boot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
