### PR TITLE
feat(ops): watch the queue from outside the worker

### DIFF
--- a/app/jobs/queue_health_check_job.rb
+++ b/app/jobs/queue_health_check_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# The one recurring job that is NOT a Temporal schedule, on purpose — see
+# QueueHealthCheck for why, and config/recurring.yml for the cadence.
+#
+# It runs in the Solid Queue supervisor (the `jobs` deployment), which is the
+# whole point: it has to survive the failure it exists to report.
+class QueueHealthCheckJob < ApplicationJob
+  queue_as :default
+
+  # Never retry. The next tick is a minute away and carries a fresher answer; a
+  # retried watchdog would report state that has already moved on.
+  discard_on StandardError do |_job, error|
+    Rails.logger.error("[QueueHealth] check failed: #{error.class}: #{error.message}")
+    Sentry.capture_exception(error) if Sentry.initialized?
+  end
+
+  def perform
+    QueueHealthCheck.call
+  end
+end

--- a/app/models/workflow_run.rb
+++ b/app/models/workflow_run.rb
@@ -40,6 +40,37 @@ class WorkflowRun < ApplicationRecord
   broadcasts_to ->(run) { run }, on: :update
   after_commit :broadcast_run_list_update, on: :update
 
+  # Transactional outbox for run dispatch, mirroring TriggerEvent's. `state` is
+  # the run's own lifecycle; `relay_state` answers a different question — was the
+  # Temporal execution that drives this run ever confirmed started?
+  #
+  # WHY IT IS NOT THE SAME QUESTION: WorkflowService.start dials Temporal inline,
+  # and TemporalService.start_workflow does not raise on a failed RPC — it returns
+  # { ok: false, ... }. A run whose start never reached Temporal therefore looked
+  # exactly like one the worker had not picked up yet: `state` "pending", nothing
+  # logged above a Rails.logger.error, and no retry anywhere. It would sit there
+  # forever.
+  RELAY_GRACE = 2.minutes
+
+  # Stop re-dispatching a run whose start keeps failing, so one poison run cannot
+  # churn forever. Same ceiling as TriggerEvent: ~33h at the grace cadence, which
+  # rides out a long outage without burying it.
+  RELAY_MAX_ATTEMPTS = 1000
+
+  # What the relay re-drives. Deliberately narrower than "relay_state pending":
+  #
+  # * `state: "pending"` — a run the worker has already advanced is running
+  #   whether or not our inline call got its confirmation, and re-driving it would
+  #   be pointless. It stops being swept and keeps its honest relay_state.
+  # * `stop_requested_at: nil` — never start an execution for a run somebody
+  #   cancelled while it sat undispatched.
+  scope :stuck_for_relay, ->(now = Time.current) {
+    where(relay_state: "pending", state: "pending", stop_requested_at: nil)
+      .where(relay_attempts: ...RELAY_MAX_ATTEMPTS)
+      .where(created_at: ..(now - RELAY_GRACE))
+      .order(:id)
+  }
+
   scope :active, -> { where(state: %w[pending running paused]) }
   scope :for_project_in_period, ->(project, since) { where(project: project, created_at: since..) }
   scope :for_user_in_project, ->(project, user, since) { where(project: project, user: user, created_at: since..) }

