### PR TITLE
feat(workflows): make run dispatch durable and fail loudly

### DIFF
--- a/app/models/workflow_run.rb
+++ b/app/models/workflow_run.rb
@@ -40,6 +40,37 @@ class WorkflowRun < ApplicationRecord
   broadcasts_to ->(run) { run }, on: :update
   after_commit :broadcast_run_list_update, on: :update
 
+  # Transactional outbox for run dispatch, mirroring TriggerEvent's. `state` is
+  # the run's own lifecycle; `relay_state` answers a different question — was the
+  # Temporal execution that drives this run ever confirmed started?
+  #
+  # WHY IT IS NOT THE SAME QUESTION: WorkflowService.start dials Temporal inline,
+  # and TemporalService.start_workflow does not raise on a failed RPC — it returns
+  # { ok: false, ... }. A run whose start never reached Temporal therefore looked
+  # exactly like one the worker had not picked up yet: `state` "pending", nothing
+  # logged above a Rails.logger.error, and no retry anywhere. It would sit there
+  # forever.
+  RELAY_GRACE = 2.minutes
+
+  # Stop re-dispatching a run whose start keeps failing, so one poison run cannot
+  # churn forever. Same ceiling as TriggerEvent: ~33h at the grace cadence, which
+  # rides out a long outage without burying it.
+  RELAY_MAX_ATTEMPTS = 1000
+
+  # What the relay re-drives. Deliberately narrower than "relay_state pending":
+  #
+  # * `state: "pending"` — a run the worker has already advanced is running
+  #   whether or not our inline call got its confirmation, and re-driving it would
+  #   be pointless. It stops being swept and keeps its honest relay_state.
+  # * `stop_requested_at: nil` — never start an execution for a run somebody
+  #   cancelled while it sat undispatched.
+  scope :stuck_for_relay, ->(now = Time.current) {
+    where(relay_state: "pending", state: "pending", stop_requested_at: nil)
+      .where(relay_attempts: ...RELAY_MAX_ATTEMPTS)
+      .where(created_at: ..(now - RELAY_GRACE))
+      .order(:id)
+  }
+
   scope :active, -> { where(state: %w[pending running paused]) }
   scope :for_project_in_period, ->(project, since) { where(project: project, created_at: since..) }
   scope :for_user_in_project, ->(project, user, since) { where(project: project, user: user, created_at: since..) }

--- a/app/services/temporal_workflow_registry.rb
+++ b/app/services/temporal_workflow_registry.rb
@@ -124,6 +124,13 @@ class TemporalWorkflowRegistry
         wf,
         { workflow_run_id: workflow_run.id },
         id: "workflow-execution-#{workflow_run.id}",
+        # What makes re-dispatch safe, and therefore the outbox relay possible
+        # (WorkflowRunRelay). The id is per-run, so a duplicate start can only
+        # mean this run's execution already exists — which is success, not a
+        # failure, and is how a re-drive of a run Temporal did receive settles.
+        # It also forbids reusing the id after the execution closed, so a
+        # finished run can never be silently re-run.
+        reject_duplicate: true,
         # Queue time is not execution budget (AD-7), so an admitted run gets far
         # more than a day — but it still gets a ceiling. "No timeout at all"
         # means a wedged run is invisible to every deadline we have.