--- a/app/services/queue_health_check.rb
+++ b/app/services/queue_health_check.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+# Watches whether work is actually moving, from a process that is not the one
+# doing the moving.
+#
+# WHY IT DOES NOT LIVE IN TEMPORAL: every other recurring job in this app is a
+# Temporal schedule executed by the worker (config/queue.yml says so, and that
+# convention is right for work). This one is not work, it is the watch — and on
+# 2026-09-12 the worker itself was what failed. Its Sentry interceptor, the
+# admission reconciler, the quota and no-output scanners, the outbox relay: every
+# safety net in the installation was a Temporal schedule, so they all stopped
+# together, silently, and nothing noticed for nearly two hours. A watchdog hosted
+# by the thing it watches is not a watchdog. This one runs in the Solid Queue
+# supervisor (the `jobs` deployment), which stayed up throughout.
+#
+# WHAT IT WATCHES: symptoms, not liveness. "Is a worker polling?" is a question
+# with a fragile answer; "has any run been sitting unstarted for five minutes?" is
+# a question the database can answer alone, it is the thing the queue is sold on,
+# and it is true whatever the cause — a crashed worker, an unreachable Temporal, a
+# wedged task queue, or something nobody has thought of yet.
+class QueueHealthCheck
+  # A run the worker has not started. Normally this is seconds: the run row and
+  # the Temporal execution are created in the same call, and the first activity
+  # follows immediately. Queueing for capacity happens one level down, at the
+  # session — an admitted run whose step is waiting for a slot is `running`, not
+  # `pending` — so nothing legitimate parks a run here.
+  UNSTARTED_RUN_THRESHOLD = 5.minutes
+
+  # A session that has waited this long for a slot is not necessarily wrong — a
+  # full pool is the feature working — but it is worth seeing, because "the pool
+  # is full" and "the pool is full of reservations nothing will ever release" look
+  # identical from outside.
+  ADMISSION_WAIT_THRESHOLD = 30.minutes
+
+  class << self
+    def call(now: Time.current)
+      stats = snapshot(now: now)
+      report(stats)
+      stats
+    end
+
+    def snapshot(now: Time.current)
+      unstarted = WorkflowRun.where(state: "pending", stop_requested_at: nil)
+                             .where(created_at: ..(now - UNSTARTED_RUN_THRESHOLD))
+      undispatched = WorkflowRun.stuck_for_relay(now)
+      waiting = SessionAdmission.unreleased.where(admitted_at: nil, stop_requested_at: nil)
+
+      {
+        unstarted_runs: unstarted.count,
+        oldest_unstarted_seconds: age(unstarted.minimum(:created_at), now),
+        undispatched_runs: undispatched.count,
+        oldest_undispatched_seconds: age(undispatched.minimum(:created_at), now),
+        queued_admissions: waiting.count,
+        oldest_admission_wait_seconds: age(waiting.minimum(:created_at), now),
+        pinned_reservations: SessionRuntimeOperation.pinning.count
+      }
+    end
+
+    # What each number means when it is not zero, in the order an operator should
+    # read them. `undispatched_runs` is listed before `unstarted_runs` because it
+    # is the more specific diagnosis of the same symptom: the run never reached
+    # Temporal at all, rather than reaching it and finding nobody home.
+    def problems(stats)
+      problems = []
+      if stats[:undispatched_runs].positive?
+        problems << "#{stats[:undispatched_runs]} run(s) never reached Temporal " \
+                    "(oldest #{stats[:oldest_undispatched_seconds]}s)"
+      end
+      if stats[:unstarted_runs].positive?
+        problems << "#{stats[:unstarted_runs]} run(s) unstarted for over " \
+                    "#{UNSTARTED_RUN_THRESHOLD.inspect} (oldest #{stats[:oldest_unstarted_seconds]}s) — " \
+                    "nothing is executing the queue"
+      end
+      if stats[:oldest_admission_wait_seconds] > ADMISSION_WAIT_THRESHOLD.to_i
+        problems << "a session has waited #{stats[:oldest_admission_wait_seconds]}s for a slot"
+      end
+      if stats[:pinned_reservations].positive?
+        problems << "#{stats[:pinned_reservations]} reservation(s) pinned by an unprovable runtime " \
+                    "operation, holding capacity until an operator releases them"
+      end
+      problems
+    end
+
+    private
+
+    def age(timestamp, now) = timestamp ? (now - timestamp).to_i : 0
+
+    # One structured line every tick so the log pipeline has a series to draw, and
+    # a Sentry event only when something is actually wrong — a watchdog that cries
+    # every minute is one nobody reads.
+    def report(stats)
+      Rails.logger.info("[QueueHealth] #{stats.to_json}")
+      found = problems(stats)
+      return stats if found.empty?
+
+      message = "Queue is not draining: #{found.join('; ')}"
+      Rails.logger.error("[QueueHealth] #{message}")
+      Sentry.capture_message(message, level: :error, extra: stats) if Sentry.initialized?
+      stats
+    end
+  end
+end

--- a/app/services/temporal_workflow_registry.rb
+++ b/app/services/temporal_workflow_registry.rb
@@ -124,6 +124,13 @@ class TemporalWorkflowRegistry
         wf,
         { workflow_run_id: workflow_run.id },
         id: "workflow-execution-#{workflow_run.id}",
+        # What makes re-dispatch safe, and therefore the outbox relay possible
+        # (WorkflowRunRelay). The id is per-run, so a duplicate start can only
+        # mean this run's execution already exists — which is success, not a
+        # failure, and is how a re-drive of a run Temporal did receive settles.
+        # It also forbids reusing the id after the execution closed, so a
+        # finished run can never be silently re-run.
+        reject_duplicate: true,
         # Queue time is not execution budget (AD-7), so an admitted run gets far
         # more than a day — but it still gets a ceiling. "No timeout at all"
         # means a wedged run is invisible to every deadline we have.

--- a/app/services/workflow_run_relay.rb
+++ b/app/services/workflow_run_relay.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# The relay side of the transactional outbox for run DISPATCH. Sibling of
+# OutboxRelay, which relays trigger events; this one relays the step after it.
+#
+# WHY BOTH EXIST: OutboxRelay guarantees that an event a producer committed
+# eventually reaches WorkflowService.start. Nothing guaranteed the next hop.
+# WorkflowService.start dials Temporal inline, and TemporalService.start_workflow
+# does not raise on a failed RPC — it returns { ok: false, ... }. So a run created
+# while Temporal was unreachable was committed, never executed, and looked exactly
+# like one the worker had not picked up yet. There was no retry: the stale-run
+# reaper only touches `running`/`paused` runs past four hours, and the admission
+# reconciler does not look at runs at all. It sat in `pending` forever.
+#
+# Delivery is at-least-once and re-dispatch is idempotent: the Temporal execution
+# id is per-run and duplicates are rejected, with a rejected duplicate reported as
+# success (see TemporalWorkflowRegistry#start_workflow_execution).
+class WorkflowRunRelay
+  # Cap per sweep so one cron tick does a bounded amount of work; each run costs a
+  # Temporal RPC. A backlog drains over successive minutely ticks.
+  DEFAULT_LIMIT = 50
+
+  class << self
+    # Re-dispatch runs left undispatched past the grace window. Rows are claimed
+    # under FOR UPDATE SKIP LOCKED in a short transaction so concurrent drainers
+    # never grab the same run, and the lock is released before dispatching — the
+    # Temporal call must not run while holding row locks.
+    #
+    # Returns { swept:, dispatched:, failed: } counts.
+    def drain(limit: DEFAULT_LIMIT, now: Time.current)
+      run_ids = claim_ids(limit: limit, now: now)
+      dispatched = 0
+      failed = 0
+
+      run_ids.each do |id|
+        run = WorkflowRun.find_by(id: id)
+        next if run.nil?
+
+        begin
+          WorkflowService.dispatch!(run)
+          dispatched += 1
+          Rails.logger.info("[WorkflowRunRelay] run ##{id} dispatched on attempt #{run.relay_attempts}")
+        rescue WorkflowService::DispatchFailed => e
+          # Expected while the outage that stranded the run is still going. The
+          # attempt counter is what eventually stops a poison run (RELAY_MAX_ATTEMPTS),
+          # so a failure here is recorded and the sweep moves on.
+          failed += 1
+          Rails.logger.warn("[WorkflowRunRelay] run ##{id} still undispatched: #{e.message}")
+        end
+      end
+
+      if run_ids.any?
+        Rails.logger.warn("[WorkflowRunRelay] swept=#{run_ids.size} dispatched=#{dispatched} failed=#{failed}")
+      end
+
+      { swept: run_ids.size, dispatched: dispatched, failed: failed }
+    end
+
+    private
+
+    def claim_ids(limit:, now:)
+      WorkflowRun.transaction do
+        WorkflowRun
+          .stuck_for_relay(now)
+          .limit(limit)
+          .lock("FOR UPDATE SKIP LOCKED")
+          .pluck(:id)
+      end
+    end
+  end
+end

--- a/app/services/workflow_service.rb
+++ b/app/services/workflow_service.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class WorkflowService
+  # A run was saved but its Temporal execution could not be started. Raised, not
+  # returned: an undispatched run is an outage, not a validation error, and the
+  # thing that used to happen instead — log a line and hand the caller a run that
+  # looked started — is what let a queue stall go unnoticed for two hours.
+  DispatchFailed = Class.new(StandardError)
+
   class << self
     def update(workflow:, params:)
       attrs = params.to_h
@@ -34,20 +40,64 @@ class WorkflowService
       # SessionAdmissionPolicy.sync! refuses to flip the mode while any run is
       # pending, running or paused.
       run.shared_context = run.shared_context.merge("session_admission" => SessionAdmissionPolicy.enabled?)
+      # Enrol the run in the outbox in the very write that creates it. From here
+      # on a dispatch that never lands is a row the relay can find, instead of a
+      # run indistinguishable from one the worker simply has not reached yet.
+      run.relay_state = "pending"
       return run unless run.save
 
       workflow.steps.not_deleted.order(:position).each do |step|
         run.step_runs.find_or_create_by!(step: step)
       end
 
-      TemporalWorkflowRegistry.start_workflow_execution(run)
+      dispatch!(run)
       record_activity(run, :workflow_started)
       broadcast_task_updated(run)
 
       run
-    rescue StandardError => e
-      Rails.logger.error("[WorkflowService] Failed to start workflow for run ##{run&.id}: #{e.message}")
-      run
+    end
+
+    # Turns a saved run into a Temporal execution, and is the only thing allowed
+    # to call that done.
+    #
+    # Loud on purpose. This used to be a bare call whose return value was
+    # discarded, under a `rescue StandardError` that logged one line and handed
+    # back a run that read as started. TemporalService.start_workflow does not
+    # raise on a failed RPC — it returns { ok: false, ... } — so a Temporal outage
+    # never even reached that rescue: it produced a committed run nobody would
+    # ever execute, and a success response. Now the caller gets an exception (and
+    # Sentry an event), while the run stays enrolled in the outbox so
+    # WorkflowRunRelay re-drives it within WorkflowRun::RELAY_GRACE.
+    #
+    # Safe to call again, which is what makes the relay safe: the execution id is
+    # per-run and duplicates are rejected, with a rejected duplicate reported as
+    # success — the execution this run needs already exists.
+    def dispatch!(run)
+      run.increment!(:relay_attempts)
+      result = TemporalWorkflowRegistry.start_workflow_execution(run)
+
+      if result.is_a?(Hash) && result[:ok]
+        # update_columns, not update!: relay bookkeeping is not a change anyone
+        # should be notified about, and update! would fire the run's broadcast on
+        # every single start.
+        run.update_columns(relay_state: "dispatched", relay_error: nil, updated_at: Time.current)
+        return result
+      end
+
+      error = result.is_a?(Hash) ? result[:error] : "start_workflow_execution returned #{result.inspect}"
+      run.update_columns(relay_error: error.to_s.first(255), updated_at: Time.current)
+
+      # A deployment that has switched Temporal off has no executor to dispatch to
+      # and no relay to recover with — the relay is itself a Temporal schedule.
+      # Nothing is stranded, because nothing was ever going to run. Development and
+      # test work this way; production does not, which is why the check is on the
+      # deployment's own switch and not on the shape of the error.
+      unless TemporalService.enabled?
+        Rails.logger.info("[WorkflowService] Temporal is disabled; run ##{run.id} was not dispatched")
+        return result
+      end
+
+      raise DispatchFailed, "WorkflowRun ##{run.id} was not dispatched to Temporal: #{error}"
     end
 
     def cancel(run:)

--- a/app/temporal/activities/outbox/relay_drain_activity.rb
+++ b/app/temporal/activities/outbox/relay_drain_activity.rb
@@ -2,13 +2,22 @@
 
 module Activities
   module Outbox
-    # Drains the transactional outbox: dispatches any trigger events left
-    # "pending" past the grace window (producers that committed their domain write
-    # but died before dispatching). Idempotent — TriggerDispatch dedup makes a
-    # re-dispatch a no-op, so at-least-once delivery never double-launches.
+    # Drains both halves of the transactional outbox, in the order the work flows:
+    #
+    #   1. Trigger events left "pending" past the grace window — producers that
+    #      committed their domain write but died before dispatching. Idempotent:
+    #      TriggerDispatch dedup makes a re-dispatch a no-op.
+    #   2. Runs that were created but whose Temporal execution was never confirmed
+    #      started. Idempotent: the execution id is per-run and duplicates are
+    #      rejected, with a rejected duplicate reported as success.
+    #
+    # Events first, because draining them is what creates runs — a run stranded by
+    # the same outage is then swept in the same tick rather than the next one.
     class RelayDrainActivity < ::Activities::Base
       def run(_input = nil)