--- a/app/services/workflow_run_relay.rb
+++ b/app/services/workflow_run_relay.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# The relay side of the transactional outbox for run DISPATCH. Sibling of
+# OutboxRelay, which relays trigger events; this one relays the step after it.
+#
+# WHY BOTH EXIST: OutboxRelay guarantees that an event a producer committed
+# eventually reaches WorkflowService.start. Nothing guaranteed the next hop.
+# WorkflowService.start dials Temporal inline, and TemporalService.start_workflow
+# does not raise on a failed RPC — it returns { ok: false, ... }. So a run created
+# while Temporal was unreachable was committed, never executed, and looked exactly
+# like one the worker had not picked up yet. There was no retry: the stale-run
+# reaper only touches `running`/`paused` runs past four hours, and the admission
+# reconciler does not look at runs at all. It sat in `pending` forever.
+#
+# Delivery is at-least-once and re-dispatch is idempotent: the Temporal execution
+# id is per-run and duplicates are rejected, with a rejected duplicate reported as
+# success (see TemporalWorkflowRegistry#start_workflow_execution).
+class WorkflowRunRelay
+  # Cap per sweep so one cron tick does a bounded amount of work; each run costs a
+  # Temporal RPC. A backlog drains over successive minutely ticks.
+  DEFAULT_LIMIT = 50
+
+  class << self
+    # Re-dispatch runs left undispatched past the grace window. Rows are claimed
+    # under FOR UPDATE SKIP LOCKED in a short transaction so concurrent drainers
+    # never grab the same run, and the lock is released before dispatching — the
+    # Temporal call must not run while holding row locks.
+    #
+    # Returns { swept:, dispatched:, failed: } counts.
+    def drain(limit: DEFAULT_LIMIT, now: Time.current)
+      run_ids = claim_ids(limit: limit, now: now)
+      dispatched = 0
+      failed = 0
+
+      run_ids.each do |id|
+        run = WorkflowRun.find_by(id: id)
+        next if run.nil?
+
+        begin
+          WorkflowService.dispatch!(run)
+          dispatched += 1
+          Rails.logger.info("[WorkflowRunRelay] run ##{id} dispatched on attempt #{run.relay_attempts}")
+        rescue WorkflowService::DispatchFailed => e
+          # Expected while the outage that stranded the run is still going. The
+          # attempt counter is what eventually stops a poison run (RELAY_MAX_ATTEMPTS),
+          # so a failure here is recorded and the sweep moves on.
+          failed += 1
+          Rails.logger.warn("[WorkflowRunRelay] run ##{id} still undispatched: #{e.message}")
+        end
+      end
+
+      if run_ids.any?
+        Rails.logger.warn("[WorkflowRunRelay] swept=#{run_ids.size} dispatched=#{dispatched} failed=#{failed}")
+      end
+
+      { swept: run_ids.size, dispatched: dispatched, failed: failed }
+    end
+
+    private
+
+    def claim_ids(limit:, now:)
+      WorkflowRun.transaction do
+        WorkflowRun
+          .stuck_for_relay(now)
+          .limit(limit)
+          .lock("FOR UPDATE SKIP LOCKED")
+          .pluck(:id)
+      end
+    end
+  end
+end

--- a/app/services/workflow_service.rb
+++ b/app/services/workflow_service.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class WorkflowService
+  # A run was saved but its Temporal execution could not be started. Raised, not
+  # returned: an undispatched run is an outage, not a validation error, and the
+  # thing that used to happen instead — log a line and hand the caller a run that
+  # looked started — is what let a queue stall go unnoticed for two hours.
+  DispatchFailed = Class.new(StandardError)
+
   class << self
     def update(workflow:, params:)
       attrs = params.to_h
@@ -34,20 +40,64 @@ class WorkflowService
       # SessionAdmissionPolicy.sync! refuses to flip the mode while any run is
       # pending, running or paused.
       run.shared_context = run.shared_context.merge("session_admission" => SessionAdmissionPolicy.enabled?)
+      # Enrol the run in the outbox in the very write that creates it. From here
+      # on a dispatch that never lands is a row the relay can find, instead of a
+      # run indistinguishable from one the worker simply has not reached yet.
+      run.relay_state = "pending"
       return run unless run.save
 
       workflow.steps.not_deleted.order(:position).each do |step|
         run.step_runs.find_or_create_by!(step: step)
       end
 
-      TemporalWorkflowRegistry.start_workflow_execution(run)
+      dispatch!(run)
       record_activity(run, :workflow_started)
       broadcast_task_updated(run)
 
       run