-        OutboxRelay.drain
+        events = OutboxRelay.drain
+        runs = WorkflowRunRelay.drain
+        { events: events, runs: runs }
       end
     end
   end

--- a/app/temporal/schedules.yml
+++ b/app/temporal/schedules.yml
@@ -50,9 +50,12 @@ schedules:
     overlap: skip
     enabled: true
 
-  # Transactional-outbox safety net: re-dispatches trigger events a producer
-  # committed but crashed before dispatching. Every minute is the finest cron
-  # granularity; the happy path dispatches inline, so this only recovers crashes.
+  # Transactional-outbox safety net, both halves: re-dispatches trigger events a
+  # producer committed but crashed before dispatching, then re-drives runs whose
+  # Temporal execution was never confirmed started (a Temporal outage during
+  # WorkflowService.start used to strand those in `pending` forever). Every minute
+  # is the finest cron granularity; the happy path dispatches inline, so this only
+  # recovers crashes and outages.
   # SKIP overlap: the relay is idempotent and must never run two drains at once.
   - workflow: outbox_relay_workflow
     cron: "* * * * *"

--- a/app/temporal/workflows/outbox_relay_workflow.rb
+++ b/app/temporal/workflows/outbox_relay_workflow.rb
@@ -2,8 +2,9 @@
 
 module Workflows
   # Safety-net relay for the transactional outbox. Runs on a Temporal cron
-  # schedule (see app/temporal/schedules.yml) with SKIP-overlap, and drains any
-  # trigger events left "pending" by a producer that crashed before dispatching.
+  # schedule (see app/temporal/schedules.yml) with SKIP-overlap, and drains both
+  # halves: trigger events left "pending" by a producer that crashed before
+  # dispatching, and runs whose Temporal execution was never confirmed started.
   # The happy path dispatches inline; this only catches the stragglers.
   class OutboxRelayWorkflow < Base
     def run(_input = nil)

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,0 +1,37 @@
+# Solid Queue recurring tasks.
+#
+# config/queue.yml says everything recurring belongs to Temporal, and for WORK
+# that is right — one scheduler, one place to look. QueueHealthCheckJob is the
+# deliberate exception, and the only entry this file should ever grow lightly:
+# it is the watch, not the work, and it cannot be hosted by the process it
+# watches. On 2026-09-12 every safety net in the installation was a Temporal
+# schedule, the Temporal worker crashlooped, and so they all stopped together
+# with nothing left to notice. The Solid Queue supervisor (`jobs`) stayed up.
+#
+# Anything else recurring still goes in app/temporal/schedules.yml.
+#
+# Every minute: the check is a handful of indexed COUNT/MIN queries, and
+# detection latency is the product being sold.
+default: &default
+  queue_health_check:
+    class: QueueHealthCheckJob
+    schedule: every minute
+
+development:
+  <<: *default
+
+# Deliberately empty in test: the suite exercises QueueHealthCheck and the job
+# directly, and a supervisor-scheduled tick during a test run would be a source
+# of noise, not of coverage. An explicit empty mapping rather than a bare key —
+# config/puma.rb still loads the Solid Queue plugin unless SOLID_QUEUE_IN_PUMA is
+# false, and a nil here is a worse thing to hand it than no tasks.
+test: {}
+
+qa:
+  <<: *default
+
+staging:
+  <<: *default
+
+production:
+  <<: *default

--- a/db/migrate/20260913120000_add_relay_state_to_workflow_runs.rb
+++ b/db/migrate/20260913120000_add_relay_state_to_workflow_runs.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Brings run dispatch into the transactional outbox that trigger events already
+# use. `state` is the run's own lifecycle; these columns record whether the
+# Temporal execution that drives it was ever confirmed started.
+#
+# Default "dispatched", not "pending", for the same reason trigger_events does
+# it: every existing row, and any future creation path that does not opt in, must
+# not be swept by the relay. WorkflowService.start writes "pending" explicitly.
+class AddRelayStateToWorkflowRuns < ActiveRecord::Migration[8.1]
+  def change
+    add_column :workflow_runs, :relay_state, :string, default: "dispatched", null: false
+    add_column :workflow_runs, :relay_attempts, :integer, default: 0, null: false
+    add_column :workflow_runs, :relay_error, :string
+
+    add_index :workflow_runs, [ :relay_state, :created_at ],
+      name: "index_workflow_runs_pending_relay",
+      where: "(relay_state)::text = 'pending'::text"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_11_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_13_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -1166,6 +1166,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_11_140000) do
     t.jsonb "input_asset_ids", default: []
     t.string "mode", default: "interactive", null: false
     t.bigint "project_id", null: false
+    t.integer "relay_attempts", default: 0, null: false
+    t.string "relay_error"
+    t.string "relay_state", default: "dispatched", null: false
     t.jsonb "repository_ids", default: [], null: false
     t.jsonb "shared_context", default: {}
     t.datetime "started_at"
@@ -1179,6 +1182,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_11_140000) do
     t.index ["board_task_id"], name: "index_workflow_runs_on_board_task_id"
     t.index ["failed_agent_credential_id"], name: "index_workflow_runs_on_failed_agent_credential_id"
     t.index ["project_id"], name: "index_workflow_runs_on_project_id"
+    t.index ["relay_state", "created_at"], name: "index_workflow_runs_pending_relay", where: "((relay_state)::text = 'pending'::text)"
     t.index ["state"], name: "index_workflow_runs_on_state"
     t.index ["user_id", "created_at"], name: "index_workflow_runs_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_workflow_runs_on_user_id"

--- a/test/config/recurring_tasks_test.rb
+++ b/test/config/recurring_tasks_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# config/recurring.yml is read by the Solid Queue supervisor in deployed
+# environments and by nothing else — so a typo in a class name, or an entry that
+# quietly stops being scheduled, is invisible until the thing it schedules is
+# needed. Which, for a watchdog, is the worst possible moment to find out.
+class RecurringTasksTest < ActiveSupport::TestCase
+  CONFIG = Rails.application.config_for(:recurring, env: "production").freeze
+
+  test "every recurring task names a real job class" do
+    assert CONFIG.any?, "config/recurring.yml has no production entries"
+
+    CONFIG.each do |name, task|
+      klass = task[:class].to_s.safe_constantize
+      assert klass, "recurring task #{name} names #{task[:class].inspect}, which does not exist"
+      assert_operator klass, :<, ActiveJob::Base,
+        "recurring task #{name} names #{klass}, which is not an ActiveJob"
+      assert task[:schedule].present?, "recurring task #{name} has no schedule"
+    end
+  end
+
+  # The one entry this file exists for. Every other recurring job in the app is a
+  # Temporal schedule executed by the worker; this one must not be, because the
+  # worker is what it watches. If it ever migrates to app/temporal/schedules.yml,
+  # the installation goes back to having no watchdog that survives a dead worker.
+  test "the queue watchdog is scheduled outside Temporal in every deployed environment" do
+    %w[production staging qa].each do |env|
+      config = Rails.application.config_for(:recurring, env: env)
+      task = config[:queue_health_check]
+
+      assert task, "#{env} does not schedule queue_health_check outside Temporal"
+      assert_equal "QueueHealthCheckJob", task[:class]
+    end
+
+    assert_not File.read(Rails.root.join("app/temporal/schedules.yml")).include?("queue_health"),
+      "the queue watchdog must not be a Temporal schedule — the worker is what it watches"
+  end
+end

--- a/test/helpers/temporal_helper_contract_test.rb
+++ b/test/helpers/temporal_helper_contract_test.rb
@@ -50,8 +50,9 @@ class TemporalHelperContractTest < ActiveSupport::TestCase
 
   # :handle is the one real success key the canned seams intentionally omit — no
   # success-path caller consumes it (SessionService reads :ok/:workflow_id/:run_id;
-  # WorkflowService and Tool ignore the returned hash). Pin the omission so nobody
-  # "fixes" the helper by inventing a fake handle the callers never use.
+  # WorkflowService#dispatch! reads :ok and, on failure, :error; Tool ignores the
+  # hash). Pin the omission so nobody "fixes" the helper by inventing a fake handle
+  # the callers never use.
   test "canned seams omit :handle, the only real success key no caller consumes" do
     mock_temporal_start
     start_canned = TemporalService.start_workflow(:workflow, :input)

--- a/test/jobs/queue_health_check_job_test.rb
+++ b/test/jobs/queue_health_check_job_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QueueHealthCheckJobTest < ActiveJob::TestCase
+  test "perform runs the check" do
+    QueueHealthCheck.expects(:call).once
+
+    QueueHealthCheckJob.perform_now
+  end
+
+  # A watchdog that takes a process down with it, or retries until it reports a
+  # world that has already moved on, is worse than one that misses a tick: the
+  # next tick is a minute away and carries a fresher answer.
+  test "a failing check is discarded rather than retried" do
+    QueueHealthCheck.stubs(:call).raises(ActiveRecord::StatementInvalid, "connection lost")
+
+    assert_nothing_raised { QueueHealthCheckJob.perform_now }
+    assert_equal 0, enqueued_jobs.size
+  end
+end