-    rescue StandardError => e
-      Rails.logger.error("[WorkflowService] Failed to start workflow for run ##{run&.id}: #{e.message}")
-      run
+    end
+
+    # Turns a saved run into a Temporal execution, and is the only thing allowed
+    # to call that done.
+    #
+    # Loud on purpose. This used to be a bare call whose return value was
+    # discarded, under a `rescue StandardError` that logged one line and handed
+    # back a run that read as started. TemporalService.start_workflow does not
+    # raise on a failed RPC — it returns { ok: false, ... } — so a Temporal outage
+    # never even reached that rescue: it produced a committed run nobody would
+    # ever execute, and a success response. Now the caller gets an exception (and
+    # Sentry an event), while the run stays enrolled in the outbox so
+    # WorkflowRunRelay re-drives it within WorkflowRun::RELAY_GRACE.
+    #
+    # Safe to call again, which is what makes the relay safe: the execution id is
+    # per-run and duplicates are rejected, with a rejected duplicate reported as
+    # success — the execution this run needs already exists.
+    def dispatch!(run)
+      run.increment!(:relay_attempts)
+      result = TemporalWorkflowRegistry.start_workflow_execution(run)
+
+      if result.is_a?(Hash) && result[:ok]
+        # update_columns, not update!: relay bookkeeping is not a change anyone
+        # should be notified about, and update! would fire the run's broadcast on
+        # every single start.
+        run.update_columns(relay_state: "dispatched", relay_error: nil, updated_at: Time.current)
+        return result
+      end
+
+      error = result.is_a?(Hash) ? result[:error] : "start_workflow_execution returned #{result.inspect}"
+      run.update_columns(relay_error: error.to_s.first(255), updated_at: Time.current)
+
+      # A deployment that has switched Temporal off has no executor to dispatch to
+      # and no relay to recover with — the relay is itself a Temporal schedule.
+      # Nothing is stranded, because nothing was ever going to run. Development and
+      # test work this way; production does not, which is why the check is on the
+      # deployment's own switch and not on the shape of the error.
+      unless TemporalService.enabled?
+        Rails.logger.info("[WorkflowService] Temporal is disabled; run ##{run.id} was not dispatched")
+        return result
+      end
+
+      raise DispatchFailed, "WorkflowRun ##{run.id} was not dispatched to Temporal: #{error}"
     end
 
     def cancel(run:)

--- a/app/temporal/activities/outbox/relay_drain_activity.rb
+++ b/app/temporal/activities/outbox/relay_drain_activity.rb
@@ -2,13 +2,22 @@
 
 module Activities
   module Outbox
-    # Drains the transactional outbox: dispatches any trigger events left
-    # "pending" past the grace window (producers that committed their domain write
-    # but died before dispatching). Idempotent — TriggerDispatch dedup makes a
-    # re-dispatch a no-op, so at-least-once delivery never double-launches.
+    # Drains both halves of the transactional outbox, in the order the work flows:
+    #
+    #   1. Trigger events left "pending" past the grace window — producers that
+    #      committed their domain write but died before dispatching. Idempotent:
+    #      TriggerDispatch dedup makes a re-dispatch a no-op.
+    #   2. Runs that were created but whose Temporal execution was never confirmed
+    #      started. Idempotent: the execution id is per-run and duplicates are
+    #      rejected, with a rejected duplicate reported as success.
+    #
+    # Events first, because draining them is what creates runs — a run stranded by
+    # the same outage is then swept in the same tick rather than the next one.
     class RelayDrainActivity < ::Activities::Base
       def run(_input = nil)
-        OutboxRelay.drain
+        events = OutboxRelay.drain
+        runs = WorkflowRunRelay.drain
+        { events: events, runs: runs }
       end
     end
   end

--- a/app/temporal/schedules.yml
+++ b/app/temporal/schedules.yml
@@ -50,9 +50,12 @@ schedules:
     overlap: skip
     enabled: true
 
-  # Transactional-outbox safety net: re-dispatches trigger events a producer
-  # committed but crashed before dispatching. Every minute is the finest cron
-  # granularity; the happy path dispatches inline, so this only recovers crashes.
+  # Transactional-outbox safety net, both halves: re-dispatches trigger events a
+  # producer committed but crashed before dispatching, then re-drives runs whose
+  # Temporal execution was never confirmed started (a Temporal outage during
+  # WorkflowService.start used to strand those in `pending` forever). Every minute
+  # is the finest cron granularity; the happy path dispatches inline, so this only
+  # recovers crashes and outages.
   # SKIP overlap: the relay is idempotent and must never run two drains at once.
   - workflow: outbox_relay_workflow
     cron: "* * * * *"

--- a/app/temporal/workflows/outbox_relay_workflow.rb
+++ b/app/temporal/workflows/outbox_relay_workflow.rb
@@ -2,8 +2,9 @@
 
 module Workflows
   # Safety-net relay for the transactional outbox. Runs on a Temporal cron
-  # schedule (see app/temporal/schedules.yml) with SKIP-overlap, and drains any
-  # trigger events left "pending" by a producer that crashed before dispatching.
+  # schedule (see app/temporal/schedules.yml) with SKIP-overlap, and drains both
+  # halves: trigger events left "pending" by a producer that crashed before
+  # dispatching, and runs whose Temporal execution was never confirmed started.
   # The happy path dispatches inline; this only catches the stragglers.
   class OutboxRelayWorkflow < Base
     def run(_input = nil)