--- a/test/services/queue_health_check_test.rb
+++ b/test/services/queue_health_check_test.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QueueHealthCheckTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user, :with_company)
+    @company = @user.companies.first
+    @project = create(:project, owner: @user, company: @company)
+    @workflow = create(:workflow, scope: @project)
+  end
+
+  def run_pending_since(created_at, **attrs)
+    create(:workflow_run,
+      workflow: @workflow, project: @project, user: @user,
+      state: "pending", created_at: created_at, **attrs)
+  end
+
+  test "a healthy installation reports nothing to act on" do
+    run_pending_since(Time.current)
+
+    stats = QueueHealthCheck.snapshot
+
+    assert_equal 0, stats[:unstarted_runs]
+    assert_equal 0, stats[:undispatched_runs]
+    assert_equal 0, stats[:oldest_unstarted_seconds]
+    assert_empty QueueHealthCheck.problems(stats)
+  end
+
+  # The exact shape of the 2026-09-12 outage: runs created, Temporal holding the
+  # executions, no worker polling. Nothing was queued for a slot and the pool was
+  # a third full, so every number the admission reconciler published stayed calm.
+  test "runs nobody executes are reported even when the admission queue looks perfectly healthy" do
+    run_pending_since(20.minutes.ago, relay_state: "dispatched")
+    run_pending_since(10.minutes.ago, relay_state: "dispatched")
+
+    stats = QueueHealthCheck.snapshot
+
+    assert_equal 2, stats[:unstarted_runs]
+    assert_operator stats[:oldest_unstarted_seconds], :>=, 20.minutes.to_i
+    assert_equal 0, stats[:queued_admissions]
+    assert_equal 0, stats[:undispatched_runs]
+
+    problems = QueueHealthCheck.problems(stats)
+    assert_equal 1, problems.size
+    assert_match(/nothing is executing the queue/, problems.sole)
+  end
+
+  test "a run whose dispatch never reached Temporal is named as its own problem" do
+    run_pending_since(10.minutes.ago, relay_state: "pending", relay_attempts: 1)
+
+    stats = QueueHealthCheck.snapshot
+
+    assert_equal 1, stats[:undispatched_runs]
+    assert_match(/never reached Temporal/, QueueHealthCheck.problems(stats).first)
+  end
+
+  test "a run still inside the threshold is not yet a problem" do
+    run_pending_since(QueueHealthCheck::UNSTARTED_RUN_THRESHOLD.ago + 30.seconds, relay_state: "dispatched")
+
+    assert_equal 0, QueueHealthCheck.snapshot[:unstarted_runs]
+  end
+
+  # Someone asked for it to stop; it not starting is the requested outcome.
+  test "a cancelled run is not counted as unstarted" do
+    run_pending_since(20.minutes.ago, relay_state: "dispatched", stop_requested_at: Time.current)
+
+    assert_equal 0, QueueHealthCheck.snapshot[:unstarted_runs]
+  end
+
+  # There are no factories for admissions on purpose: a reservation only exists by
+  # going through the queue, so the tests build one the way production does.
+  def admitted_session_with_operation(phase:, state: "uncertain")
+    SessionAdmissionPolicy.sync!(installation_limit: 5)
+    session = create(:terminal_session, user: @user, state: "running", started_at: 1.hour.ago)
+    admission = SessionAdmissionService.enqueue!(session)
+    SessionAdmissionService.drain!
+    admission.reload.session_runtime_operations.create!(phase: phase, state: state)
+    admission
+  end
+
+  test "a reservation pinned by an unprovable runtime operation is reported as held capacity" do
+    admitted_session_with_operation(phase: "create_container")
+
+    stats = QueueHealthCheck.snapshot
+
+    assert_equal 1, stats[:pinned_reservations]
+    assert_match(/pinned by an unprovable runtime operation/, QueueHealthCheck.problems(stats).sole)
+  end
+
+  # An `exec` nobody can account for is worth seeing elsewhere, but it costs no
+  # capacity: by the time it could run, cleanup has proved the container gone.
+  test "an unaccountable exec is not reported as held capacity" do
+    admitted_session_with_operation(phase: "exec")
+
+    assert_equal 0, QueueHealthCheck.snapshot[:pinned_reservations]
+  end
+
+  test "call returns the snapshot it reported" do
+    run_pending_since(20.minutes.ago, relay_state: "dispatched")
+
+    assert_equal QueueHealthCheck.snapshot.keys.sort, QueueHealthCheck.call.keys.sort
+    assert_equal 1, QueueHealthCheck.call[:unstarted_runs]
+  end
+end

--- a/test/services/workflow_run_relay_test.rb
+++ b/test/services/workflow_run_relay_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class WorkflowRunRelayTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user, :with_company)
+    @company = @user.companies.first
+    @project = create(:project, owner: @user, company: @company)
+    @workflow = create(:workflow, scope: @project)
+    # The relay only ever runs inside the Temporal worker, so a failed dispatch is
+    # a real failure there — never the "Temporal is switched off" case.
+    TemporalService.stubs(:enabled?).returns(true)
+  end
+
+  # A run as WorkflowService.start leaves it when the Temporal RPC never landed:
+  # committed, enrolled in the outbox, and executed by nobody.
+  def undispatched_run(created_at: 5.minutes.ago, attempts: 1, **attrs)
+    create(:workflow_run,
+      workflow: @workflow, project: @project, user: @user,
+      state: "pending", relay_state: "pending", relay_attempts: attempts,
+      created_at: created_at, **attrs)
+  end
+
+  test "drain re-dispatches a run stranded past the grace window" do
+    run = undispatched_run
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: true)
+
+    result = WorkflowRunRelay.drain
+
+    assert_equal 1, result[:swept]
+    assert_equal 1, result[:dispatched]
+    assert_equal 0, result[:failed]
+    assert_equal "dispatched", run.reload.relay_state
+    assert_equal 2, run.relay_attempts
+  end
+
+  test "drain leaves a fresh run alone until the grace window passes" do
+    run = undispatched_run(created_at: Time.current)
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).never
+
+    result = WorkflowRunRelay.drain
+
+    assert_equal 0, result[:swept]
+    assert_equal "pending", run.reload.relay_state
+  end
+
+  test "drain ignores runs whose dispatch was already confirmed" do
+    undispatched_run(relay_state: "dispatched")
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).never
+
+    assert_equal 0, WorkflowRunRelay.drain[:swept]
+  end
+
+  # The worker moved the run on, so the execution plainly exists — whatever our
+  # inline call did or did not hear back.
+  test "drain ignores a run the worker has already started" do
+    undispatched_run(state: "running")
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).never
+
+    assert_equal 0, WorkflowRunRelay.drain[:swept]
+  end
+
+  test "drain never starts an execution for a run that was cancelled while undispatched" do
+    run = undispatched_run(stop_requested_at: Time.current)
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).never
+
+    assert_equal 0, WorkflowRunRelay.drain[:swept]
+    assert_equal "pending", run.reload.relay_state
+  end
+
+  test "drain counts a still-failing dispatch and leaves the run for the next sweep" do
+    run = undispatched_run
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: false, error: "unavailable")
+
+    result = WorkflowRunRelay.drain
+
+    assert_equal 1, result[:swept]
+    assert_equal 0, result[:dispatched]
+    assert_equal 1, result[:failed]
+    assert_equal "pending", run.reload.relay_state
+    assert_equal 2, run.relay_attempts
+    assert_match(/unavailable/, run.relay_error)
+  end
+
+  # One run that can never start must not consume every sweep forever.
+  test "drain abandons a run past the attempt ceiling" do
+    undispatched_run(attempts: WorkflowRun::RELAY_MAX_ATTEMPTS)
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).never
+
+    assert_equal 0, WorkflowRunRelay.drain[:swept]
+  end
+
+  test "drain does a bounded amount of work per sweep" do
+    3.times { undispatched_run }
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).twice.returns(ok: true)
+
+    assert_equal 2, WorkflowRunRelay.drain(limit: 2)[:swept]
+  end
+
+  test "a failing run keeps its place in line rather than blocking the ones behind it" do
+    poison = undispatched_run(created_at: 10.minutes.ago)
+    healthy = undispatched_run(created_at: 5.minutes.ago)
+    TemporalWorkflowRegistry.stubs(:start_workflow_execution).returns(ok: false, error: "unavailable").then.returns(ok: true)
+
+    result = WorkflowRunRelay.drain
+
+    assert_equal 2, result[:swept]
+    assert_equal 1, result[:dispatched]
+    assert_equal "pending", poison.reload.relay_state
+    assert_equal "dispatched", healthy.reload.relay_state
+  end
+end

--- a/test/services/workflow_service_test.rb
+++ b/test/services/workflow_service_test.rb
@@ -15,7 +15,7 @@ class WorkflowServiceTest < ActiveSupport::TestCase
   # == start ==
 
   test "start creates workflow run with step runs and starts temporal" do
-    TemporalWorkflowRegistry.expects(:start_workflow_execution).once
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: true)
 
     run = WorkflowService.start(
       workflow: @workflow,
@@ -31,7 +31,7 @@ class WorkflowServiceTest < ActiveSupport::TestCase
   end
 
   test "start persists agent_runtime when provided" do
-    TemporalWorkflowRegistry.expects(:start_workflow_execution).once
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: true)
 
     run = WorkflowService.start(
       workflow: @workflow,
@@ -45,7 +45,7 @@ class WorkflowServiceTest < ActiveSupport::TestCase
   end
 
   test "start with task associates board_task" do
-    TemporalWorkflowRegistry.expects(:start_workflow_execution).once
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: true)
 
     board = create(:board, project: @project)
     column = create(:board_column, board: board)
@@ -79,7 +79,7 @@ class WorkflowServiceTest < ActiveSupport::TestCase
   # == cancel ==
 
   test "cancel sends signal and cancels active step runs" do
-    TemporalWorkflowRegistry.stubs(:start_workflow_execution)
+    TemporalWorkflowRegistry.stubs(:start_workflow_execution).returns(ok: true)
     run = WorkflowService.start(workflow: @workflow, project: @project, user: @user)
     run.start! if run.may_start?
 
@@ -94,7 +94,7 @@ class WorkflowServiceTest < ActiveSupport::TestCase
   # The cancellation itself is not the news — the reason is. A session killed by a
   # spend limit or a lost node has one, and the step is where a user sees it.
   test "cancel carries the session's diagnosed reason onto the step run" do
-    TemporalWorkflowRegistry.stubs(:start_workflow_execution)
+    TemporalWorkflowRegistry.stubs(:start_workflow_execution).returns(ok: true)
     TemporalService.stubs(:send_signal)
     run = WorkflowService.start(workflow: @workflow, project: @project, user: @user)
     run.start! if run.may_start?
@@ -110,7 +110,7 @@ class WorkflowServiceTest < ActiveSupport::TestCase
   end
 
   test "cancel leaves the step run unexplained when the generic reason is all there is" do
-    TemporalWorkflowRegistry.stubs(:start_workflow_execution)
+    TemporalWorkflowRegistry.stubs(:start_workflow_execution).returns(ok: true)
     TemporalService.stubs(:send_signal)
     run = WorkflowService.start(workflow: @workflow, project: @project, user: @user)
     run.start! if run.may_start?
@@ -125,7 +125,7 @@ class WorkflowServiceTest < ActiveSupport::TestCase
   end
 
   test "cancel records a workflow_cancelled activity on the task's board" do
-    TemporalWorkflowRegistry.stubs(:start_workflow_execution)
+    TemporalWorkflowRegistry.stubs(:start_workflow_execution).returns(ok: true)
     TemporalService.stubs(:send_signal)
     board = create(:board, project: @project)
     column = create(:board_column, board: board)
@@ -139,6 +139,80 @@ class WorkflowServiceTest < ActiveSupport::TestCase
     activity = BoardActivity.by_event_type(:workflow_cancelled).sole
     assert_equal task.id, activity.board_task_id
     assert_equal run.id, activity.metadata["workflow_run_id"]