--- a/db/migrate/20260913120000_add_relay_state_to_workflow_runs.rb
+++ b/db/migrate/20260913120000_add_relay_state_to_workflow_runs.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Brings run dispatch into the transactional outbox that trigger events already
+# use. `state` is the run's own lifecycle; these columns record whether the
+# Temporal execution that drives it was ever confirmed started.
+#
+# Default "dispatched", not "pending", for the same reason trigger_events does
+# it: every existing row, and any future creation path that does not opt in, must
+# not be swept by the relay. WorkflowService.start writes "pending" explicitly.
+class AddRelayStateToWorkflowRuns < ActiveRecord::Migration[8.1]
+  def change
+    add_column :workflow_runs, :relay_state, :string, default: "dispatched", null: false
+    add_column :workflow_runs, :relay_attempts, :integer, default: 0, null: false
+    add_column :workflow_runs, :relay_error, :string
+
+    add_index :workflow_runs, [ :relay_state, :created_at ],
+      name: "index_workflow_runs_pending_relay",
+      where: "(relay_state)::text = 'pending'::text"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_11_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_13_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -1166,6 +1166,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_11_140000) do
     t.jsonb "input_asset_ids", default: []
     t.string "mode", default: "interactive", null: false
     t.bigint "project_id", null: false
+    t.integer "relay_attempts", default: 0, null: false
+    t.string "relay_error"
+    t.string "relay_state", default: "dispatched", null: false
     t.jsonb "repository_ids", default: [], null: false
     t.jsonb "shared_context", default: {}
     t.datetime "started_at"
@@ -1179,6 +1182,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_11_140000) do
     t.index ["board_task_id"], name: "index_workflow_runs_on_board_task_id"
     t.index ["failed_agent_credential_id"], name: "index_workflow_runs_on_failed_agent_credential_id"
     t.index ["project_id"], name: "index_workflow_runs_on_project_id"
+    t.index ["relay_state", "created_at"], name: "index_workflow_runs_pending_relay", where: "((relay_state)::text = 'pending'::text)"
     t.index ["state"], name: "index_workflow_runs_on_state"
     t.index ["user_id", "created_at"], name: "index_workflow_runs_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_workflow_runs_on_user_id"

--- a/test/helpers/temporal_helper_contract_test.rb
+++ b/test/helpers/temporal_helper_contract_test.rb
@@ -50,8 +50,9 @@ class TemporalHelperContractTest < ActiveSupport::TestCase
 
   # :handle is the one real success key the canned seams intentionally omit — no
   # success-path caller consumes it (SessionService reads :ok/:workflow_id/:run_id;
-  # WorkflowService and Tool ignore the returned hash). Pin the omission so nobody
-  # "fixes" the helper by inventing a fake handle the callers never use.
+  # WorkflowService#dispatch! reads :ok and, on failure, :error; Tool ignores the
+  # hash). Pin the omission so nobody "fixes" the helper by inventing a fake handle
+  # the callers never use.
   test "canned seams omit :handle, the only real success key no caller consumes" do
     mock_temporal_start
     start_canned = TemporalService.start_workflow(:workflow, :input)

--- a/test/services/workflow_run_relay_test.rb
+++ b/test/services/workflow_run_relay_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class WorkflowRunRelayTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user, :with_company)
+    @company = @user.companies.first
+    @project = create(:project, owner: @user, company: @company)
+    @workflow = create(:workflow, scope: @project)
+    # The relay only ever runs inside the Temporal worker, so a failed dispatch is
+    # a real failure there — never the "Temporal is switched off" case.
+    TemporalService.stubs(:enabled?).returns(true)
+  end
+
+  # A run as WorkflowService.start leaves it when the Temporal RPC never landed:
+  # committed, enrolled in the outbox, and executed by nobody.
+  def undispatched_run(created_at: 5.minutes.ago, attempts: 1, **attrs)
+    create(:workflow_run,
+      workflow: @workflow, project: @project, user: @user,
+      state: "pending", relay_state: "pending", relay_attempts: attempts,
+      created_at: created_at, **attrs)
+  end
+
+  test "drain re-dispatches a run stranded past the grace window" do
+    run = undispatched_run
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: true)
+
+    result = WorkflowRunRelay.drain
+
+    assert_equal 1, result[:swept]
+    assert_equal 1, result[:dispatched]
+    assert_equal 0, result[:failed]
+    assert_equal "dispatched", run.reload.relay_state
+    assert_equal 2, run.relay_attempts
+  end
+
+  test "drain leaves a fresh run alone until the grace window passes" do
+    run = undispatched_run(created_at: Time.current)
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).never
+
+    result = WorkflowRunRelay.drain
+
+    assert_equal 0, result[:swept]
+    assert_equal "pending", run.reload.relay_state
+  end
+
+  test "drain ignores runs whose dispatch was already confirmed" do
+    undispatched_run(relay_state: "dispatched")
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).never
+
+    assert_equal 0, WorkflowRunRelay.drain[:swept]
+  end
+
+  # The worker moved the run on, so the execution plainly exists — whatever our
+  # inline call did or did not hear back.
+  test "drain ignores a run the worker has already started" do
+    undispatched_run(state: "running")
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).never
+
+    assert_equal 0, WorkflowRunRelay.drain[:swept]
+  end
+
+  test "drain never starts an execution for a run that was cancelled while undispatched" do
+    run = undispatched_run(stop_requested_at: Time.current)
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).never
+
+    assert_equal 0, WorkflowRunRelay.drain[:swept]
+    assert_equal "pending", run.reload.relay_state
+  end
+
+  test "drain counts a still-failing dispatch and leaves the run for the next sweep" do
+    run = undispatched_run
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: false, error: "unavailable")
+
+    result = WorkflowRunRelay.drain
+
+    assert_equal 1, result[:swept]
+    assert_equal 0, result[:dispatched]
+    assert_equal 1, result[:failed]
+    assert_equal "pending", run.reload.relay_state
+    assert_equal 2, run.relay_attempts
+    assert_match(/unavailable/, run.relay_error)
+  end
+
+  # One run that can never start must not consume every sweep forever.
+  test "drain abandons a run past the attempt ceiling" do
+    undispatched_run(attempts: WorkflowRun::RELAY_MAX_ATTEMPTS)
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).never
+
+    assert_equal 0, WorkflowRunRelay.drain[:swept]
+  end
+
+  test "drain does a bounded amount of work per sweep" do
+    3.times { undispatched_run }
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).twice.returns(ok: true)
+
+    assert_equal 2, WorkflowRunRelay.drain(limit: 2)[:swept]
+  end
+
+  test "a failing run keeps its place in line rather than blocking the ones behind it" do
+    poison = undispatched_run(created_at: 10.minutes.ago)
+    healthy = undispatched_run(created_at: 5.minutes.ago)
+    TemporalWorkflowRegistry.stubs(:start_workflow_execution).returns(ok: false, error: "unavailable").then.returns(ok: true)
+
+    result = WorkflowRunRelay.drain
+
+    assert_equal 2, result[:swept]
+    assert_equal 1, result[:dispatched]
+    assert_equal "pending", poison.reload.relay_state
+    assert_equal "dispatched", healthy.reload.relay_state
+  end
+end

--- a/test/services/workflow_service_test.rb
+++ b/test/services/workflow_service_test.rb
@@ -15,7 +15,7 @@ class WorkflowServiceTest < ActiveSupport::TestCase
   # == start ==
 
   test "start creates workflow run with step runs and starts temporal" do
-    TemporalWorkflowRegistry.expects(:start_workflow_execution).once
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: true)
 
     run = WorkflowService.start(
       workflow: @workflow,
@@ -31,7 +31,7 @@ class WorkflowServiceTest < ActiveSupport::TestCase
   end
 
   test "start persists agent_runtime when provided" do
-    TemporalWorkflowRegistry.expects(:start_workflow_execution).once
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: true)
 
     run = WorkflowService.start(
       workflow: @workflow,
@@ -45,7 +45,7 @@ class WorkflowServiceTest < ActiveSupport::TestCase
   end
 
   test "start with task associates board_task" do
-    TemporalWorkflowRegistry.expects(:start_workflow_execution).once
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: true)
 
     board = create(:board, project: @project)
     column = create(:board_column, board: board)
@@ -79,7 +79,7 @@ class WorkflowServiceTest < ActiveSupport::TestCase
   # == cancel ==
 
   test "cancel sends signal and cancels active step runs" do