+  end
+
+  # == dispatch (transactional outbox) ==
+
+  test "start marks the run dispatched once Temporal confirms the execution" do
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: true)
+
+    run = WorkflowService.start(workflow: @workflow, project: @project, user: @user)
+
+    assert_equal "dispatched", run.reload.relay_state
+    assert_equal 1, run.relay_attempts
+    assert_nil run.relay_error
+  end
+
+  # The failure this whole mechanism exists for: TemporalService.start_workflow
+  # answers a failed RPC with { ok: false }, not an exception, so the old code
+  # discarded it and reported a run that would never execute as started.
+  test "start raises and leaves the run enrolled in the outbox when Temporal refuses the start" do
+    TemporalService.stubs(:enabled?).returns(true)
+    TemporalWorkflowRegistry.expects(:start_workflow_execution)
+      .once.returns(ok: false, error: "storage is (re)initializing")
+
+    error = assert_raises(WorkflowService::DispatchFailed) do
+      WorkflowService.start(workflow: @workflow, project: @project, user: @user)
+    end
+
+    assert_match(/storage is \(re\)initializing/, error.message)
+
+    run = WorkflowRun.sole
+    assert_equal "pending", run.relay_state
+    assert_equal "pending", run.state
+    assert_equal 1, run.relay_attempts
+    assert_match(/storage is/, run.relay_error)
+  end
+
+  # A run that was never handed to Temporal is worth nothing without its steps
+  # being re-drivable too, so the row has to survive the raise.
+  test "a run stranded by a failed dispatch keeps its step runs and becomes relay work" do
+    TemporalService.stubs(:enabled?).returns(true)
+    TemporalWorkflowRegistry.stubs(:start_workflow_execution).returns(ok: false, error: "unavailable")
+
+    assert_raises(WorkflowService::DispatchFailed) do
+      WorkflowService.start(workflow: @workflow, project: @project, user: @user)
+    end
+
+    run = WorkflowRun.sole
+    assert_equal 2, run.step_runs.count
+    assert_empty WorkflowRun.stuck_for_relay
+    travel_to(WorkflowRun::RELAY_GRACE.from_now + 1.second) do
+      assert_equal [ run.id ], WorkflowRun.stuck_for_relay.pluck(:id)
+    end
+  end
+
+  # Development and test run with Temporal switched off. Nothing is stranded there
+  # — there is no executor to strand it from, and no relay either, since the relay
+  # is itself a Temporal schedule.
+  test "dispatch! does not raise when the deployment has Temporal switched off" do
+    TemporalService.stubs(:enabled?).returns(false)
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: false, error: "Temporal is disabled")
+
+    run = create(:workflow_run, workflow: @workflow, project: @project, user: @user, relay_state: "pending")
+
+    assert_nothing_raised { WorkflowService.dispatch!(run) }
+    assert_equal "pending", run.reload.relay_state
+  end
+
+  test "dispatch! is safe to repeat and settles a run Temporal already had" do
+    run = create(:workflow_run, workflow: @workflow, project: @project, user: @user, relay_state: "pending")
+    # A rejected duplicate is reported as success: the execution this run needs exists.
+    TemporalWorkflowRegistry.expects(:start_workflow_execution).once.returns(ok: true, workflow_id: "workflow-execution-#{run.id}")
+
+    WorkflowService.dispatch!(run)
+
+    assert_equal "dispatched", run.reload.relay_state
   end
 
   # == approve_step ==


### PR DESCRIPTION
**Carries #256.** This branch was cut from `feat/durable-workflow-run-dispatch` and now targets
`develop` directly, so its diff includes that commit — the watchdog reads
`WorkflowRun.stuck_for_relay`, which #256 introduces. Merging this merges both; #256 is then
redundant and should be closed rather than merged after.

## Why a watchdog outside Temporal

Every safety net in this installation is a Temporal schedule executed by the Temporal worker:

| schedule | recovers |
|---|---|
| `session_admission_reconciliation` | wedged reservations, stranded runtime operations |
| `quota_error_scan`, `no_output_scan` | agents blocked on a prompt or out of quota |
| `dead_container_scan` | containers that died without telling anyone |
| `stale_run_cleanup`, `stale_session_cleanup` | runs and sessions that lost their process |
| `outbox_relay` | events a producer committed but never dispatched |

On 2026-09-12 the worker crashlooped and all of them stopped together. So did
`app/temporal/interceptors/sentry_interceptor.rb`, the only thing that reports worker-side
exceptions. Nothing noticed for nearly two hours — the stall was found by a person asking why
their runs said "pending".

A watchdog hosted by the thing it watches is not a watchdog. This one runs in the Solid Queue
supervisor (the `jobs` deployment, up 13 days through the incident). It is the deliberate
exception to `config/queue.yml`'s "everything recurring belongs to Temporal", and
`RecurringTasksTest` pins it there — including an assertion that it never migrates into
`app/temporal/schedules.yml`.

## Symptoms, not liveness

"Is a worker polling the task queue?" has a fragile answer and needs a Temporal RPC from a process
that may be the only one still healthy. "Has any run been sitting unstarted for five minutes?" the
database answers alone, it is the thing the queue is sold on, and it is true whatever the cause.

| metric | means |
|---|---|
| `undispatched_runs` | the run never reached Temporal (from #256's outbox) |
| `unstarted_runs` | it reached Temporal and found nobody home — **the 2026-09-12 signal** |
| `queued_admissions` / `oldest_admission_wait_seconds` | a genuinely full pool, or one full of reservations nothing will release |
| `pinned_reservations` | capacity held by an unprovable create/start until an operator releases it |

Queueing for capacity happens one level below a run — an admitted run whose step waits for a slot
is `running`, not `pending` — so nothing legitimate parks a run in `pending`.

**The number that was missing.** `SessionAdmissionReconciler` already publishes
`oldest_queue_wait_seconds`; it was `0` for the entire outage. Nothing was queued for a slot, the
pool was at `occupied: 6` of `limit: 20`, and every number the queue published stayed calm while no
work moved at all. That is why the run-level metrics are here.

One structured log line per tick for the pipeline to draw a series from; a Sentry event only when
something is actually wrong — a watchdog that cries every minute is one nobody reads.

## Follow-ups deliberately not in this PR

- Polling a Temporal `DescribeTaskQueue` for a direct "nobody is polling" signal — a stronger
  diagnosis, but a fragile dependency; the symptom check above fires first and needs nothing.
- Slack delivery beside Sentry.
- A liveness heartbeat written by the worker itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