-    TemporalWorkflowRegistry.stubs(:start_workflow_execution)
+    TemporalWorkflowRegistry.stubs(:start_workflow_execution).returns(ok: true)
     run = WorkflowService.start(workflow: @workflow, project: @project, user: @user)
     run.start! if run.may_start?
 
@@ -94,7 +94,7 @@ class WorkflowServiceTest < ActiveSupport::TestCase
   # The cancellation itself is not the news — the reason is. A session killed by a
   # spend limit or a lost node has one, and the step is where a user sees it.
   test "cancel carries the session's diagnosed reason onto the step run" do
-    TemporalWorkflowRegistry.stubs(:start_workflow_execution)
+    TemporalWorkflowRegistry.stubs(:start_workflow_execution).returns(ok: true)
     TemporalService.stubs(:send_signal)
     run = WorkflowService.start(workflow: @workflow, project: @project, user: @user)
     run.start! if run.may_start?
@@ -110,7 +110,7 @@ class WorkflowServiceTest < ActiveSupport::TestCase
   end
 
   test "cancel leaves the step run unexplained when the generic reason is all there is" do
-    TemporalWorkflowRegistry.stubs(:start_workflow_execution)
+    TemporalWorkflowRegistry.stubs(:start_workflow_execution).returns(ok: true)
     TemporalService.stubs(:send_signal)
     run = WorkflowService.start(workflow: @workflow, project: @project, user: @user)
     run.start! if run.may_start?
@@ -125,7 +125,7 @@ class WorkflowServiceTest < ActiveSupport::TestCase
   end
 
   test "cancel records a workflow_cancelled activity on the task's board" do
-    TemporalWorkflowRegistry.stubs(:start_workflow_execution)
+    TemporalWorkflowRegistry.stubs(:start_workflow_execution).returns(ok: true)
     TemporalService.stubs(:send_signal)
     board = create(:board, project: @project)
     column = create(:board_column, board: board)
@@ -139,6 +139,80 @@ class WorkflowServiceTest < ActiveSupport::TestCase
     activity = BoardActivity.by_event_type(:workflow_cancelled).sole
     assert_equal task.id, activity.board_task_id
     assert_equal run.id, activity.metadata["workflow_run_id"]
+  end
+
+  # == dispatch (transactional outbox) ==
+
+  test "start marks the run dispatched once Temporal confirms the execution" do
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: true)
+
+    run = WorkflowService.start(workflow: @workflow, project: @project, user: @user)
+
+    assert_equal "dispatched", run.reload.relay_state
+    assert_equal 1, run.relay_attempts
+    assert_nil run.relay_error
+  end
+
+  # The failure this whole mechanism exists for: TemporalService.start_workflow
+  # answers a failed RPC with { ok: false }, not an exception, so the old code
+  # discarded it and reported a run that would never execute as started.
+  test "start raises and leaves the run enrolled in the outbox when Temporal refuses the start" do
+    TemporalService.stubs(:enabled?).returns(true)
+    TemporalWorkflowRegistry.expects(:start_workflow_execution)
+      .once.returns(ok: false, error: "storage is (re)initializing")
+
+    error = assert_raises(WorkflowService::DispatchFailed) do
+      WorkflowService.start(workflow: @workflow, project: @project, user: @user)
+    end
+
+    assert_match(/storage is \(re\)initializing/, error.message)
+
+    run = WorkflowRun.sole
+    assert_equal "pending", run.relay_state
+    assert_equal "pending", run.state
+    assert_equal 1, run.relay_attempts
+    assert_match(/storage is/, run.relay_error)
+  end
+
+  # A run that was never handed to Temporal is worth nothing without its steps
+  # being re-drivable too, so the row has to survive the raise.
+  test "a run stranded by a failed dispatch keeps its step runs and becomes relay work" do
+    TemporalService.stubs(:enabled?).returns(true)
+    TemporalWorkflowRegistry.stubs(:start_workflow_execution).returns(ok: false, error: "unavailable")
+
+    assert_raises(WorkflowService::DispatchFailed) do
+      WorkflowService.start(workflow: @workflow, project: @project, user: @user)
+    end
+
+    run = WorkflowRun.sole
+    assert_equal 2, run.step_runs.count
+    assert_empty WorkflowRun.stuck_for_relay
+    travel_to(WorkflowRun::RELAY_GRACE.from_now + 1.second) do
+      assert_equal [ run.id ], WorkflowRun.stuck_for_relay.pluck(:id)
+    end
+  end
+
+  # Development and test run with Temporal switched off. Nothing is stranded there
+  # — there is no executor to strand it from, and no relay either, since the relay
+  # is itself a Temporal schedule.
+  test "dispatch! does not raise when the deployment has Temporal switched off" do
+    TemporalService.stubs(:enabled?).returns(false)
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: false, error: "Temporal is disabled")
+
+    run = create(:workflow_run, workflow: @workflow, project: @project, user: @user, relay_state: "pending")
+
+    assert_nothing_raised { WorkflowService.dispatch!(run) }
+    assert_equal "pending", run.reload.relay_state
+  end
+
+  test "dispatch! is safe to repeat and settles a run Temporal already had" do
+    run = create(:workflow_run, workflow: @workflow, project: @project, user: @user, relay_state: "pending")
+    # A rejected duplicate is reported as success: the execution this run needs exists.
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: true, workflow_id: "workflow-execution-#{run.id}")
+
+    WorkflowService.dispatch!(run)
+
+    assert_equal "dispatched", run.reload.relay_state
   end
 
   # == approve_step ==


### PR DESCRIPTION
Follow-up to #253 / #255, from the same incident: the queue is sold as always available, so a
stall has to be loud and the work has to survive it.

## The hole

`WorkflowService.start` committed the run, then dispatched it to Temporal with an inline RPC
whose result nobody read:

```ruby
TemporalWorkflowRegistry.start_workflow_execution(run)   # return value discarded
record_activity(run, :workflow_started)
...
rescue StandardError => e
  Rails.logger.error("[WorkflowService] Failed to start workflow for run ##{run&.id}: #{e.message}")
  run
end
```

`TemporalService.start_workflow` does not raise on a failed RPC — it answers `{ ok: false, ... }`.
So a Temporal outage never even reached that `rescue`: it produced a committed run, a
`workflow_started` activity, and a success response. The `rescue` caught the other half
(ActiveRecord, NoMethodError) and also returned the run as if started.

Nothing re-drove it:

| mechanism | covers |
|---|---|
| `CleanupStaleRunsActivity` | only `running` / `paused` past 4h — `pending` is out of scope |
| `SessionAdmissionReconciler` | does not look at runs |
| `OutboxRelay` | trigger **events** — the hop before this one |

A run created while Temporal was unreachable stayed `pending` forever, and looked exactly like one
the worker had simply not picked up yet.

## The change

**Loud.** `dispatch!` reads the result and raises `WorkflowService::DispatchFailed`. The caller
gets an exception and Sentry an event.

A deployment that has switched Temporal off is not a failure and does not raise — it has no
executor to strand a run from, and no relay either, since the relay is itself a Temporal schedule.
The check is on `TemporalService.enabled?`, the deployment's own switch, not on the shape of the
error string. Development and test keep working exactly as before.

**Durable.** The run is enrolled in the outbox in the same write that creates it
(`relay_state: "pending"`), and `WorkflowRunRelay` re-drives anything still undispatched past
`WorkflowRun::RELAY_GRACE`, in the same minutely `outbox_relay_workflow` tick as the event relay —
events first, since draining them is what creates runs.

The two halves need each other. Loud without durable turns an outage into lost work; durable
without loud is the silence this incident was made of.

**Idempotent.** `start_workflow_execution` now passes `reject_duplicate: true`. The execution id is
per-run, so a duplicate start can only mean this run's execution already exists — reported as
success, which is how a re-drive of a run Temporal *did* receive settles. It also forbids reusing
the id after the execution closed, so a finished run can never be silently re-run.

The relay ignores runs the worker has already advanced (nothing to do) and runs cancelled while
undispatched (must never be started), and gives up after `RELAY_MAX_ATTEMPTS` so one poison run
cannot own every sweep.

## Consequence worth naming

A user whose run fails to dispatch now sees an error instead of a run page — and the run still
starts within the grace window. That is the intended trade: the alternative is what we had, where
nobody saw anything at all.

## Schema

`db/schema.rb` was edited by hand (columns + partial index, alphabetical, version bumped) rather
than dumped from a local database, per the local-dump hazards. `SchemaParityTest` replays the
migrations into a throwaway database and diffs, so CI is the arbiter of whether the hand edit
matches what Rails renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
